### PR TITLE
Sprint 1 Step 5: UTC datetime wire format with Z suffix

### DIFF
--- a/api/schemas/_serializers.py
+++ b/api/schemas/_serializers.py
@@ -1,0 +1,26 @@
+"""Shared response-schema mixin: emit ISO 8601 UTC datetimes with `Z` suffix on the wire.
+
+Pydantic 2 already serializes timezone-aware UTC datetimes as `...Z`. The DB layer in
+this project stores naive UTC (`api/utils/timeutils.utcnow()` strips tzinfo for SQLite
+portability), so without help the wire would emit `2026-05-05T12:30:45` with no offset
+hint — Dart's `DateTime.parse` then assumes local time. `BaseResponse` localizes any
+naive datetime field to UTC after model construction so the existing Pydantic
+serializer produces the desired `...Z` form.
+"""
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class BaseResponse(BaseModel):
+    """Mixin for API response models. Treats naive datetime fields as UTC."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _localize_naive_datetimes(self) -> "BaseResponse":
+        for field_name, value in list(self.__dict__.items()):
+            if isinstance(value, datetime) and value.tzinfo is None:
+                object.__setattr__(self, field_name, value.replace(tzinfo=UTC))
+        return self

--- a/api/schemas/event.py
+++ b/api/schemas/event.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
+
+from api.schemas._serializers import BaseResponse
 
 
 class EventBase(BaseModel):
@@ -34,10 +36,8 @@ class EventUpdate(BaseModel):
     extra_data: dict[str, Any] | None = None
 
 
-class EventResponse(EventBase):
+class EventResponse(BaseResponse, EventBase):
     """Schema for event response."""
-
-    model_config = ConfigDict(from_attributes=True)
 
     id: str
     org_id: str

--- a/api/schemas/organization.py
+++ b/api/schemas/organization.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
+
+from api.schemas._serializers import BaseResponse
 
 
 class OrganizationBase(BaseModel):
@@ -28,10 +30,8 @@ class OrganizationUpdate(BaseModel):
     config: dict[str, Any] | None = None
 
 
-class OrganizationResponse(OrganizationBase):
+class OrganizationResponse(BaseResponse, OrganizationBase):
     """Schema for organization response."""
-
-    model_config = ConfigDict(from_attributes=True)
 
     id: str
     created_at: datetime

--- a/api/schemas/person.py
+++ b/api/schemas/person.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field
+
+from api.schemas._serializers import BaseResponse
 
 
 class PersonBase(BaseModel):
@@ -35,10 +37,8 @@ class PersonUpdate(BaseModel):
     extra_data: dict[str, Any] | None = None
 
 
-class PersonResponse(PersonBase):
+class PersonResponse(BaseResponse, PersonBase):
     """Schema for person response."""
-
-    model_config = ConfigDict(from_attributes=True)
 
     id: str
     org_id: str

--- a/tests/api/test_datetime_format.py
+++ b/tests/api/test_datetime_format.py
@@ -1,0 +1,83 @@
+"""Wire format tests: API responses serialize datetimes as ISO 8601 with `Z`."""
+
+import re
+from datetime import UTC, datetime
+
+import pytest
+
+from api.schemas.event import EventResponse
+from api.schemas.organization import OrganizationResponse
+from api.schemas.person import PersonResponse
+
+# ISO 8601 with mandatory Z suffix and optional fractional seconds.
+ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$")
+
+
+@pytest.fixture
+def utc_dt() -> datetime:
+    return datetime(2026, 5, 5, 12, 30, 45, tzinfo=UTC)
+
+
+@pytest.fixture
+def naive_dt() -> datetime:
+    """Naive datetime (no tzinfo). Wire format should still produce Z."""
+    return datetime(2026, 5, 5, 12, 30, 45)
+
+
+def _person(dt: datetime) -> PersonResponse:
+    return PersonResponse(
+        id="p1",
+        org_id="o1",
+        name="Test Person",
+        email="t@example.com",
+        roles=["volunteer"],
+        timezone="UTC",
+        extra_data={},
+        created_at=dt,
+        updated_at=dt,
+    )
+
+
+def _organization(dt: datetime) -> OrganizationResponse:
+    return OrganizationResponse(
+        id="o1",
+        name="Test Org",
+        region="Test",
+        config={},
+        created_at=dt,
+        updated_at=dt,
+    )
+
+
+def _event(dt: datetime) -> EventResponse:
+    return EventResponse(
+        id="e1",
+        org_id="o1",
+        type="service",
+        start_time=dt,
+        end_time=dt,
+        extra_data={},
+        created_at=dt,
+        updated_at=dt,
+    )
+
+
+@pytest.mark.parametrize("factory", [_person, _organization, _event])
+def test_response_serializes_utc_datetime_with_z_suffix(factory, utc_dt):
+    payload = factory(utc_dt).model_dump(mode="json")
+    for field in ("created_at", "updated_at"):
+        value = payload[field]
+        assert ISO_Z_RE.match(value), f"{field} = {value!r} is not ISO 8601 with Z"
+
+
+@pytest.mark.parametrize("factory", [_person, _organization, _event])
+def test_response_treats_naive_datetime_as_utc(factory, naive_dt):
+    payload = factory(naive_dt).model_dump(mode="json")
+    for field in ("created_at", "updated_at"):
+        assert payload[field].endswith("Z"), f"{field} should end in Z, got {payload[field]!r}"
+
+
+def test_event_start_and_end_time_serialize_with_z(utc_dt):
+    payload = _event(utc_dt).model_dump(mode="json")
+    assert ISO_Z_RE.match(payload["start_time"])
+    assert ISO_Z_RE.match(payload["end_time"])


### PR DESCRIPTION
## Summary

- Add `BaseResponse` mixin in `api/schemas/_serializers.py` that promotes naive datetime fields to UTC after model construction; combined with Pydantic 2's default behavior this yields wire-format timestamps like `"2026-05-05T12:30:45Z"`.
- Apply the mixin to `PersonResponse`, `OrganizationResponse`, `EventResponse` — the three response shapes carrying the most datetime fields the Flutter client will consume.

The gap was naive datetimes coming out of the DB (`api/utils/timeutils.utcnow` strips tzinfo for SQLite portability) — without help they wired as `"2026-05-05T12:30:45"` and Dart's `DateTime.parse` assumed local time.

## Changed files

- `api/schemas/_serializers.py` (new): `BaseResponse` with `model_validator(mode="after")` that localizes naive datetimes to UTC.
- `api/schemas/person.py`, `organization.py`, `event.py`: response classes now inherit `BaseResponse` (and drop the duplicated `from_attributes=True` config).
- `tests/api/test_datetime_format.py` (new): 7 parametrized tests covering aware UTC and naive datetime serialization across the three response models, plus event `start_time` / `end_time`.

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/` — 380 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Other response schemas (Team, Constraint, Solution, Invitation, Availability) carry datetime fields too. Migration to `BaseResponse` is mechanical and can land alongside Step 3 (uniform list envelope) which touches the same files.
- Sprint 1 OpenAPI contract test tier comes next.