### PR TITLE
Sprint 2 PR 2: Cross-tenant query safety net

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -39,6 +39,13 @@ engine = create_engine(
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+# Install the cross-tenant query guard. The listener is registered against
+# the global Session class so it covers SessionLocal as well as any test
+# sessionmakers spun up against in-memory SQLite (e.g., tests/api/conftest.py).
+from api.utils.tenancy_guard import install_tenancy_guard  # noqa: E402
+
+install_tenancy_guard(Session)
+
 
 def _resolve_sqlite_path(db_url: str) -> Path | None:
     """Translate SQLite URLs into filesystem paths."""

--- a/api/utils/tenancy_guard.py
+++ b/api/utils/tenancy_guard.py
@@ -1,0 +1,115 @@
+"""Cross-tenant query safety net.
+
+A SQLAlchemy `do_orm_execute` listener that flags SELECTs against models
+carrying a direct `org_id` column when the WHERE clause does not constrain
+`org_id`. This catches the common "forgot to filter by org_id" leak before
+it reaches a response.
+
+Modes (env var `TENANCY_GUARD`):
+- `off` — listener does nothing (recommended only for migrations).
+- `warn` — log a warning and continue (recommended for production).
+- `strict` — raise `TenancyViolationError` (recommended for tests).
+
+This is a defense-in-depth check, not a primary control. The primary
+control remains explicit `verify_org_member()` in route handlers.
+"""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import event
+from sqlalchemy.orm import ORMExecuteState, Session
+
+from api.logging_config import logger
+
+
+class TenancyViolationError(RuntimeError):
+    """Raised when a select against a tenant-scoped model omits org_id filtering."""
+
+
+def _mode() -> str:
+    return os.getenv("TENANCY_GUARD", "warn").strip().lower()
+
+
+def _tenant_scoped_entities(state: ORMExecuteState) -> set[str]:
+    """Return names of selected entities that have a direct `org_id` column."""
+    names: set[str] = set()
+    try:
+        descs = state.statement.column_descriptions or []
+    except Exception:
+        return names
+    for desc in descs:
+        entity = desc.get("entity") if isinstance(desc, dict) else None
+        if entity is None:
+            continue
+        if hasattr(entity, "org_id"):
+            cls_name = getattr(entity, "__name__", None)
+            if cls_name:
+                names.add(cls_name)
+    return names
+
+
+# Filter substrings that count as "sufficiently restrictive": tenant scoping
+# (`org_id`) plus globally-unique identifiers used for legitimate single-row
+# lookups (signup duplicate check, login, password reset, invitation accept).
+# This is a heuristic — the primary tenant control is `verify_org_member()` in
+# route handlers; the listener catches the common "forgot to filter" leak.
+_SAFE_FILTER_FRAGMENTS = (
+    "org_id",
+    ".id =",
+    ".id IN",
+    ".email =",
+    ".email IN",
+    ".token =",
+    ".calendar_token =",
+)
+
+
+def _where_is_safe(state: ORMExecuteState) -> bool:
+    where = getattr(state.statement, "whereclause", None)
+    if where is None:
+        return False
+    try:
+        rendered = str(where.compile(compile_kwargs={"literal_binds": False}))
+    except Exception:
+        return False
+    return any(fragment in rendered for fragment in _SAFE_FILTER_FRAGMENTS)
+
+
+def _check(state: ORMExecuteState) -> None:
+    mode = _mode()
+    if mode == "off":
+        return
+    if not state.is_select:
+        return
+    # Relationship loads (e.g., parent.children lazy-load on delete cascade)
+    # are scoped by the parent row's PK, not by org_id. The parent's tenancy
+    # was already enforced when the parent was loaded.
+    if getattr(state, "is_relationship_load", False):
+        return
+    entities = _tenant_scoped_entities(state)
+    if not entities:
+        return
+    if _where_is_safe(state):
+        return
+
+    msg = (
+        f"Tenancy guard: SELECT against {sorted(entities)} without org_id filter. "
+        f"This is a multi-tenant data leak risk."
+    )
+    if mode == "strict":
+        raise TenancyViolationError(msg)
+    logger.warning(msg)
+
+
+_INSTALLED = False
+
+
+def install_tenancy_guard(target: type = Session) -> None:
+    """Install the listener on a Session class. Idempotent."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    event.listen(target, "do_orm_execute", _check)
+    _INSTALLED = True

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -26,6 +26,12 @@ from api.models import Base
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _strict_tenancy_guard(monkeypatch):
+    """Make the tenancy guard raise inside this tier so tenant leaks fail tests."""
+    monkeypatch.setenv("TENANCY_GUARD", "strict")
+
+
 @pytest.fixture(scope="function")
 def db():
     """Fresh in-memory SQLite database per test. All tables created/dropped."""

--- a/tests/api/test_password_reset.py
+++ b/tests/api/test_password_reset.py
@@ -5,29 +5,16 @@ Covers two regressions:
 - The token round-trip must still be testable, gated behind DEBUG_RETURN_RESET_TOKEN.
 """
 
-import pytest
 from fastapi.testclient import TestClient
 
-from api.database import get_db
 from api.main import app
-from api.models import Organization, Person
+from api.models import AuditAction, AuditLog, Organization, Person
 
 
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-@pytest.fixture
-def reset_user(client):
-    """Seed an org and one person with a known email; cleanup on teardown."""
-    db_gen = get_db()
-    db = next(db_gen)
-
+def _seed_reset_user(db):
+    """Add an org and one volunteer to the test session."""
     org = Organization(id="reset_test_org", name="Reset Test Org", region="Test")
     db.add(org)
-    db.commit()
-
     person = Person(
         id="reset_test_person",
         org_id="reset_test_org",
@@ -38,19 +25,16 @@ def reset_user(client):
     )
     db.add(person)
     db.commit()
-
-    yield person
-
-    db.delete(person)
-    db.delete(org)
-    db.commit()
+    return person
 
 
 class TestForgotPasswordResponseShape:
     """Default response must not leak reset token / link."""
 
-    def test_response_omits_token_and_link_by_default(self, client, reset_user, monkeypatch):
+    def test_response_omits_token_and_link_by_default(self, db, monkeypatch):
         monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+        client = TestClient(app)
         response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
         assert response.status_code == 200
         body = response.json()
@@ -58,8 +42,8 @@ class TestForgotPasswordResponseShape:
         assert "token" not in body
         assert "message" in body
 
-    def test_response_omits_token_for_unknown_email(self, client):
-        """Same response shape regardless of whether the email exists."""
+    def test_response_omits_token_for_unknown_email(self, db):
+        client = TestClient(app)
         response = client.post(
             "/api/v1/auth/forgot-password", json={"email": "no-such-user@example.com"}
         )
@@ -73,8 +57,10 @@ class TestForgotPasswordResponseShape:
 class TestForgotPasswordDebugFlag:
     """Under DEBUG_RETURN_RESET_TOKEN=true the token comes back in the body for E2E."""
 
-    def test_token_returned_when_flag_enabled(self, client, reset_user, monkeypatch):
+    def test_token_returned_when_flag_enabled(self, db, monkeypatch):
         monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        _seed_reset_user(db)
+        client = TestClient(app)
         response = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
         assert response.status_code == 200
         body = response.json()
@@ -82,8 +68,10 @@ class TestForgotPasswordDebugFlag:
         assert isinstance(body["token"], str)
         assert len(body["token"]) >= 20
 
-    def test_full_reset_flow_with_debug_flag(self, client, reset_user, monkeypatch):
+    def test_full_reset_flow_with_debug_flag(self, db, monkeypatch):
         monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        _seed_reset_user(db)
+        client = TestClient(app)
 
         forgot = client.post("/api/v1/auth/forgot-password", json={"email": "reset@example.com"})
         token = forgot.json()["token"]
@@ -107,13 +95,11 @@ class TestForgotPasswordDebugFlag:
 class TestForgotPasswordAuditTrail:
     """The forgot-password endpoint should leave an audit row regardless of leak flag."""
 
-    def test_audit_row_created_on_request(self, client, reset_user, monkeypatch):
+    def test_audit_row_created_on_request(self, db, monkeypatch):
         monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+        client = TestClient(app)
 
-        from api.models import AuditAction, AuditLog
-
-        db_gen = get_db()
-        db = next(db_gen)
         before = (
             db.query(AuditLog)
             .filter(AuditLog.action == AuditAction.PASSWORD_RESET_REQUESTED)

--- a/tests/integration/test_tenancy_guard.py
+++ b/tests/integration/test_tenancy_guard.py
@@ -1,0 +1,114 @@
+"""Integration tests for the cross-tenant query guard.
+
+The guard listens on SQLAlchemy `do_orm_execute` for SELECTs against models
+with a direct `org_id` column. Without `org_id` in the WHERE clause it logs
+a warning (`TENANCY_GUARD=warn`) or raises (`TENANCY_GUARD=strict`).
+"""
+
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from api.models import Base, Constraint, Event, Invitation, Organization, Person, Solution, Team
+from api.utils.tenancy_guard import (
+    TenancyViolationError,
+    install_tenancy_guard,
+)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    install_tenancy_guard(Session)
+    s = factory()
+    org = Organization(id="t_org", name="T", region="T")
+    person = Person(
+        id="t_p",
+        org_id="t_org",
+        name="T P",
+        email="tp@example.com",
+        password_hash="$2b$12$x",
+        roles=["volunteer"],
+    )
+    s.add_all([org, person])
+    s.commit()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+@pytest.fixture
+def strict(monkeypatch):
+    monkeypatch.setenv("TENANCY_GUARD", "strict")
+
+
+@pytest.fixture
+def warn(monkeypatch):
+    monkeypatch.setenv("TENANCY_GUARD", "warn")
+
+
+@pytest.fixture
+def off(monkeypatch):
+    monkeypatch.setenv("TENANCY_GUARD", "off")
+
+
+@pytest.mark.parametrize("model", [Person, Team, Event, Constraint, Solution, Invitation])
+def test_strict_raises_when_org_id_filter_is_missing(session, strict, model):
+    with pytest.raises(TenancyViolationError):
+        session.query(model).all()
+
+
+@pytest.mark.parametrize("model", [Person, Team, Event, Constraint, Solution, Invitation])
+def test_strict_passes_when_org_id_filter_present(session, strict, model):
+    # Should not raise — exact rows don't matter, only that the listener allows it.
+    list(session.query(model).filter(model.org_id == "t_org").all())
+
+
+def test_warn_does_not_raise(session, warn, caplog):
+    """Warn mode logs but the query proceeds."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        rows = session.query(Person).all()
+    assert isinstance(rows, list)
+    assert any("Tenancy guard" in r.message for r in caplog.records)
+
+
+def test_off_disables_the_guard(session, off):
+    rows = session.query(Person).all()
+    assert isinstance(rows, list)
+
+
+def test_organization_query_is_not_guarded(session, strict):
+    """Organization itself has no org_id — it's the tenant root."""
+    list(session.query(Organization).all())
+
+
+def test_count_with_org_id_filter_is_allowed(session, strict):
+    session.query(Person).filter(Person.org_id == "t_org").count()
+
+
+def test_first_with_org_id_filter_is_allowed(session, strict):
+    session.query(Person).filter(Person.org_id == "t_org").first()
+
+
+def test_join_with_org_id_filter_on_parent_passes(session, strict):
+    """Joining Assignment to Event and filtering Event.org_id should pass."""
+    # Assignment has no org_id, but Event does. The query has org_id in WHERE
+    # via the Event join.
+    from api.models import Assignment
+
+    list(
+        session.query(Assignment)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(Event.org_id == "t_org")
+        .all()
+    )


### PR DESCRIPTION
## Summary

- New SQLAlchemy `do_orm_execute` listener at `api/utils/tenancy_guard.py`: fires on every SELECT against models carrying a direct `org_id` column. Without `org_id` (or another globally-unique identifier filter) in the WHERE clause, it logs (`TENANCY_GUARD=warn`, the default) or raises `TenancyViolationError` (`TENANCY_GUARD=strict`, used in tests).
- `tests/api/conftest.py` autouse fixture sets strict mode so the api tier fails any forgotten `org_id` filter at test time.
- Defense-in-depth: the primary tenant control remains explicit `verify_org_member()` in route handlers; this is the safety net.

## Heuristic refinements (false-positive avoidance)

- Skip relationship loads (`state.is_relationship_load`): cascade lazy-loads use FK→PK, parent tenancy already enforced.
- Treat globally-unique-identifier filters as safe: WHERE includes `org_id`, `.id =/IN`, `.email =/IN`, `.token =`, or `.calendar_token =`. Covers signup duplicate-email check, login by email, password-reset token lookup, calendar feed token lookup.
- Skip models without direct `org_id` (e.g., `Organization` itself, `Assignment`, `Availability` — the latter two protected by their parent FK).

## Changed files

- `api/utils/tenancy_guard.py` (new)
- `api/database.py`: register listener at engine creation
- `tests/api/conftest.py`: autouse fixture sets strict mode for the api tier
- `tests/integration/test_tenancy_guard.py` (new): 18 tests — strict/warn/off modes, parametrized over six tenant-scoped models, join-with-FK, Organization root case

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 386 passed, 21 skipped
- [x] `poetry run pytest tests/integration/test_tenancy_guard.py` — 18/18 pass
- [ ] CI green on the PR

## Follow-ups

- Sprint 2 PR 3 (volunteer assignment self-service) — new endpoints will be born under strict mode.
- `tests/integration/` tier has 22 pre-existing fixture errors and is not in CI yet; separate follow-up.