### PR TITLE
Sprint 1 Step 1: CORS lockdown + X-Request-ID middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgresql://signupflow:changeme_in_production_use_strong_password@db:5432/signupflow
 
 # ==============================================================================
+# CORS Configuration
+# ==============================================================================
+# Comma-separated list of allowed origins for cross-origin requests.
+# Leave empty to use local-dev defaults (localhost:8000, :8080, :3000, plus 127.0.0.1).
+# In production, set to your mobile app's web origin(s) and any admin web client.
+# Example: CORS_ALLOWED_ORIGINS=https://app.signupflow.example.com,https://admin.signupflow.example.com
+CORS_ALLOWED_ORIGINS=
+
+# ==============================================================================
 # Rate Limiting Configuration
 # ==============================================================================
 RATE_LIMIT_SIGNUP_MAX=3

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -26,11 +26,25 @@ file_handler = logging.FileHandler(LOGS_DIR / "rostio.log")
 error_handler = logging.FileHandler(LOGS_DIR / "rostio_errors.log")
 error_handler.setLevel(logging.ERROR)
 
+from api.utils.request_context import request_id_var
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current request ID (or '-') into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get() or "-"
+        return True
+
+
+for _handler in (console_handler, file_handler, error_handler):
+    _handler.addFilter(RequestIDFilter())
+
 # Configure logging format
-log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+log_format = "%(asctime)s - %(name)s - [%(request_id)s] - %(levelname)s - %(message)s"
 if DEBUG:
     # More detailed format in debug mode
-    log_format = "%(asctime)s - %(name)s - [%(filename)s:%(lineno)d] - %(levelname)s - %(message)s"
+    log_format = "%(asctime)s - %(name)s - [%(request_id)s] - [%(filename)s:%(lineno)d] - %(levelname)s - %(message)s"
 
 # Configure logging
 logging.basicConfig(

--- a/api/main.py
+++ b/api/main.py
@@ -70,13 +70,16 @@ async def error_logging_middleware(request: Request, call_next):
         )
 
 
+from api.utils.cors_config import get_cors_origins
+from api.utils.request_id_middleware import RequestIDMiddleware
 from api.utils.security_headers_middleware import add_security_headers_middleware
 
 add_security_headers_middleware(app)
