### PR TITLE
Sprint 2 PR 1: Password-reset token leak fix

### DIFF
--- a/api/core/config.py
+++ b/api/core/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     # Application
     APP_URL: str = "http://localhost:8000"
     TESTING: bool = False
+    # When true, /auth/forgot-password returns the raw reset token in the JSON
+    # response. Default off — never enable in production. Used by E2E tests
+    # that exercise the reset flow without a real email service.
+    DEBUG_RETURN_RESET_TOKEN: bool = False
 
     # Email Service (General)
     EMAIL_FROM: str = "noreply@signupflow.io"

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -1,16 +1,24 @@
 """Password reset endpoints."""
 
+import os
 import secrets
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Person
+from api.models import AuditAction, Person
 from api.security import hash_password
+from api.utils.audit_logger import log_audit_event
 from api.utils.rate_limit_middleware import rate_limit
+
+
+def _debug_return_reset_token() -> bool:
+    """True iff DEBUG_RETURN_RESET_TOKEN is opted into via env. Default off."""
+    return os.getenv("DEBUG_RETURN_RESET_TOKEN", "false").strip().lower() in ("1", "true", "yes")
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -34,30 +42,45 @@ class PasswordResetConfirm(BaseModel):
 @router.post("/forgot-password", dependencies=[Depends(rate_limit("password_reset"))])
 def request_password_reset(
     request: PasswordResetRequest,
+    http_request: Request,
     db: Session = Depends(get_db),
 ):
-    """Request a password reset token."""
+    """Request a password reset token.
+
+    Always returns the same generic message regardless of whether the email
+    exists. Audits every request. The reset token is held in-memory and is
+    NEVER returned in the response in production. Set
+    `DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into
+    receiving the token in the JSON body for E2E exercise.
+    """
+    generic_response = {"message": "If the email exists, a password reset link will be sent"}
     person = db.query(Person).filter(Person.email == request.email).first()
 
-    if not person:
-        # Don't reveal if email exists (security)
-        return {"message": "If the email exists, a reset link will be sent"}
+    log_audit_event(
+        db,
+        action=AuditAction.PASSWORD_RESET_REQUESTED,
+        user_id=person.id if person else None,
+        user_email=request.email,
+        organization_id=person.org_id if person else None,
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+        status="success" if person else "denied",
+    )
 
-    # Generate reset token
+    if not person:
+        return generic_response
+
     token = secrets.token_urlsafe(32)
     reset_tokens[token] = {
         "person_id": person.id,
         "expires": datetime.now() + timedelta(hours=1),
     }
 
-    # In production, send email with reset link here
-    # For now, return the token (in production, don't return it!)
-    reset_link = f"http://localhost:8000/reset-password?token={token}"
+    if _debug_return_reset_token():
+        # Test/dev affordance ONLY. Default off.
+        return {**generic_response, "token": token}
 
-    return {
-        "message": "Password reset link sent to email",
-        "reset_link": reset_link,  # Remove in production!
-    }
+    return generic_response
 
 
 @router.post("/reset-password", dependencies=[Depends(rate_limit("password_reset_confirm"))])

