### PR TITLE
Sprint 1 Step 2: URL versioning under /api/v1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,20 +53,22 @@ make migrate              # Run Alembic migrations
 ### Active API Routers (registered in `api/main.py`)
 
 ```
-/api/auth           — signup, login, email check
-/api/organizations  — CRUD for organizations
-/api/people         — CRUD for people, /me profile
-/api/teams          — CRUD for teams + membership
-/api/events         — CRUD for events + assignments
-/api/constraints    — CRUD for scheduling constraints (DSL-based)
-/api/solver         — POST /solve to generate schedules
-/api/solutions      — list/view generated solutions
-/api/availability   — time-off / blocked dates
-/api/conflicts      — conflict checking between person+event
-/api/invitations    — create/verify/accept invitation tokens
-/api/calendar       — ICS export of personal schedules
-/api/analytics      — volunteer stats, event stats
-/api/password-reset — request/confirm password reset
+/api/v1/auth           — signup, login, email check
+/api/v1/organizations  — CRUD for organizations
+/api/v1/people         — CRUD for people, /me profile
+/api/v1/teams          — CRUD for teams + membership
+/api/v1/events         — CRUD for events + assignments
+/api/v1/constraints    — CRUD for scheduling constraints (DSL-based)
+/api/v1/solver         — POST /solve to generate schedules
+/api/v1/solutions      — list/view generated solutions
+/api/v1/availability   — time-off / blocked dates
+/api/v1/conflicts      — conflict checking between person+event
+/api/v1/invitations    — create/verify/accept invitation tokens
+/api/v1/calendar       — ICS export of personal schedules
+/api/v1/analytics      — volunteer stats, event stats
+/api/v1/password-reset — request/confirm password reset
+
+Bare `/api` is a 308 redirect to `/api/v1` for one release.
 ```
 
 ### Key Files

--- a/api/main.py
+++ b/api/main.py
@@ -120,23 +120,23 @@ def health_check():
     return health_status
 
 
-app.include_router(auth.router, prefix="/api")
-app.include_router(organizations.router, prefix="/api")
-app.include_router(people.router, prefix="/api")
-app.include_router(teams.router, prefix="/api")
-app.include_router(events.router, prefix="/api")
-app.include_router(constraints.router, prefix="/api")
-app.include_router(solver.router, prefix="/api")
-app.include_router(solutions.router, prefix="/api")
-app.include_router(availability.router, prefix="/api")
-app.include_router(conflicts.router, prefix="/api")
-app.include_router(password_reset.router, prefix="/api")
-app.include_router(analytics.router, prefix="/api")
-app.include_router(invitations.router, prefix="/api")
-app.include_router(calendar.router, prefix="/api")
+app.include_router(auth.router, prefix="/api/v1")
+app.include_router(organizations.router, prefix="/api/v1")
+app.include_router(people.router, prefix="/api/v1")
+app.include_router(teams.router, prefix="/api/v1")
+app.include_router(events.router, prefix="/api/v1")
+app.include_router(constraints.router, prefix="/api/v1")
+app.include_router(solver.router, prefix="/api/v1")
+app.include_router(solutions.router, prefix="/api/v1")
+app.include_router(availability.router, prefix="/api/v1")
+app.include_router(conflicts.router, prefix="/api/v1")
+app.include_router(password_reset.router, prefix="/api/v1")
+app.include_router(analytics.router, prefix="/api/v1")
+app.include_router(invitations.router, prefix="/api/v1")
+app.include_router(calendar.router, prefix="/api/v1")
 
 
-@app.get("/api", tags=["root"])
+@app.get("/api/v1", tags=["root"])
 def api_info():
     """API information endpoint."""
     return {
@@ -146,15 +146,23 @@ def api_info():
         "docs": "/docs",
         "redoc": "/redoc",
         "endpoints": {
-            "organizations": "/api/organizations",
-            "people": "/api/people",
-            "teams": "/api/teams",
-            "events": "/api/events",
-            "constraints": "/api/constraints",
-            "solver": "/api/solver/solve",
-            "solutions": "/api/solutions",
+            "organizations": "/api/v1/organizations",
+            "people": "/api/v1/people",
+            "teams": "/api/v1/teams",
+            "events": "/api/v1/events",
+            "constraints": "/api/v1/constraints",
+            "solver": "/api/v1/solver/solve",
+            "solutions": "/api/v1/solutions",
         },
     }
+
+
+@app.get("/api", tags=["root"], include_in_schema=False)
+def api_redirect():
+    """Redirect bare /api to versioned /api/v1 for one release."""
+    from fastapi.responses import RedirectResponse
+
+    return RedirectResponse(url="/api/v1", status_code=308)
 
 
 def start():

--- a/api/utils/calendar_utils.py
+++ b/api/utils/calendar_utils.py
@@ -204,7 +204,7 @@ def generate_webcal_url(base_url: str, token: str) -> str:
     elif base_url.startswith("http://"):
         base_url = base_url.replace("http://", "")
 
-    return f"webcal://{base_url}/api/calendar/feed/{token}"
+    return f"webcal://{base_url}/api/v1/calendar/feed/{token}"
 
 
 def generate_https_feed_url(base_url: str, token: str) -> str:
@@ -225,4 +225,4 @@ def generate_https_feed_url(base_url: str, token: str) -> str:
     # Remove trailing slash
     base_url = base_url.rstrip("/")
 
-    return f"{base_url}/api/calendar/feed/{token}"
+    return f"{base_url}/api/v1/calendar/feed/{token}"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -84,7 +84,9 @@ def reset_database_between_tests():
 
 def seed_org(client: TestClient, org_id: str, name: str = "Test Org", region: str = "US") -> dict:
     """Create an organization. Returns response JSON."""
