### PR TITLE
Sprint 2 PR 3: Volunteer assignment self-service

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -16,6 +16,7 @@ from api.database import init_db
 from api.logging_config import logger
 from api.routers import (
     analytics,
+    assignments,
     auth,
     availability,
     calendar,
@@ -134,6 +135,7 @@ app.include_router(password_reset.router, prefix="/api/v1")
 app.include_router(analytics.router, prefix="/api/v1")
 app.include_router(invitations.router, prefix="/api/v1")
 app.include_router(calendar.router, prefix="/api/v1")
+app.include_router(assignments.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/models.py
+++ b/api/models.py
@@ -889,6 +889,11 @@ class AuditAction:
     DATABASE_BACKUP = "system.database.backup"
     CONFIG_CHANGED = "system.config.changed"
 
+    # Assignment self-service
+    ASSIGNMENT_ACCEPTED = "assignment.accepted"
+    ASSIGNMENT_DECLINED = "assignment.declined"
+    ASSIGNMENT_SWAP_REQUESTED = "assignment.swap_requested"
+
 
 class SmsPreference(Base):
     """SMS notification preferences for volunteers."""

--- a/api/routers/assignments.py
+++ b/api/routers/assignments.py
@@ -1,0 +1,155 @@
+"""Volunteer-facing assignment self-service.
+
+Volunteers can manage their own assignment lifecycle:
+- accept (status -> "confirmed")
+- decline (status -> "declined", with required reason)
+- request a swap (status -> "swap_requested", optional note)
+- list their own assignments
+
+Admins keep their existing entry points in api/routers/events.py
+(`POST /events/{id}/assignments` for assign/unassign,
+ `GET /events/assignments/all` for org-wide listing).
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from api.database import get_db
+from api.dependencies import get_current_user
+from api.models import Assignment, AuditAction, Event, Person
+from api.schemas.assignment import (
+    AssignmentDeclineRequest,
+    AssignmentResponse,
+    AssignmentSwapRequest,
+)
+from api.utils.audit_logger import log_audit_event
+
+router = APIRouter(prefix="/assignments", tags=["assignments"])
+
+
+def _load_own_assignment(assignment_id: int, current_user: Person, db: Session) -> Assignment:
+    """Load an assignment that belongs to the caller; 404 if missing, 403 if not theirs."""
+    assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
+    if not assignment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found")
+    if assignment.person_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only manage your own assignments",
+        )
+    return assignment
+
+
+def _audit_status_change(
+    db: Session,
+    *,
+    action: str,
+    user: Person,
+    assignment: Assignment,
+    http_request: Request,
+    details: dict | None = None,
+) -> None:
+    log_audit_event(
+        db,
+        action=action,
+        user_id=user.id,
+        user_email=user.email,
+        organization_id=user.org_id,
+        resource_type="assignment",
+        resource_id=str(assignment.id),
+        details=details or {},
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+
+@router.post("/{assignment_id}/accept", response_model=AssignmentResponse)
+def accept_assignment(
+    assignment_id: int,
+    http_request: Request,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mark the caller's assignment as confirmed."""
+    assignment = _load_own_assignment(assignment_id, current_user, db)
+    assignment.status = "confirmed"
+    assignment.decline_reason = None
+    db.commit()
+    db.refresh(assignment)
+    _audit_status_change(
+        db,
+        action=AuditAction.ASSIGNMENT_ACCEPTED,
+        user=current_user,
+        assignment=assignment,
+        http_request=http_request,
+    )
+    return assignment
+
+
+@router.post("/{assignment_id}/decline", response_model=AssignmentResponse)
+def decline_assignment(
+    assignment_id: int,
+    body: AssignmentDeclineRequest,
+    http_request: Request,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Decline the caller's assignment with a reason."""
+    assignment = _load_own_assignment(assignment_id, current_user, db)
+    assignment.status = "declined"
+    assignment.decline_reason = body.decline_reason
+    db.commit()
+    db.refresh(assignment)
+    _audit_status_change(
+        db,
+        action=AuditAction.ASSIGNMENT_DECLINED,
+        user=current_user,
+        assignment=assignment,
+        http_request=http_request,
+        details={"decline_reason": body.decline_reason},
+    )
+    return assignment
+
+
+@router.post("/{assignment_id}/swap-request", response_model=AssignmentResponse)
+def request_swap(
+    assignment_id: int,
+    body: AssignmentSwapRequest,
+    http_request: Request,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Flag the caller's assignment for swap; admin follows up out of band."""
+    assignment = _load_own_assignment(assignment_id, current_user, db)
+    assignment.status = "swap_requested"
+    db.commit()
+    db.refresh(assignment)
+    details = {"note": body.note} if body.note else {}
+    _audit_status_change(
+        db,
+        action=AuditAction.ASSIGNMENT_SWAP_REQUESTED,
+        user=current_user,
+        assignment=assignment,
+        http_request=http_request,
+        details=details,
+    )
+    return assignment
+
+
+@router.get("/me", response_model=list[AssignmentResponse])
+def list_my_assignments(
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return every assignment belonging to the caller, scoped to their org via the join."""
+    rows = (
+        db.query(Assignment)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(
+            Assignment.person_id == current_user.id,
+            Event.org_id == current_user.org_id,
+        )
+        .order_by(Assignment.assigned_at.desc())
+        .all()
+    )
+    return rows

--- a/api/schemas/assignment.py
+++ b/api/schemas/assignment.py
@@ -1,0 +1,33 @@
+"""Schemas for the volunteer-assignment self-service endpoints."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.schemas._serializers import BaseResponse
+
+
+class AssignmentDeclineRequest(BaseModel):
+    """Body for POST /assignments/{id}/decline."""
+
+    decline_reason: str = Field(..., min_length=1, max_length=500)
+
+
+class AssignmentSwapRequest(BaseModel):
+    """Body for POST /assignments/{id}/swap-request."""
+
+    note: str | None = Field(None, max_length=500)
+
+
+class AssignmentResponse(BaseResponse):
+    """Single-assignment response shape returned by self-service mutations."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    event_id: str
+    person_id: str
+    role: str | None
+    status: str
+    decline_reason: str | None
+    assigned_at: datetime

--- a/tests/api/test_assignment_self_service.py
+++ b/tests/api/test_assignment_self_service.py
@@ -1,0 +1,198 @@
+"""Volunteer assignment self-service tests.
+
+Volunteers (not just admins) can:
+- accept their own assignment
+- decline their own assignment with a reason
+- request a swap on their own assignment
+- list their own assignments
+
+Cross-user actions are forbidden. Cross-org actions are blocked by the tenancy guard.
+"""
+
+import pytest
+
+from tests.api.conftest import auth_headers, seed_event, seed_org, seed_user
+
+
+def _setup_org_with_assignment(client, db, suffix: str, role: str = "usher"):
+    """Create an org, an admin, a volunteer, an event, and assign the volunteer to it."""
+    org_id = f"vss-org-{suffix}"
+    seed_org(client, org_id)
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@vss.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    vol = seed_user(
+        client,
+        org_id,
+        email=f"vol-{suffix}@vss.org",
+        name="Volunteer",
+        password="VolPass1!",
+        roles=["volunteer"],
+    )
+    admin_hdrs = auth_headers(client, email=f"admin-{suffix}@vss.org", password="AdminPass1!")
+    event = seed_event(
+        client,
+        admin_hdrs,
+        org_id,
+        event_id=f"evt-{suffix}",
+    )
+    resp = client.post(
+        f"/api/v1/events/{event['id']}/assignments",
+        json={"person_id": vol["person_id"], "action": "assign", "role": role},
+        headers=admin_hdrs,
+    )
+    assert resp.status_code == 200, resp.text
+    aid = resp.json()["assignment_id"]
+    return {
+        "org_id": org_id,
+        "admin_hdrs": admin_hdrs,
+        "vol": vol,
+        "event": event,
+        "assignment_id": aid,
+    }
+
+
+@pytest.mark.no_mock_auth
+class TestVolunteerAccept:
+    def test_volunteer_accepts_own_assignment(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "accept")
+        vol_hdrs = auth_headers(client, email="vol-accept@vss.org", password="VolPass1!")
+
+        resp = client.post(f"/api/v1/assignments/{ctx['assignment_id']}/accept", headers=vol_hdrs)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "confirmed"
+
+    def test_volunteer_cannot_accept_someone_elses_assignment(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "cross")
+        # Add a second volunteer in the same org
+        seed_user(
+            client,
+            ctx["org_id"],
+            email="other@vss.org",
+            name="Other",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        other_hdrs = auth_headers(client, email="other@vss.org", password="VolPass1!")
+
+        resp = client.post(f"/api/v1/assignments/{ctx['assignment_id']}/accept", headers=other_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestVolunteerDecline:
+    def test_decline_persists_reason(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "decline")
+        vol_hdrs = auth_headers(client, email="vol-decline@vss.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/assignments/{ctx['assignment_id']}/decline",
+            json={"decline_reason": "Out of town"},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "declined"
+        assert body["decline_reason"] == "Out of town"
+
+    def test_decline_requires_reason(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "decline-no-reason")
+        vol_hdrs = auth_headers(client, email="vol-decline-no-reason@vss.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/assignments/{ctx['assignment_id']}/decline",
+            json={},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.no_mock_auth
+class TestVolunteerSwapRequest:
+    def test_swap_request_sets_status(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "swap")
+        vol_hdrs = auth_headers(client, email="vol-swap@vss.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/assignments/{ctx['assignment_id']}/swap-request",
+            json={"note": "Family wedding that day"},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "swap_requested"
+
+    def test_swap_request_works_without_note(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "swap-no-note")
+        vol_hdrs = auth_headers(client, email="vol-swap-no-note@vss.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/assignments/{ctx['assignment_id']}/swap-request",
+            json={},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "swap_requested"
+
+
+@pytest.mark.no_mock_auth
+class TestListMyAssignments:
+    def test_returns_only_caller_assignments(self, client, db):
+        ctx = _setup_org_with_assignment(client, db, "list")
+        # Add a second volunteer in the same org and assign them to a second event
+        org_id = ctx["org_id"]
+        seed_user(
+            client,
+            org_id,
+            email="other-list@vss.org",
+            name="Other",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        admin_hdrs = ctx["admin_hdrs"]
+        ev2 = seed_event(client, admin_hdrs, org_id, event_id="evt-list-2")
+        resp = client.post(
+            f"/api/v1/events/{ev2['id']}/assignments",
+            json={"person_id": "other-list@vss.org-id-not-this", "action": "assign", "role": "u"},
+            headers=admin_hdrs,
+        )
+        # That'll fail because the placeholder person_id doesn't match — fall back to listing only.
+        # Use the real other person_id:
+        other = client.post(
+            "/api/v1/auth/login",
+            json={"email": "other-list@vss.org", "password": "VolPass1!"},
+        ).json()
+        client.post(
+            f"/api/v1/events/{ev2['id']}/assignments",
+            json={"person_id": other["person_id"], "action": "assign", "role": "u"},
+            headers=admin_hdrs,
+        )
+
+        # Caller (the original vol) should see only the original assignment
+        vol_hdrs = auth_headers(client, email="vol-list@vss.org", password="VolPass1!")
+        resp = client.get("/api/v1/assignments/me", headers=vol_hdrs)
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert isinstance(rows, list)
+        assert len(rows) == 1
+        assert rows[0]["event_id"] == ctx["event"]["id"]
+
+
+@pytest.mark.no_mock_auth
+class TestAuditTrail:
+    def test_accept_emits_audit_row(self, client, db):
+        from api.models import AuditAction, AuditLog
+
+        ctx = _setup_org_with_assignment(client, db, "audit")
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.ASSIGNMENT_ACCEPTED).count()
+        )
+        vol_hdrs = auth_headers(client, email="vol-audit@vss.org", password="VolPass1!")
+        client.post(f"/api/v1/assignments/{ctx['assignment_id']}/accept", headers=vol_hdrs)
+        after = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.ASSIGNMENT_ACCEPTED).count()
+        )
+        assert after == before + 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1,6 +1,22 @@
 {
   "components": {
     "schemas": {
+      "AssignmentDeclineRequest": {
+        "description": "Body for POST /assignments/{id}/decline.",
+        "properties": {
+          "decline_reason": {
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Decline Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decline_reason"
+        ],
+        "title": "AssignmentDeclineRequest",
+        "type": "object"
+      },
       "AssignmentRequest": {
         "description": "Request to assign/unassign a person.",
         "properties": {
@@ -29,6 +45,84 @@
           "action"
         ],
         "title": "AssignmentRequest",
+        "type": "object"
+      },
+      "AssignmentResponse": {
+        "description": "Single-assignment response shape returned by self-service mutations.",
+        "properties": {
+          "assigned_at": {
+            "format": "date-time",
+            "title": "Assigned At",
+            "type": "string"
+          },
+          "decline_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decline Reason"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "person_id": {
+            "title": "Person Id",
+            "type": "string"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "event_id",
+          "person_id",
+          "role",
+          "status",
+          "decline_reason",
+          "assigned_at"
+        ],
+        "title": "AssignmentResponse",
+        "type": "object"
+      },
+      "AssignmentSwapRequest": {
+        "description": "Body for POST /assignments/{id}/swap-request.",
+        "properties": {
+          "note": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          }
+        },
+        "title": "AssignmentSwapRequest",
         "type": "object"
       },
       "AuthResponse": {
@@ -2325,6 +2419,201 @@
         "summary": "Get Volunteer Stats",
         "tags": [
           "analytics"
+        ]
+      }
+    },
+    "/api/v1/assignments/me": {
+      "get": {
+        "description": "Return every assignment belonging to the caller, scoped to their org via the join.",
+        "operationId": "listMyAssignments",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssignmentResponse"
+                  },
+                  "title": "Response List My Assignments Api V1 Assignments Me Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List My Assignments",
+        "tags": [
+          "assignments"
+        ]
+      }
+    },
+    "/api/v1/assignments/{assignment_id}/accept": {
+      "post": {
+        "description": "Mark the caller's assignment as confirmed.",
+        "operationId": "acceptAssignment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assignment_id",
+            "required": true,
+            "schema": {
+              "title": "Assignment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Accept Assignment",
+        "tags": [
+          "assignments"
+        ]
+      }
+    },
+    "/api/v1/assignments/{assignment_id}/decline": {
+      "post": {
+        "description": "Decline the caller's assignment with a reason.",
+        "operationId": "declineAssignment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assignment_id",
+            "required": true,
+            "schema": {
+              "title": "Assignment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignmentDeclineRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Decline Assignment",
+        "tags": [
+          "assignments"
+        ]
+      }
+    },
+    "/api/v1/assignments/{assignment_id}/swap-request": {
+      "post": {
+        "description": "Flag the caller's assignment for swap; admin follows up out of band.",
+        "operationId": "requestSwap",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assignment_id",
+            "required": true,
+            "schema": {
+              "title": "Assignment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignmentSwapRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Request Swap",
+        "tags": [
+          "assignments"
         ]
       }
     },


### PR DESCRIPTION
## Summary

New `api/routers/assignments.py` with four volunteer-facing endpoints under `/api/v1/assignments`:

- `POST /{id}/accept` — sets `Assignment.status="confirmed"`, clears `decline_reason`
- `POST /{id}/decline` — sets `status="declined"` + persists `decline_reason` (required, 1-500 chars)
- `POST /{id}/swap-request` — sets `status="swap_requested"`, optional `note`
- `GET /me` — caller's assignments only, scoped to their org via `Event` join

Each transition emits an audit row via `log_audit_event` with new `ASSIGNMENT_ACCEPTED` / `DECLINED` / `SWAP_REQUESTED` actions on `AuditAction`.

Authorization: `get_current_user` (volunteer-OK). Cross-user actions return 403; cross-org access blocked by the tenancy guard from PR 2.

## Changed files

- `api/routers/assignments.py` (new): 4 endpoints + helpers
- `api/schemas/assignment.py` (new): request/response models, uses `BaseResponse` for `assigned_at` Z-suffixed serialization
- `api/models.py`: 3 new `AuditAction` constants
- `api/main.py`: register the new router
- `tests/api/test_assignment_self_service.py` (new): 8 tests
- `tests/contract/openapi.snapshot.json`: refreshed (4 new endpoints)

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 394 passed, 21 skipped
- [ ] CI green on the PR

## Existing surfaces unchanged

- Admin-only `POST /events/{id}/assignments` still owns assign/unassign
- Admin-only `GET /events/assignments/all` still owns org-wide listing

## Follow-ups

- Sprint 2 PR 4 (audit log read endpoint) will surface these new rows.
- Admin "approve swap / reassign" workflow is Phase 2.
- Notifications on status change (email/SMS) blocked behind disabled feature flags.