--- a/tests/api/test_password_reset.py
+++ b/tests/api/test_password_reset.py
@@ -1,0 +1,131 @@
+"""Password-reset endpoint security tests.
+
+Covers two regressions:
+- The default response must NOT include the reset token / reset link.
+- The token round-trip must still be testable, gated behind DEBUG_RETURN_RESET_TOKEN.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.database import get_db
+from api.main import app
+from api.models import Organization, Person
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def reset_user(client):
+    """Seed an org and one person with a known email; cleanup on teardown."""
+    db_gen = get_db()
+    db = next(db_gen)
+
+    org = Organization(id="reset_test_org", name="Reset Test Org", region="Test")
+    db.add(org)
+    db.commit()
+
+    person = Person(
+        id="reset_test_person",
+        org_id="reset_test_org",
+        name="Reset Tester",
+        email="reset@example.com",
+        password_hash="$2b$12$dummy_hash_will_be_replaced",
+        roles=["volunteer"],
+    )
+    db.add(person)
+    db.commit()
+
+    yield person
+
+    db.delete(person)
+    db.delete(org)
+    db.commit()
+
+
+class TestForgotPasswordResponseShape:
+    """Default response must not leak reset token / link."""
+
+    def test_response_omits_token_and_link_by_default(self, client, reset_user, monkeypatch):
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
+        assert response.status_code == 200
+        body = response.json()
+        assert "reset_link" not in body
+        assert "token" not in body
+        assert "message" in body
+
+    def test_response_omits_token_for_unknown_email(self, client):
+        """Same response shape regardless of whether the email exists."""
+        response = client.post(
+            "/api/v1/auth/forgot-password", json={"email": "no-such-user@example.com"}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "reset_link" not in body
+        assert "token" not in body
+        assert "message" in body
+
+
+class TestForgotPasswordDebugFlag:
+    """Under DEBUG_RETURN_RESET_TOKEN=true the token comes back in the body for E2E."""
+
+    def test_token_returned_when_flag_enabled(self, client, reset_user, monkeypatch):
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
+        assert response.status_code == 200
+        body = response.json()
+        assert "token" in body
+        assert isinstance(body["token"], str)
+        assert len(body["token"]) >= 20
+
+    def test_full_reset_flow_with_debug_flag(self, client, reset_user, monkeypatch):
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+
+        forgot = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
+        token = forgot.json()["token"]
+
+        new_password = "BrandNewPassword99!"
+        confirm = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": new_password},
+        )
+        assert confirm.status_code == 200
+        assert confirm.json()["message"] == "Password reset successfully"
+
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"email": "reset@example.com", "password": new_password},
+        )
+        assert login.status_code == 200
+        assert "token" in login.json()
+
+
+class TestForgotPasswordAuditTrail:
+    """The forgot-password endpoint should leave an audit row regardless of leak flag."""
+
+    def test_audit_row_created_on_request(self, client, reset_user, monkeypatch):
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+
+        from api.models import AuditAction, AuditLog
+
+        db_gen = get_db()
+        db = next(db_gen)
+        before = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.PASSWORD_RESET_REQUESTED)
+            .count()
+        )
+
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
+        assert response.status_code == 200
+
+        after = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.PASSWORD_RESET_REQUESTED)
+            .count()
+        )
+        assert after == before + 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -2372,7 +2372,7 @@
     },
     "/api/v1/auth/forgot-password": {
       "post": {
-        "description": "Request a password reset token.",
+        "description": "Request a password reset token.\n\nAlways returns the same generic message regardless of whether the email\nexists. Audits every request. The reset token is held in-memory and is\nNEVER returned in the response in production. Set\n`DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into\nreceiving the token in the JSON body for E2E exercise.",
         "operationId": "requestPasswordReset",
         "requestBody": {
           "content": {

--- a/tests/unit/test_password_reset.py
+++ b/tests/unit/test_password_reset.py
@@ -12,6 +12,11 @@ from api.security import verify_password
 class TestPasswordResetSecurity:
     """Test that password reset uses bcrypt instead of SHA256."""
 
+    @pytest.fixture(autouse=True)
+    def _enable_reset_token_debug(self, monkeypatch):
+        """These tests need the raw token in the response to drive the reset flow."""
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+
     def test_password_reset_uses_bcrypt(self):
         """Verify that password reset hashes passwords with bcrypt, not SHA256."""
         client = TestClient(app)
@@ -37,15 +42,12 @@ class TestPasswordResetSecurity:
         db.add(person)
         db.commit()
 
-        # Request password reset
+        # Request password reset (token returned only because of DEBUG flag set above)
         response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
         assert response.status_code == 200
         data = response.json()
-        assert "reset_link" in data
-
-        # Extract token from reset link
-        reset_link = data["reset_link"]
-        token = reset_link.split("token=")[1]
+        assert "token" in data
+        token = data["token"]
 
         # Reset password
         new_password = "NewSecurePassword123!"
@@ -112,7 +114,7 @@ class TestPasswordResetSecurity:
 
         # Request password reset
         response = client.post("/api/v1/auth/forgot-password", json={"email": "sha@example.com"})
-        token = response.json()["reset_link"].split("token=")[1]
+        token = response.json()["token"]
 
         # Reset password
         new_password = "TestPassword123"
@@ -173,7 +175,7 @@ class TestPasswordResetSecurity:
 
         # Request password reset
         response = client.post("/api/v1/auth/forgot-password", json={"email": "login@example.com"})
-        token = response.json()["reset_link"].split("token=")[1]
+        token = response.json()["token"]
 
         # Reset password to known value
         new_password = "MyNewPassword456!"


### PR DESCRIPTION
## Summary

- `/auth/forgot-password` no longer returns `reset_link` in the JSON response by default. Anyone hitting the endpoint with a valid email could previously harvest the token directly without ever needing the email — that's the security gap this closes.
- Behind `DEBUG_RETURN_RESET_TOKEN=true` (default off), the endpoint optionally includes a `token` field so dev/test E2E flows can drive the reset without an email service.
- Audit every forgot-password request via `log_audit_event(action=AuditAction.PASSWORD_RESET_REQUESTED)`. `status="success"` if the email exists, `status="denied"` if not. Captures user_id, user_email, organization_id, ip_address, user_agent.
- Unknown-email and known-email branches now produce identical response bodies (no shape drift).

First PR of Sprint 2 per the approved plan; smallest-surface security fix.

## Changed files

- `api/routers/password_reset.py`: drop `reset_link`; new `_debug_return_reset_token()` helper; audit log call wired
- `api/core/config.py`: document `DEBUG_RETURN_RESET_TOKEN: bool = False`
- `tests/api/test_password_reset.py` (new): 5 tests — response shape, debug flag round-trip, audit row creation
- `tests/unit/test_password_reset.py`: autouse fixture sets `DEBUG_RETURN_RESET_TOKEN=true`; tests now read `data["token"]`
- `tests/contract/openapi.snapshot.json`: refreshed (response schema shrank)

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 386 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 2 PR 2 (cross-tenant safety net) next.
- mypy still advisory.