### PR TITLE
Sprint 2 PR 4: Admin-only audit log read endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from api.logging_config import logger
 from api.routers import (
     analytics,
     assignments,
+    audit,
     auth,
     availability,
     calendar,
@@ -136,6 +137,7 @@ app.include_router(analytics.router, prefix="/api/v1")
 app.include_router(invitations.router, prefix="/api/v1")
 app.include_router(calendar.router, prefix="/api/v1")
 app.include_router(assignments.router, prefix="/api/v1")
+app.include_router(audit.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -1,0 +1,80 @@
+"""Admin-only audit log read endpoint."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from api.database import get_db
+from api.dependencies import get_current_admin_user
+from api.models import AuditAction, AuditLog, Person
+from api.schemas.audit import AuditLogResponse
+from api.utils.audit_logger import log_audit_event
+
+router = APIRouter(prefix="/audit-logs", tags=["audit"])
+
+
+@router.get("", response_model=list[AuditLogResponse])
+def list_audit_logs(
+    http_request: Request,
+    user_id: str | None = Query(None, description="Filter by user_id"),
+    action: str | None = Query(None, description="Filter by action (e.g., auth.login.success)"),
+    resource_type: str | None = Query(None, description="Filter by resource_type"),
+    start_date: datetime | None = Query(None, description="Inclusive lower bound on timestamp"),
+    end_date: datetime | None = Query(None, description="Inclusive upper bound on timestamp"),
+    audit_status: str
+    | None = Query(None, alias="status", description="success / failure / denied"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Return audit log rows scoped to the caller's organization.
+
+    Admin-only. Each call is itself recorded as a `data.exported` audit event
+    so reads of the audit log are themselves auditable.
+    """
+    query = db.query(AuditLog).filter(AuditLog.organization_id == current_admin.org_id)
+
+    if user_id is not None:
+        query = query.filter(AuditLog.user_id == user_id)
+    if action is not None:
+        query = query.filter(AuditLog.action == action)
+    if resource_type is not None:
+        query = query.filter(AuditLog.resource_type == resource_type)
+    if start_date is not None:
+        query = query.filter(AuditLog.timestamp >= start_date)
+    if end_date is not None:
+        query = query.filter(AuditLog.timestamp <= end_date)
+    if audit_status is not None:
+        query = query.filter(AuditLog.status == audit_status)
+
+    rows = query.order_by(AuditLog.timestamp.desc()).offset(offset).limit(limit).all()
+
+    log_audit_event(
+        db,
+        action=AuditAction.DATA_EXPORTED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=current_admin.org_id,
+        resource_type="audit_log",
+        details={
+            "filters": {
+                k: v
+                for k, v in {
+                    "user_id": user_id,
+                    "action": action,
+                    "resource_type": resource_type,
+                    "status": audit_status,
+                }.items()
+                if v is not None
+            },
+            "limit": limit,
+            "offset": offset,
+            "result_count": len(rows),
+        },
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    return rows

--- a/api/schemas/audit.py
+++ b/api/schemas/audit.py
@@ -1,0 +1,28 @@
+"""Schemas for the audit-log read endpoint."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import ConfigDict
+
+from api.schemas._serializers import BaseResponse
+
+
+class AuditLogResponse(BaseResponse):
+    """One audit log row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    user_id: str | None
+    user_email: str | None
+    organization_id: str | None
+    action: str
+    resource_type: str | None
+    resource_id: str | None
+    details: dict[str, Any] | None
+    timestamp: datetime
+    ip_address: str | None
+    user_agent: str | None
+    status: str
+    error_message: str | None

--- a/tests/api/test_audit_log_query.py
+++ b/tests/api/test_audit_log_query.py
@@ -1,0 +1,171 @@
+"""Audit log read endpoint tests.
+
+GET /api/v1/audit-logs is admin-only and scoped to the caller's organization.
+The endpoint itself emits a `data.exported` audit row each time it's read.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from api.models import AuditAction, AuditLog
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _seed_audit_row(db, *, action: str, org_id: str, when: datetime, user_id: str = "test-user"):
+    """Insert one AuditLog row directly. Bypasses the tenancy guard."""
+    row = AuditLog(
+        id=f"audit_{action}_{when.timestamp()}_{org_id}",
+        user_id=user_id,
+        user_email="seed@example.com",
+        organization_id=org_id,
+        action=action,
+        resource_type="person",
+        resource_id=user_id,
+        details={},
+        timestamp=when,
+        status="success",
+    )
+    db.add(row)
+    db.commit()
+
+
+def _admin_setup(client, suffix: str):
+    org_id = f"audit-org-{suffix}"
+    seed_org(client, org_id)
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@audit.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return org_id, auth_headers(client, email=f"admin-{suffix}@audit.org", password="AdminPass1!")
+
+
+@pytest.mark.no_mock_auth
+class TestAuditLogReadAccess:
+    def test_volunteer_cannot_read_audit_logs(self, client, db):
+        org_id = "audit-org-vol"
+        seed_org(client, org_id)
+        seed_user(client, org_id, email="admin@v.org", name="Admin", password="AdminPass1!")
+        seed_user(
+            client,
+            org_id,
+            email="vol@v.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@v.org", password="VolPass1!")
+        resp = client.get("/api/v1/audit-logs", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestAuditLogScoping:
+    def test_admin_sees_only_own_org_rows(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "scope")
+        other_org = "audit-org-other"
+        seed_org(client, other_org)
+
+        now = datetime.now(UTC)
+        _seed_audit_row(db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=now)
+        _seed_audit_row(db, action=AuditAction.LOGIN_SUCCESS, org_id=other_org, when=now)
+
+        resp = client.get("/api/v1/audit-logs", headers=admin_hdrs)
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert all(r["organization_id"] == org_id for r in rows)
+
+
+@pytest.mark.no_mock_auth
+class TestAuditLogFilters:
+    def test_filter_by_action(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "action")
+        now = datetime.now(UTC)
+        _seed_audit_row(db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=now)
+        _seed_audit_row(db, action=AuditAction.PASSWORD_RESET_REQUESTED, org_id=org_id, when=now)
+
+        resp = client.get(
+            f"/api/v1/audit-logs?action={AuditAction.LOGIN_SUCCESS}", headers=admin_hdrs
+        )
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert all(r["action"] == AuditAction.LOGIN_SUCCESS for r in rows)
+        assert len(rows) >= 1
+
+    def test_filter_by_date_range(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "date")
+        now = datetime.now(UTC)
+        old = now - timedelta(days=10)
+        _seed_audit_row(db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=old)
+        _seed_audit_row(db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=now)
+
+        # Request only the last day; old row excluded.
+        # Use Z suffix so the URL doesn't need to escape '+' (which becomes space).
+        start = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+        resp = client.get("/api/v1/audit-logs", params={"start_date": start}, headers=admin_hdrs)
+        assert resp.status_code == 200
+        rows = resp.json()
+        # All returned rows must be within the range
+        for r in rows:
+            assert r["timestamp"] >= start
+
+    def test_ordering_is_desc_by_timestamp(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "order")
+        t1 = datetime.now(UTC) - timedelta(minutes=5)
+        t2 = datetime.now(UTC) - timedelta(minutes=1)
+        _seed_audit_row(
+            db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=t1, user_id="u-old"
+        )
+        _seed_audit_row(
+            db, action=AuditAction.LOGIN_SUCCESS, org_id=org_id, when=t2, user_id="u-new"
+        )
+
+        resp = client.get(
+            f"/api/v1/audit-logs?action={AuditAction.LOGIN_SUCCESS}", headers=admin_hdrs
+        )
+        rows = resp.json()
+        timestamps = [r["timestamp"] for r in rows]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+
+@pytest.mark.no_mock_auth
+class TestAuditLogPagination:
+    def test_limit_caps_results(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "page")
+        now = datetime.now(UTC)
+        for i in range(5):
+            _seed_audit_row(
+                db,
+                action=AuditAction.LOGIN_SUCCESS,
+                org_id=org_id,
+                when=now - timedelta(seconds=i),
+                user_id=f"u{i}",
+            )
+
+        resp = client.get("/api/v1/audit-logs?limit=2", headers=admin_hdrs)
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 2
+
+
+@pytest.mark.no_mock_auth
+class TestAuditLogSelfAuditing:
+    def test_query_emits_data_exported_row(self, client, db):
+        org_id, admin_hdrs = _admin_setup(client, "self")
+        before = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.DATA_EXPORTED)
+            .filter(AuditLog.organization_id == org_id)
+            .count()
+        )
+        client.get("/api/v1/audit-logs", headers=admin_hdrs)
+        after = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.DATA_EXPORTED)
+            .filter(AuditLog.organization_id == org_id)
+            .count()
+        )
+        assert after == before + 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -125,6 +125,145 @@
         "title": "AssignmentSwapRequest",
         "type": "object"
       },
+      "AuditLogResponse": {
+        "description": "One audit log row.",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "ip_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip Address"
+          },
+          "organization_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Id"
+          },
+          "resource_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Id"
+          },
+          "resource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Type"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "user_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Agent"
+          },
+          "user_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Email"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "user_email",
+          "organization_id",
+          "action",
+          "resource_type",
+          "resource_id",
+          "details",
+          "timestamp",
+          "ip_address",
+          "user_agent",
+          "status",
+          "error_message"
+        ],
+        "title": "AuditLogResponse",
+        "type": "object"
+      },
       "AuthResponse": {
         "description": "Authentication response.",
         "properties": {
@@ -2614,6 +2753,182 @@
         "summary": "Request Swap",
         "tags": [
           "assignments"
+        ]
+      }
+    },
+    "/api/v1/audit-logs": {
+      "get": {
+        "description": "Return audit log rows scoped to the caller's organization.\n\nAdmin-only. Each call is itself recorded as a `data.exported` audit event\nso reads of the audit log are themselves auditable.",
+        "operationId": "listAuditLogs",
+        "parameters": [
+          {
+            "description": "Filter by user_id",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by user_id",
+              "title": "User Id"
+            }
+          },
+          {
+            "description": "Filter by action (e.g., auth.login.success)",
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by action (e.g., auth.login.success)",
+              "title": "Action"
+            }
+          },
+          {
+            "description": "Filter by resource_type",
+            "in": "query",
+            "name": "resource_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by resource_type",
+              "title": "Resource Type"
+            }
+          },
+          {
+            "description": "Inclusive lower bound on timestamp",
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive lower bound on timestamp",
+              "title": "Start Date"
+            }
+          },
+          {
+            "description": "Inclusive upper bound on timestamp",
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inclusive upper bound on timestamp",
+              "title": "End Date"
+            }
+          },
+          {
+            "description": "success / failure / denied",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "success / failure / denied",
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AuditLogResponse"
+                  },
+                  "title": "Response List Audit Logs Api V1 Audit Logs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Audit Logs",
+        "tags": [
+          "audit"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- New `api/routers/audit.py` exposes `GET /api/v1/audit-logs` (admin-only).
- Filters: `user_id`, `action`, `resource_type`, `start_date`, `end_date`, `status` (alias for the `status` query param to avoid clashing with Python's `status` namespace).
- Always scoped to `current_admin.org_id`; cross-org reads not exposed.
- Pagination: `limit` (1-200, default 50) + `offset` (default 0).
- Ordering: `timestamp DESC` (newest first), uses existing `idx_audit_org_timestamp` index.
- Reading the audit log is itself audited — every call emits a `data.exported` row including filter params and result count.

## Existing infrastructure leveraged

- `AuditLog` model + 3 composite indexes (`api/models.py:803`)
- `log_audit_event` already in `api/utils/audit_logger.py`
- `get_current_admin_user` dependency for the admin gate
- `BaseResponse` mixin so timestamps wire as Z-suffixed ISO 8601

## Changed files

- `api/routers/audit.py` (new)
- `api/schemas/audit.py` (new): `AuditLogResponse`
- `api/main.py`: register router
- `tests/api/test_audit_log_query.py` (new): 7 tests — 403 for non-admin, org scoping, action/date filters, desc ordering, pagination cap, self-audit
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 401 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 2 PR 5 (uniform list envelope) will convert `audit-logs` to `ListResponse[AuditLogResponse]`.
- Audit retention / archival policy is a separate plan.
- Cross-org audit access for a super-admin role is Phase 2.