+app.add_middleware(RequestIDMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=get_cors_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/api/utils/cors_config.py
+++ b/api/utils/cors_config.py
@@ -1,0 +1,19 @@
+"""CORS origin parsing from CORS_ALLOWED_ORIGINS env var."""
+
+import os
+
+DEFAULT_DEV_ORIGINS = [
+    "http://localhost:8000",
+    "http://localhost:8080",
+    "http://localhost:3000",
+    "http://127.0.0.1:8000",
+    "http://127.0.0.1:8080",
+]
+
+
+def get_cors_origins() -> list[str]:
+    """Return the configured allowed origins, or local-dev defaults if unset."""
+    raw = os.getenv("CORS_ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return list(DEFAULT_DEV_ORIGINS)
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/api/utils/request_context.py
+++ b/api/utils/request_context.py
@@ -1,0 +1,7 @@
+"""ContextVar shared between request middleware and the logging filter."""
+
+import contextvars
+
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)

--- a/api/utils/request_id_middleware.py
+++ b/api/utils/request_id_middleware.py
@@ -1,0 +1,26 @@
+"""Middleware that attaches an X-Request-ID to every request and response."""
+
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from api.utils.request_context import request_id_var
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Read or generate X-Request-ID; expose via request.state and ContextVar; echo on response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+        request.state.request_id = request_id
+        token = request_id_var.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response

--- a/tests/api/test_middleware.py
+++ b/tests/api/test_middleware.py
@@ -1,0 +1,59 @@
+"""Middleware integration tests: request ID round-trip and CORS lockdown."""
+
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestRequestID:
+    """X-Request-ID is generated when missing and echoed when supplied."""
+
+    def test_request_id_generated_when_missing(self, client):
+        response = client.get("/health")
+        assert "X-Request-ID" in response.headers
+        assert UUID_RE.match(response.headers["X-Request-ID"])
+
+    def test_request_id_preserved_when_supplied(self, client):
+        custom_id = "client-supplied-12345"
+        response = client.get("/health", headers={"X-Request-ID": custom_id})
+        assert response.headers.get("X-Request-ID") == custom_id
+
+    def test_request_id_unique_per_request(self, client):
+        r1 = client.get("/health")
+        r2 = client.get("/health")
+        assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]
+
+
+class TestCORS:
+    """CORS preflight allows configured origins and rejects others."""
+
+    def test_allows_localhost_dev_origin(self, client):
+        response = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:8000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:8000"
+
+    def test_rejects_unconfigured_origin(self, client):
+        response = client.options(
+            "/health",
+            headers={
+                "Origin": "http://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        header_keys = {k.lower() for k in response.headers.keys()}
+        assert "access-control-allow-origin" not in header_keys

--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -1,0 +1,46 @@
+"""Unit tests for CORS env parsing."""
+
+import os
+from unittest.mock import patch
+
+from api.utils.cors_config import get_cors_origins
+
+
+def test_default_when_unset():
+    """Defaults include localhost dev origins when env is unset."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("CORS_ALLOWED_ORIGINS", None)
+        origins = get_cors_origins()
+    assert any("localhost" in o for o in origins)
+    assert "http://localhost:8000" in origins
+
+
+def test_default_when_empty_string():
+    """Empty string falls through to defaults."""
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": ""}):
+        origins = get_cors_origins()
+    assert any("localhost" in o for o in origins)
+
+
+def test_comma_separated_list():
+    """Comma-separated values become a list."""
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": "https://a.com,https://b.com"}):
+        assert get_cors_origins() == ["https://a.com", "https://b.com"]
+
+
+def test_strips_whitespace():
+    """Whitespace around entries is stripped."""
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": " https://a.com , https://b.com "}):
+        assert get_cors_origins() == ["https://a.com", "https://b.com"]
+
+
+def test_skips_empty_entries():
+    """Empty entries from trailing commas are dropped."""
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": "https://a.com,,"}):
+        assert get_cors_origins() == ["https://a.com"]
+
+
+def test_single_value():
+    """A single origin without commas works."""
+    with patch.dict(os.environ, {"CORS_ALLOWED_ORIGINS": "https://prod.example.com"}):
+        assert get_cors_origins() == ["https://prod.example.com"]


### PR DESCRIPTION
## Summary

- Replace permissive `allow_origins=["*"]` with env-driven `CORS_ALLOWED_ORIGINS` (defaults to local-dev origins for now).
- Add `RequestIDMiddleware` that reads or generates `X-Request-ID`, exposes it via `request.state` and a `ContextVar`, and echoes it back on the response.
- Bind a `RequestIDFilter` into `api/logging_config.py` so every log record carries the active request id.

First step of the Sprint 1 backend pre-flight from the Flutter-readiness plan.

## Changed files

- `api/main.py`: register `RequestIDMiddleware`, switch CORS to `get_cors_origins()`
- `api/logging_config.py`: install `RequestIDFilter` on all handlers, add `%(request_id)s` to format
- `api/utils/cors_config.py` (new): comma-split parser + dev defaults
- `api/utils/request_id_middleware.py` (new): the middleware
- `api/utils/request_context.py` (new): shared `ContextVar`
- `.env.example`: document `CORS_ALLOWED_ORIGINS`
- `tests/unit/test_cors_config.py` (new): 6 tests for env parsing
- `tests/api/test_middleware.py` (new): 5 tests for X-Request-ID round-trip and CORS allow/reject

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/` — 366 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 1 Step 2 (URL versioning under `/api/v1`) is the next PR.
- mypy is advisory in CI; legacy backlog remediation tracked separately.