-    resp = client.post("/api/organizations/", json={"id": org_id, "name": name, "region": region})
+    resp = client.post(
+        "/api/v1/organizations/", json={"id": org_id, "name": name, "region": region}
+    )
     assert resp.status_code == 201, f"seed_org failed: {resp.status_code} {resp.text}"
     return resp.json()
 
@@ -99,7 +101,7 @@ def seed_user(
 ) -> dict:
     """Sign up a user. First user in org auto-becomes admin. Returns auth response with token."""
     resp = client.post(
-        "/api/auth/signup",
+        "/api/v1/auth/signup",
         json={
             "org_id": org_id,
             "name": name,
@@ -114,7 +116,7 @@ def seed_user(
 
 def login(client: TestClient, email: str, password: str) -> dict:
     """Log in and return full auth response (including token)."""
-    resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    resp = client.post("/api/v1/auth/login", json={"email": email, "password": password})
     assert resp.status_code == 200, f"login failed: {resp.status_code} {resp.text}"
     return resp.json()
 
@@ -139,7 +141,7 @@ def seed_event(
     start = datetime.now() + timedelta(days=days_from_now)
     end = start + timedelta(hours=duration_hours)
     resp = client.post(
-        "/api/events/",
+        "/api/v1/events/",
         json={
             "id": event_id,
             "org_id": org_id,
@@ -164,7 +166,7 @@ def seed_invitation(
 ) -> dict:
     """Create an invitation (admin only). Returns invitation with token."""
     resp = client.post(
-        f"/api/invitations?org_id={org_id}",
+        f"/api/v1/invitations?org_id={org_id}",
         json={
             "email": email,
             "name": name,
@@ -179,7 +181,7 @@ def seed_invitation(
 def accept_invitation(client: TestClient, token: str, password: str = "VolPass123!") -> dict:
     """Accept invitation. NOTE: returned token is NOT a JWT — must call login() after."""
     resp = client.post(
-        f"/api/invitations/{token}/accept",
+        f"/api/v1/invitations/{token}/accept",
         json={
             "password": password,
             "timezone": "UTC",
@@ -199,7 +201,7 @@ def seed_team(
 ) -> dict:
     """Create a team (admin only). Returns team response."""
     resp = client.post(
-        "/api/teams/",
+        "/api/v1/teams/",
         json={
             "id": team_id,
             "org_id": org_id,
@@ -221,7 +223,7 @@ def add_timeoff(
 ) -> dict:
     """Add time-off for a person. Dates are ISO strings like '2026-05-01'."""
     resp = client.post(
-        f"/api/availability/{person_id}/timeoff",
+        f"/api/v1/availability/{person_id}/timeoff",
         json={
             "start_date": start_date,
             "end_date": end_date,

--- a/tests/api/test_church_scenario.py
+++ b/tests/api/test_church_scenario.py
@@ -91,14 +91,14 @@ class TestChurchScenario:
         hdrs, members = self._setup_church(client)
 
         # Verify all 6 people in org (pastor + 5 members)
-        resp = client.get(f"/api/people/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 6
 
         # Verify Sarah has dual roles
         members["sarah.chen@grace.org"]
         sarah_hdrs = auth_headers(client, "sarah.chen@grace.org", self.VOL_PW)
-        resp = client.get("/api/people/me", headers=sarah_hdrs)
+        resp = client.get("/api/v1/people/me", headers=sarah_hdrs)
         assert resp.status_code == 200
         profile = resp.json()
         assert "musician" in profile["roles"]
@@ -134,7 +134,7 @@ class TestChurchScenario:
         assert teaching["name"] == "Teaching Team"
 
         # Sarah is on BOTH teams
-        resp = client.get(f"/api/teams/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/teams/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 2
 
@@ -182,7 +182,7 @@ class TestChurchScenario:
             role_counts={"youth_leader": 1, "volunteer": 2},
         )
 
-        resp = client.get(f"/api/events/?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/?org_id={self.ORG}")
         assert resp.status_code == 200
         assert resp.json()["total"] == 3
 
@@ -209,12 +209,12 @@ class TestChurchScenario:
         add_timeoff(client, james_id, wed_date, wed_date, reason="Work commitment")
 
         # Verify time-off recorded
-        resp = client.get(f"/api/availability/{maria_id}/timeoff")
+        resp = client.get(f"/api/v1/availability/{maria_id}/timeoff")
         assert resp.status_code == 200
         assert resp.json()["total"] == 1
         assert resp.json()["timeoff"][0]["reason"] == "Family vacation in Mexico"
 
-        resp = client.get(f"/api/availability/{james_id}/timeoff")
+        resp = client.get(f"/api/v1/availability/{james_id}/timeoff")
         assert resp.status_code == 200
         assert resp.json()["total"] == 1
 
@@ -245,7 +245,7 @@ class TestChurchScenario:
         from_date = (datetime.now() + timedelta(days=13)).strftime("%Y-%m-%d")
         to_date = (datetime.now() + timedelta(days=45)).strftime("%Y-%m-%d")
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": from_date,
@@ -268,7 +268,7 @@ class TestChurchScenario:
         assert "per_person_counts" in fairness
 
         # Verify assignments via API
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
         assignments = resp.json()["assignments"]
         assert len(assignments) > 0
@@ -300,7 +300,7 @@ class TestChurchScenario:
 
         # Pastor assigns Sarah as musician
         resp = client.post(
-            f"/api/events/{event['id']}/assignments",
+            f"/api/v1/events/{event['id']}/assignments",
             json={
                 "person_id": sarah_id,
                 "action": "assign",
@@ -311,7 +311,7 @@ class TestChurchScenario:
         assert resp.status_code == 200
 
         # Verify assignment
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
         assignments = resp.json()["assignments"]
         sarah_assigned = [
@@ -344,7 +344,7 @@ class TestChurchScenario:
         from_date = (datetime.now() + timedelta(days=13)).strftime("%Y-%m-%d")
         to_date = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
         client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": from_date,
@@ -357,12 +357,12 @@ class TestChurchScenario:
 
         # Sarah logs in and checks assignments
         sarah_hdrs = auth_headers(client, "sarah.chen@grace.org", self.VOL_PW)
-        resp = client.get("/api/people/me", headers=sarah_hdrs)
+        resp = client.get("/api/v1/people/me", headers=sarah_hdrs)
         assert resp.status_code == 200
         assert resp.json()["name"] == "Sarah Chen"
 
         # Assignments list is org-wide (Sarah can see it)
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
 
     # ------------------------------------------------------------------
@@ -384,7 +384,7 @@ class TestChurchScenario:
         )
 
         # Verify invitation is pending
-        resp = client.get(f"/api/invitations?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/invitations?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         pending = [i for i in resp.json()["invitations"] if i["email"] == "rachel.wong@gmail.com"]
         assert len(pending) == 1
@@ -397,6 +397,6 @@ class TestChurchScenario:
 
         # Rachel can now log in
         rachel_hdrs = auth_headers(client, "rachel.wong@gmail.com", "Rachel123!")
-        resp = client.get("/api/people/me", headers=rachel_hdrs)
+        resp = client.get("/api/v1/people/me", headers=rachel_hdrs)
         assert resp.status_code == 200
         assert resp.json()["name"] == "Rachel Wong"

--- a/tests/api/test_event_crud.py
+++ b/tests/api/test_event_crud.py
@@ -54,14 +54,14 @@ class TestEventCRUD:
         hdrs = self._setup(client)
         seed_event(client, hdrs, self.ORG, "evt-get")
 
-        resp = client.get("/api/events/evt-get")
+        resp = client.get("/api/v1/events/evt-get")
         assert resp.status_code == 200
         assert resp.json()["id"] == "evt-get"
 
     def test_get_nonexistent_event_returns_404(self, client):
         """Getting a missing event returns 404."""
         self._setup(client)
-        resp = client.get("/api/events/does-not-exist")
+        resp = client.get("/api/v1/events/does-not-exist")
         assert resp.status_code == 404
 
     def test_list_events_filtered_by_org(self, client):
@@ -70,7 +70,7 @@ class TestEventCRUD:
         seed_event(client, hdrs, self.ORG, "evt-a", days_from_now=14)
         seed_event(client, hdrs, self.ORG, "evt-b", days_from_now=21)
 
-        resp = client.get(f"/api/events/?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/?org_id={self.ORG}")
         assert resp.status_code == 200
         assert resp.json()["total"] == 2
 
@@ -80,7 +80,7 @@ class TestEventCRUD:
         seed_event(client, hdrs, self.ORG, "evt-update", event_type="Regular Service")
 
         resp = client.put(
-            "/api/events/evt-update",
+            "/api/v1/events/evt-update",
             json={
                 "type": "Easter Service",
                 "extra_data": {"role_counts": {"musician": 3, "usher": 2}},
@@ -103,7 +103,7 @@ class TestEventCRUD:
         new_end = new_start + timedelta(hours=3)
 
         resp = client.put(
-            "/api/events/evt-reschedule",
+            "/api/v1/events/evt-reschedule",
             json={
                 "start_time": new_start.isoformat(),
                 "end_time": new_end.isoformat(),
@@ -116,7 +116,7 @@ class TestEventCRUD:
     def test_update_nonexistent_event_returns_404(self, client):
         """Updating a missing event returns 404."""
         hdrs = self._setup(client)
-        resp = client.put("/api/events/ghost", json={"type": "X"}, headers=hdrs)
+        resp = client.put("/api/v1/events/ghost", json={"type": "X"}, headers=hdrs)
         assert resp.status_code == 404
 
     def test_delete_event(self, client):
@@ -124,17 +124,17 @@ class TestEventCRUD:
         hdrs = self._setup(client)
         seed_event(client, hdrs, self.ORG, "evt-delete")
 
-        resp = client.delete("/api/events/evt-delete", headers=hdrs)
+        resp = client.delete("/api/v1/events/evt-delete", headers=hdrs)
         assert resp.status_code == 204
 
         # Verify gone
-        resp = client.get("/api/events/evt-delete")
+        resp = client.get("/api/v1/events/evt-delete")
         assert resp.status_code == 404
 
     def test_delete_nonexistent_event_returns_404(self, client):
         """Deleting a missing event returns 404."""
         hdrs = self._setup(client)
-        resp = client.delete("/api/events/ghost", headers=hdrs)
+        resp = client.delete("/api/v1/events/ghost", headers=hdrs)
         assert resp.status_code == 404
 
     def test_volunteer_cannot_update_event(self, client):
@@ -144,7 +144,7 @@ class TestEventCRUD:
         seed_user(client, self.ORG, "vol@crud.org", "Vol", "VolPass123!")
         vol_hdrs = auth_headers(client, "vol@crud.org", "VolPass123!")
 
-        resp = client.put("/api/events/evt-protected", json={"type": "Hacked"}, headers=vol_hdrs)
+        resp = client.put("/api/v1/events/evt-protected", json={"type": "Hacked"}, headers=vol_hdrs)
         assert resp.status_code == 403
 
     def test_volunteer_cannot_delete_event(self, client):
@@ -154,7 +154,7 @@ class TestEventCRUD:
         seed_user(client, self.ORG, "vol@crud.org", "Vol", "VolPass123!")
         vol_hdrs = auth_headers(client, "vol@crud.org", "VolPass123!")
 
-        resp = client.delete("/api/events/evt-nodelete", headers=vol_hdrs)
+        resp = client.delete("/api/v1/events/evt-nodelete", headers=vol_hdrs)
         assert resp.status_code == 403
 
 
@@ -179,7 +179,7 @@ class TestConflictDetection:
         event = seed_event(client, hdrs, self.ORG, "evt-clean", days_from_now=14)
 
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": vol["person_id"],
                 "event_id": event["id"],
@@ -197,7 +197,7 @@ class TestConflictDetection:
 
         # Assign first
         client.post(
-            f"/api/events/{event['id']}/assignments",
+            f"/api/v1/events/{event['id']}/assignments",
             json={
                 "person_id": vol["person_id"],
                 "action": "assign",
@@ -208,7 +208,7 @@ class TestConflictDetection:
 
         # Check conflicts — should detect already_assigned
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": vol["person_id"],
                 "event_id": event["id"],
@@ -232,7 +232,7 @@ class TestConflictDetection:
 
         # Check conflicts — should detect time_off
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": vol["person_id"],
                 "event_id": event["id"],
@@ -254,7 +254,7 @@ class TestConflictDetection:
 
         # Assign to event A
         client.post(
-            f"/api/events/{evt_a['id']}/assignments",
+            f"/api/v1/events/{evt_a['id']}/assignments",
             json={
                 "person_id": vol["person_id"],
                 "action": "assign",
@@ -265,7 +265,7 @@ class TestConflictDetection:
 
         # Check conflicts for event B — should detect double_booked
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": vol["person_id"],
                 "event_id": evt_b["id"],
@@ -284,7 +284,7 @@ class TestConflictDetection:
         event = seed_event(client, hdrs, self.ORG, "evt-x", days_from_now=14)
 
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": "ghost-person",
                 "event_id": event["id"],
@@ -297,7 +297,7 @@ class TestConflictDetection:
         hdrs, vol = self._setup_with_volunteer(client)
 
         resp = client.post(
-            "/api/conflicts/check",
+            "/api/v1/conflicts/check",
             json={
                 "person_id": vol["person_id"],
                 "event_id": "ghost-event",
@@ -327,7 +327,7 @@ class TestAvailabilityManagement:
 
         add_timeoff(client, pid, "2026-06-01", "2026-06-07", reason="Vacation")
 
-        resp = client.get(f"/api/availability/{pid}/timeoff")
+        resp = client.get(f"/api/v1/availability/{pid}/timeoff")
         assert resp.status_code == 200
         data = resp.json()
         assert data["total"] == 1
@@ -342,7 +342,7 @@ class TestAvailabilityManagement:
         add_timeoff(client, pid, "2026-06-01", "2026-06-07", reason="Vacation 1")
         add_timeoff(client, pid, "2026-07-01", "2026-07-07", reason="Vacation 2")
 
-        resp = client.get(f"/api/availability/{pid}/timeoff")
+        resp = client.get(f"/api/v1/availability/{pid}/timeoff")
         assert resp.status_code == 200
         assert resp.json()["total"] == 2
 
@@ -354,21 +354,21 @@ class TestAvailabilityManagement:
         add_timeoff(client, pid, "2026-08-01", "2026-08-07", reason="To be deleted")
 
         # Get the timeoff ID
-        resp = client.get(f"/api/availability/{pid}/timeoff")
+        resp = client.get(f"/api/v1/availability/{pid}/timeoff")
         timeoff_id = resp.json()["timeoff"][0]["id"]
 
         # Delete it
-        resp = client.delete(f"/api/availability/{pid}/timeoff/{timeoff_id}")
+        resp = client.delete(f"/api/v1/availability/{pid}/timeoff/{timeoff_id}")
         assert resp.status_code == 204
 
         # Verify gone
-        resp = client.get(f"/api/availability/{pid}/timeoff")
+        resp = client.get(f"/api/v1/availability/{pid}/timeoff")
         assert resp.json()["total"] == 0
 
     def test_timeoff_for_unknown_person_returns_empty(self, client):
         """Querying time-off for a non-existent person returns empty list."""
         self._setup_with_volunteer(client)
-        resp = client.get("/api/availability/ghost-person/timeoff")
+        resp = client.get("/api/v1/availability/ghost-person/timeoff")
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
 
@@ -389,7 +389,7 @@ class TestProfileAndTeamMembers:
         vol_hdrs = auth_headers(client, "vol@profile.org", "VolPass123!")
 
         resp = client.put(
-            "/api/people/me",
+            "/api/v1/people/me",
             json={
                 "name": "New Name",
                 "timezone": "US/Pacific",
@@ -409,7 +409,7 @@ class TestProfileAndTeamMembers:
 
         # Create empty team
         resp = client.post(
-            "/api/teams/",
+            "/api/v1/teams/",
             json={
                 "id": "team-1",
                 "org_id": self.ORG,
@@ -421,7 +421,7 @@ class TestProfileAndTeamMembers:
 
         # Add member
         resp = client.post(
-            "/api/teams/team-1/members",
+            "/api/v1/teams/team-1/members",
             json={
                 "person_ids": [vol["person_id"]],
             },
@@ -430,14 +430,14 @@ class TestProfileAndTeamMembers:
         assert resp.status_code == 204
 
         # Verify member count increased
-        resp = client.get("/api/teams/team-1", headers=hdrs)
+        resp = client.get("/api/v1/teams/team-1", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["member_count"] == 1
 
         # Remove member (DELETE with body requires request method)
         resp = client.request(
             "DELETE",
-            "/api/teams/team-1/members",
+            "/api/v1/teams/team-1/members",
             json={
                 "person_ids": [vol["person_id"]],
             },
@@ -446,5 +446,5 @@ class TestProfileAndTeamMembers:
         assert resp.status_code == 204
 
         # Verify member count back to 0
-        resp = client.get("/api/teams/team-1", headers=hdrs)
+        resp = client.get("/api/v1/teams/team-1", headers=hdrs)
         assert resp.json()["member_count"] == 0

--- a/tests/api/test_middleware.py
+++ b/tests/api/test_middleware.py
@@ -34,6 +34,22 @@ class TestRequestID:
         assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]
 
 
+class TestApiPrefixRedirect:
+    """Bare /api is a 308 redirect to /api/v1 for one release."""
+
+    def test_bare_api_redirects_to_v1(self, client):
+        response = client.get("/api", follow_redirects=False)
+        assert response.status_code == 308
+        assert response.headers["location"] == "/api/v1"
+
+    def test_v1_api_info_is_canonical(self, client):
+        response = client.get("/api/v1")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["service"] == "SignUpFlow API"
+        assert body["endpoints"]["organizations"] == "/api/v1/organizations"
+
+
 class TestCORS:
     """CORS preflight allows configured origins and rejects others."""
 

--- a/tests/api/test_multi_tenant.py
+++ b/tests/api/test_multi_tenant.py
@@ -38,8 +38,8 @@ class TestMultiTenantIsolation:
         hdrs1, hdrs2 = self._setup_two_orgs(client)
 
         # Each org lists its own people
-        resp1 = client.get(f"/api/people/?org_id={self.ORG1}", headers=hdrs1)
-        resp2 = client.get(f"/api/people/?org_id={self.ORG2}", headers=hdrs2)
+        resp1 = client.get(f"/api/v1/people/?org_id={self.ORG1}", headers=hdrs1)
+        resp2 = client.get(f"/api/v1/people/?org_id={self.ORG2}", headers=hdrs2)
         assert resp1.status_code == 200
         assert resp2.status_code == 200
         assert all(p["org_id"] == self.ORG1 for p in resp1.json()["people"])
@@ -48,7 +48,7 @@ class TestMultiTenantIsolation:
     def test_cross_org_people_access_denied(self, client):
         """Admin of org1 gets 403 trying to list org2's people."""
         hdrs1, _ = self._setup_two_orgs(client)
-        resp = client.get(f"/api/people/?org_id={self.ORG2}", headers=hdrs1)
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG2}", headers=hdrs1)
         assert resp.status_code == 403
 
     def test_cross_org_team_access_denied(self, client):
@@ -56,7 +56,7 @@ class TestMultiTenantIsolation:
         hdrs1, hdrs2 = self._setup_two_orgs(client)
         seed_team(client, hdrs2, self.ORG2, "beta-team", "Beta Ushers")
 
-        resp = client.get(f"/api/teams/?org_id={self.ORG2}", headers=hdrs1)
+        resp = client.get(f"/api/v1/teams/?org_id={self.ORG2}", headers=hdrs1)
         assert resp.status_code == 403
 
     def test_cross_org_event_creation_denied(self, client):
@@ -66,7 +66,7 @@ class TestMultiTenantIsolation:
         start = (datetime.now() + timedelta(days=7)).isoformat()
         end = (datetime.now() + timedelta(days=7, hours=2)).isoformat()
         resp = client.post(
-            "/api/events/",
+            "/api/v1/events/",
             json={
                 "id": "evt-cross",
                 "org_id": self.ORG2,
@@ -82,7 +82,7 @@ class TestMultiTenantIsolation:
         """Admin of org1 can't run solver for org2."""
         hdrs1, _ = self._setup_two_orgs(client)
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG2,
                 "from_date": "2026-05-01",
@@ -101,8 +101,8 @@ class TestMultiTenantIsolation:
         seed_event(client, hdrs1, self.ORG1, "evt-alpha-only")
         seed_event(client, hdrs2, self.ORG2, "evt-beta-only")
 
-        resp1 = client.get(f"/api/events/?org_id={self.ORG1}")
-        resp2 = client.get(f"/api/events/?org_id={self.ORG2}")
+        resp1 = client.get(f"/api/v1/events/?org_id={self.ORG1}")
+        resp2 = client.get(f"/api/v1/events/?org_id={self.ORG2}")
         assert resp1.status_code == 200
         assert resp2.status_code == 200
 
@@ -117,11 +117,11 @@ class TestMultiTenantIsolation:
         """API endpoints that require auth reject unauthenticated requests."""
         seed_org(client, self.ORG1)
 
-        resp = client.get(f"/api/people/?org_id={self.ORG1}")
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG1}")
         assert resp.status_code in (401, 403)
 
         resp = client.post(
-            "/api/events/",
+            "/api/v1/events/",
             json={
                 "id": "evt-noauth",
                 "org_id": self.ORG1,

--- a/tests/api/test_org_lifecycle.py
+++ b/tests/api/test_org_lifecycle.py
@@ -48,7 +48,7 @@ class TestOrgLifecycle:
         seed_org(client, self.ORG)
         seed_user(client, self.ORG, self.ADMIN_EMAIL, "Admin", self.ADMIN_PW)
         resp = client.post(
-            "/api/auth/signup",
+            "/api/v1/auth/signup",
             json={
                 "org_id": self.ORG,
                 "name": "Duplicate",
@@ -71,7 +71,7 @@ class TestOrgLifecycle:
         assert team["name"] == "Ushers"
 
         # Verify team in list
-        resp = client.get(f"/api/teams/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/teams/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] >= 1
 
@@ -101,7 +101,7 @@ class TestOrgLifecycle:
         start = (datetime.now() + timedelta(days=7)).isoformat()
         end = (datetime.now() + timedelta(days=7, hours=2)).isoformat()
         resp = client.post(
-            "/api/events/",
+            "/api/v1/events/",
             json={
                 "id": "evt-forbidden",
                 "org_id": self.ORG,
@@ -121,7 +121,7 @@ class TestOrgLifecycle:
         vol_hdrs = auth_headers(client, self.VOL_EMAIL, self.VOL_PW)
 
         resp = client.post(
-            "/api/teams/",
+            "/api/v1/teams/",
             json={
                 "id": "team-forbidden",
                 "org_id": self.ORG,
@@ -138,7 +138,7 @@ class TestOrgLifecycle:
         seed_user(client, self.ORG, self.VOL_EMAIL, "Sarah", self.VOL_PW)
         vol_hdrs = auth_headers(client, self.VOL_EMAIL, self.VOL_PW)
 
-        resp = client.get("/api/people/me", headers=vol_hdrs)
+        resp = client.get("/api/v1/people/me", headers=vol_hdrs)
         assert resp.status_code == 200
         assert resp.json()["email"] == self.VOL_EMAIL
 
@@ -149,6 +149,6 @@ class TestOrgLifecycle:
         seed_user(client, self.ORG, self.VOL_EMAIL, "Sarah", self.VOL_PW)
         vol_hdrs = auth_headers(client, self.VOL_EMAIL, self.VOL_PW)
 
-        resp = client.get(f"/api/people/?org_id={self.ORG}", headers=vol_hdrs)
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG}", headers=vol_hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 2

--- a/tests/api/test_scheduling_workflow.py
+++ b/tests/api/test_scheduling_workflow.py
@@ -56,7 +56,7 @@ class TestSchedulingWorkflow:
             event_ids.append(eid)
 
         # Verify events created
-        resp = client.get(f"/api/events/?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/?org_id={self.ORG}")
         assert resp.status_code == 200
         assert resp.json()["total"] == 3
 
@@ -84,7 +84,7 @@ class TestSchedulingWorkflow:
             )
 
         # Verify all people exist (1 admin + 5 volunteers)
-        resp = client.get(f"/api/people/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 6
 
@@ -101,7 +101,7 @@ class TestSchedulingWorkflow:
 
         # Verify time-off recorded
         for vol in volunteers[:2]:
-            resp = client.get(f"/api/availability/{vol['person_id']}/timeoff")
+            resp = client.get(f"/api/v1/availability/{vol['person_id']}/timeoff")
             assert resp.status_code == 200
             assert resp.json()["total"] == 1
 
@@ -109,7 +109,7 @@ class TestSchedulingWorkflow:
         from_date = (datetime.now() + timedelta(days=13)).strftime("%Y-%m-%d")
         to_date = (datetime.now() + timedelta(days=40)).strftime("%Y-%m-%d")
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": from_date,
@@ -127,7 +127,7 @@ class TestSchedulingWorkflow:
         assert solution["metrics"]["health_score"] >= 0
 
         # -- Verify solution in solutions list --
-        resp = client.get(f"/api/solutions/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/solutions/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] >= 1
 
@@ -141,7 +141,7 @@ class TestSchedulingWorkflow:
         seed_event(client, hdrs, self.ORG, "evt-far", days_from_now=60)
 
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": "2026-01-01",
@@ -164,7 +164,7 @@ class TestSchedulingWorkflow:
 
         # Assign volunteer to event
         resp = client.post(
-            f"/api/events/{event['id']}/assignments",
+            f"/api/v1/events/{event['id']}/assignments",
             json={
                 "person_id": vol["person_id"],
                 "action": "assign",
@@ -175,7 +175,7 @@ class TestSchedulingWorkflow:
         assert resp.status_code == 200
 
         # Verify assignment shows up
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
         assignments = resp.json()["assignments"]
         assert any(a["person_id"] == vol["person_id"] for a in assignments)
@@ -191,7 +191,7 @@ class TestSchedulingWorkflow:
 
         # Assign then unassign
         client.post(
-            f"/api/events/{event['id']}/assignments",
+            f"/api/v1/events/{event['id']}/assignments",
             json={
                 "person_id": vol["person_id"],
                 "action": "assign",
@@ -201,7 +201,7 @@ class TestSchedulingWorkflow:
         )
 
         resp = client.post(
-            f"/api/events/{event['id']}/assignments",
+            f"/api/v1/events/{event['id']}/assignments",
             json={
                 "person_id": vol["person_id"],
                 "action": "unassign",

--- a/tests/api/test_sports_scenario.py
+++ b/tests/api/test_sports_scenario.py
@@ -106,13 +106,13 @@ class TestSportsScenario:
         hdrs, players = self._setup_club(client)
 
         # 7 people total (coach + 6 players)
-        resp = client.get(f"/api/people/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/people/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 7
 
         # Priya plays both sports
         priya_hdrs = auth_headers(client, "priya@riverside.club", self.PLAYER_PW)
-        resp = client.get("/api/people/me", headers=priya_hdrs)
+        resp = client.get("/api/v1/people/me", headers=priya_hdrs)
         assert resp.status_code == 200
         roles = resp.json()["roles"]
         assert "bowler" in roles
@@ -120,7 +120,7 @@ class TestSportsScenario:
 
         # Alex plays both sports
         alex_hdrs = auth_headers(client, "alex@riverside.club", self.PLAYER_PW)
-        resp = client.get("/api/people/me", headers=alex_hdrs)
+        resp = client.get("/api/v1/people/me", headers=alex_hdrs)
         roles = resp.json()["roles"]
         assert "shooting_guard" in roles
         assert "all_rounder" in roles
@@ -162,7 +162,7 @@ class TestSportsScenario:
         assert basketball["name"] == "Basketball Squad"
 
         # Priya and Alex are on BOTH squads
-        resp = client.get(f"/api/teams/?org_id={self.ORG}", headers=hdrs)
+        resp = client.get(f"/api/v1/teams/?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["total"] == 2
 
@@ -228,7 +228,7 @@ class TestSportsScenario:
             role_counts={"batsman": 4, "bowler": 2, "wicket_keeper": 1},
         )
 
-        resp = client.get(f"/api/events/?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/?org_id={self.ORG}")
         assert resp.status_code == 200
         assert resp.json()["total"] == 4
 
@@ -248,7 +248,7 @@ class TestSportsScenario:
             client, rahul_id, injury_start, injury_end, reason="Hamstring injury — physio recovery"
         )
 
-        resp = client.get(f"/api/availability/{rahul_id}/timeoff")
+        resp = client.get(f"/api/v1/availability/{rahul_id}/timeoff")
         assert resp.status_code == 200
         periods = resp.json()["timeoff"]
         assert len(periods) == 1
@@ -297,7 +297,7 @@ class TestSportsScenario:
         from_date = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%d")
         to_date = (datetime.now() + timedelta(days=21)).strftime("%Y-%m-%d")
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": from_date,
@@ -314,7 +314,7 @@ class TestSportsScenario:
         assert solution["metrics"]["health_score"] >= 0
 
         # Every event should have assignments
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
         assignments = resp.json()["assignments"]
         assigned_events = {a["event_id"] for a in assignments}
@@ -365,7 +365,7 @@ class TestSportsScenario:
         from_date = (datetime.now() + timedelta(days=17)).strftime("%Y-%m-%d")
         to_date = (datetime.now() + timedelta(days=22)).strftime("%Y-%m-%d")
         resp = client.post(
-            "/api/solver/solve",
+            "/api/v1/solver/solve",
             json={
                 "org_id": self.ORG,
                 "from_date": from_date,
@@ -407,7 +407,7 @@ class TestSportsScenario:
 
         # Assign Rahul as batsman
         resp = client.post(
-            f"/api/events/{match['id']}/assignments",
+            f"/api/v1/events/{match['id']}/assignments",
             json={
                 "person_id": rahul_id,
                 "action": "assign",
@@ -419,7 +419,7 @@ class TestSportsScenario:
 
         # Assign Ben as batsman
         resp = client.post(
-            f"/api/events/{match['id']}/assignments",
+            f"/api/v1/events/{match['id']}/assignments",
             json={
                 "person_id": ben_id,
                 "action": "assign",
@@ -431,7 +431,7 @@ class TestSportsScenario:
 
         # Rahul gets injured — unassign him
         resp = client.post(
-            f"/api/events/{match['id']}/assignments",
+            f"/api/v1/events/{match['id']}/assignments",
             json={
                 "person_id": rahul_id,
                 "action": "unassign",
@@ -441,7 +441,7 @@ class TestSportsScenario:
         assert resp.status_code == 200
 
         # Verify only Ben remains assigned
-        resp = client.get(f"/api/events/assignments/all?org_id={self.ORG}")
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}")
         assert resp.status_code == 200
         match_assignments = [
             a for a in resp.json()["assignments"] if a["event_id"] == "finals-match"
@@ -463,7 +463,7 @@ class TestSportsScenario:
         start = (datetime.now() + timedelta(days=14)).isoformat()
         end = (datetime.now() + timedelta(days=14, hours=2)).isoformat()
         resp = client.post(
-            "/api/events/",
+            "/api/v1/events/",
             json={
                 "id": "unauthorized-match",
                 "org_id": self.ORG,

--- a/tests/security/test_authentication.py
+++ b/tests/security/test_authentication.py
@@ -62,7 +62,7 @@ async def test_unauthenticated_request_to_protected_endpoint():
     """Test that requests without auth token are rejected."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         # Try to access protected endpoint without token
-        response = await ac.get("/api/people/me")
+        response = await ac.get("/api/v1/people/me")
 
         # Should return 403 Forbidden (no auth header provided)
         assert response.status_code == 403
@@ -73,7 +73,7 @@ async def test_invalid_token_rejected():
     """Test that invalid tokens are rejected."""
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.get(
-            "/api/people/me", headers={"Authorization": "Bearer invalid_token_xyz"}
+            "/api/v1/people/me", headers={"Authorization": "Bearer invalid_token_xyz"}
         )
 
         # Should return 401 Unauthorized
@@ -117,7 +117,7 @@ async def test_login_returns_jwt_token():
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.post(
-            "/api/auth/login",
+            "/api/v1/auth/login",
             json={"email": "security_test@example.com", "password": "testpass123"},
         )
 
@@ -174,7 +174,7 @@ async def test_authenticated_request_with_valid_token():
     token = create_access_token(data={"sub": "auth_test_person"})
 
     async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get("/api/people/me", headers={"Authorization": f"Bearer {token}"})
+        response = await ac.get("/api/v1/people/me", headers={"Authorization": f"Bearer {token}"})
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_test_data_setup.py
+++ b/tests/test_test_data_setup.py
@@ -8,7 +8,7 @@ work correctly to create test data before tests run.
 import pytest
 import requests
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestSetupTestDataFunction:

--- a/tests/unit/test_availability.py
+++ b/tests/unit/test_availability.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestAvailabilityCreate:

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -12,7 +12,7 @@ from api.utils.calendar_utils import (
 )
 from api.utils.security import generate_calendar_token
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestCalendarUtils:
@@ -34,21 +34,21 @@ class TestCalendarUtils:
 
         # Test with https://
         url1 = generate_webcal_url("https://rostio.app", token)
-        assert url1 == "webcal://rostio.app/api/calendar/feed/test_token_123"
+        assert url1 == "webcal://rostio.app/api/v1/calendar/feed/test_token_123"
 
         # Test with http://
         url2 = generate_webcal_url("http://localhost:8000", token)
-        assert url2 == "webcal://localhost:8000/api/calendar/feed/test_token_123"
+        assert url2 == "webcal://localhost:8000/api/v1/calendar/feed/test_token_123"
 
     def test_generate_https_feed_url(self, client):
         """Test HTTPS feed URL generation."""
         token = "test_token_123"
 
         url1 = generate_https_feed_url("https://rostio.app", token)
-        assert url1 == "https://rostio.app/api/calendar/feed/test_token_123"
+        assert url1 == "https://rostio.app/api/v1/calendar/feed/test_token_123"
 
         url2 = generate_https_feed_url("rostio.app", token)
-        assert url2 == "https://rostio.app/api/calendar/feed/test_token_123"
+        assert url2 == "https://rostio.app/api/v1/calendar/feed/test_token_123"
 
     def test_generate_ics_from_assignments(self, client):
         """Test ICS generation from assignments."""

--- a/tests/unit/test_conftest_mocking.py
+++ b/tests/unit/test_conftest_mocking.py
@@ -67,7 +67,7 @@ class TestAuthenticationMocking:
         db.commit()
 
         # Call protected endpoint without Authorization header
-        response = client.get("/api/people/test_person_endpoint")
+        response = client.get("/api/v1/people/test_person_endpoint")
 
         # Should succeed because auth is mocked
         assert response.status_code == 200
@@ -213,7 +213,7 @@ class TestMockingIntegration:
 
         # Create person without auth header
         response = client.post(
-            "/api/people/",
+            "/api/v1/people/",
             json={
                 "id": "test_person_mock",
                 "org_id": "test_org_mock",
@@ -253,7 +253,7 @@ class TestMockingIntegration:
         db.commit()
 
         # Update without auth header
-        response = client.put("/api/people/test_person_update", json={"name": "Updated Name"})
+        response = client.put("/api/v1/people/test_person_update", json={"name": "Updated Name"})
 
         assert response.status_code == 200
         assert response.json()["name"] == "Updated Name"
@@ -286,7 +286,7 @@ class TestMockingIntegration:
         db.commit()
 
         # Delete without auth header
-        response = client.delete("/api/people/test_person_delete")
+        response = client.delete("/api/v1/people/test_person_delete")
 
         # DELETE returns 204 No Content on success
         assert response.status_code == 204

--- a/tests/unit/test_event_roles.py
+++ b/tests/unit/test_event_roles.py
@@ -7,7 +7,7 @@ Tests the ability to assign people to events with specific roles
 
 import time
 
-API_BASE = "/api"
+API_BASE = "/api/v1"
 
 
 class TestEventRoleAssignment:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestEventCreate:

--- a/tests/unit/test_invitations_api.py
+++ b/tests/unit/test_invitations_api.py
@@ -5,7 +5,7 @@ Following TDD/BDD - test before fixing.
 
 import pytest
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestInvitationsAPI:

--- a/tests/unit/test_organizations.py
+++ b/tests/unit/test_organizations.py
@@ -1,7 +1,7 @@
 """Unit tests for organization endpoints."""
 
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestOrganizationCreate:

--- a/tests/unit/test_password_reset.py
+++ b/tests/unit/test_password_reset.py
@@ -38,7 +38,7 @@ class TestPasswordResetSecurity:
         db.commit()
 
         # Request password reset
-        response = client.post("/api/auth/forgot-password", json={"email": "reset@example.com"})
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
         assert response.status_code == 200
         data = response.json()
         assert "reset_link" in data
@@ -50,7 +50,7 @@ class TestPasswordResetSecurity:
         # Reset password
         new_password = "NewSecurePassword123!"
         response = client.post(
-            "/api/auth/reset-password", json={"token": token, "new_password": new_password}
+            "/api/v1/auth/reset-password", json={"token": token, "new_password": new_password}
         )
         assert response.status_code == 200
         assert response.json()["message"] == "Password reset successfully"
@@ -111,13 +111,13 @@ class TestPasswordResetSecurity:
         db.commit()
 
         # Request password reset
-        response = client.post("/api/auth/forgot-password", json={"email": "sha@example.com"})
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "sha@example.com"})
         token = response.json()["reset_link"].split("token=")[1]
 
         # Reset password
         new_password = "TestPassword123"
         response = client.post(
-            "/api/auth/reset-password", json={"token": token, "new_password": new_password}
+            "/api/v1/auth/reset-password", json={"token": token, "new_password": new_password}
         )
         assert response.status_code == 200
 
@@ -172,19 +172,19 @@ class TestPasswordResetSecurity:
         db.commit()
 
         # Request password reset
-        response = client.post("/api/auth/forgot-password", json={"email": "login@example.com"})
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "login@example.com"})
         token = response.json()["reset_link"].split("token=")[1]
 
         # Reset password to known value
         new_password = "MyNewPassword456!"
         response = client.post(
-            "/api/auth/reset-password", json={"token": token, "new_password": new_password}
+            "/api/v1/auth/reset-password", json={"token": token, "new_password": new_password}
         )
         assert response.status_code == 200
 
         # Try to log in with new password
         response = client.post(
-            "/api/auth/login", json={"email": "login@example.com", "password": new_password}
+            "/api/v1/auth/login", json={"email": "login@example.com", "password": new_password}
         )
 
         # Should succeed because password was properly hashed with bcrypt

--- a/tests/unit/test_people.py
+++ b/tests/unit/test_people.py
@@ -1,7 +1,7 @@
 """Unit tests for people endpoints."""
 
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestPersonCreate:

--- a/tests/unit/test_teams.py
+++ b/tests/unit/test_teams.py
@@ -1,7 +1,7 @@
 """Unit tests for team endpoints."""
 
 
-API_BASE = "http://localhost:8000/api"
+API_BASE = "http://localhost:8000/api/v1"
 
 
 class TestTeamCreate:


### PR DESCRIPTION
## Summary

- Mount every active router under `/api/v1`. Bare `/api` becomes a 308 redirect to `/api/v1` for one release.
- Move the `api_info` endpoint to `/api/v1`; the redirect at `/api` is hidden from the OpenAPI schema.
- Update `generate_webcal_url` / `generate_https_feed_url` to emit `/api/v1/calendar/feed/{token}`.
- Mechanical sweep across tests (109 literal URL references + 9 module-level `API_BASE` constants).
- Update `CLAUDE.md` router map.

Second step of the Sprint 1 backend pre-flight from the Flutter-readiness plan.

## Changed files

- `api/main.py`: 14 router prefixes + canonical `/api/v1` info + 308 redirect
- `api/utils/calendar_utils.py`: webcal/https URL paths now versioned
- `CLAUDE.md`: router map
- 21 test files: literal URLs and `API_BASE` constants
- `tests/api/test_middleware.py`: 2 new tests for the redirect and canonical `/api/v1` info shape

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/` — 368 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Remove the `/api` redirect after the Flutter client is fully on `/api/v1`.
- Sprint 1 Step 4 (stable `operationId` for codegen) next.