### PR TITLE
Sprint 2 PR 5: Uniform list envelope + pagination params

### DIFF
--- a/api/routers/constraints.py
+++ b/api/routers/constraints.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from api.database import get_db
 from api.models import Constraint, Organization
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.constraint import (
     ConstraintCreate,
     ConstraintList,
@@ -53,8 +54,7 @@ def create_constraint(constraint_data: ConstraintCreate, db: Session = Depends(g
 def list_constraints(
     org_id: str | None = Query(None, description="Filter by organization ID"),
     constraint_type: str | None = Query(None, description="Filter by type (hard/soft)"),
-    skip: int = 0,
-    limit: int = 100,
+    pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
     """List constraints with optional filters."""
@@ -65,9 +65,14 @@ def list_constraints(
     if constraint_type:
         query = query.filter(Constraint.type == constraint_type)
 
-    constraints = query.offset(skip).limit(limit).all()
+    constraints = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()
-    return {"constraints": constraints, "total": total}
+    return {
+        "items": constraints,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{constraint_id}", response_model=ConstraintResponse)

--- a/api/routers/events.py
+++ b/api/routers/events.py
@@ -16,6 +16,7 @@ from api.models import (
     Person,
     Team,
 )
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.event import EventCreate, EventList, EventResponse, EventUpdate
 from api.utils.event_helpers import (
     count_people_with_role,
@@ -124,8 +125,7 @@ def list_events(
     | None = Query(None, description="Filter events starting after this time"),
     start_before: datetime
     | None = Query(None, description="Filter events starting before this time"),
-    skip: int = 0,
-    limit: int = 100,
+    pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
     """List events with optional filters."""
@@ -141,9 +141,14 @@ def list_events(
         query = query.filter(Event.start_time <= start_before)
 
     query = query.order_by(Event.start_time)
-    events = query.offset(skip).limit(limit).all()
+    events = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()
-    return {"events": events, "total": total}
+    return {
+        "items": events,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{event_id}", response_model=EventResponse)

--- a/api/routers/invitations.py
+++ b/api/routers/invitations.py
@@ -137,7 +137,12 @@ async def list_invitations(
 
     invitations = query.order_by(Invitation.created_at.desc()).all()
 
-    return InvitationList(invitations=invitations, total=len(invitations))
+    return InvitationList(
+        items=invitations,
+        total=len(invitations),
+        limit=len(invitations),
+        offset=0,
+    )
 
 
 @router.get(

--- a/api/routers/organizations.py
+++ b/api/routers/organizations.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from api.database import get_db
 from api.models import Organization
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.organization import (
     OrganizationCreate,
     OrganizationList,
@@ -50,11 +51,19 @@ def create_organization(org_data: OrganizationCreate, db: Session = Depends(get_
 
 
 @router.get("/", response_model=OrganizationList)
-def list_organizations(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def list_organizations(
+    pagination: PaginationParams = Depends(get_pagination_params),
+    db: Session = Depends(get_db),
+):
     """List all organizations."""
-    orgs = db.query(Organization).offset(skip).limit(limit).all()
+    orgs = db.query(Organization).offset(pagination.offset).limit(pagination.limit).all()
     total = db.query(Organization).count()
-    return {"organizations": orgs, "total": total}
+    return {
+        "items": orgs,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{org_id}", response_model=OrganizationResponse)

--- a/api/routers/people.py
+++ b/api/routers/people.py
@@ -13,6 +13,7 @@ from api.dependencies import (
 )
 from api.logging_config import logger
 from api.models import Organization, Person
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.person import PersonCreate, PersonList, PersonResponse, PersonUpdate
 
 router = APIRouter(prefix="/people", tags=["people"])
@@ -92,8 +93,7 @@ def create_person(
 def list_people(
     org_id: str | None = Query(None, description="Filter by organization ID"),
     role: str | None = Query(None, description="Filter by role"),
-    skip: int = 0,
-    limit: int = 100,
+    pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -112,14 +112,19 @@ def list_people(
     # Note: For JSON field filtering in SQLite, we'd need to load and filter in memory
     # For production with PostgreSQL, we could use JSON operators
 
-    people = query.offset(skip).limit(limit).all()
+    people = query.offset(pagination.offset).limit(pagination.limit).all()
 
     # Apply role filter in memory if specified
     if role:
         people = [p for p in people if p.roles and role in p.roles]
 
     total = query.count()
-    return {"people": people, "total": total}
+    return {
+        "items": people,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{person_id}", response_model=PersonResponse)

--- a/api/routers/solutions.py
+++ b/api/routers/solutions.py
@@ -16,6 +16,7 @@ from api.core.models import (
 )
 from api.database import get_db
 from api.models import Assignment, Event, Organization, Person, Solution
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.solver import ExportFormat, SolutionList, SolutionResponse
 from api.utils.pdf_export import generate_schedule_pdf
 
@@ -25,8 +26,7 @@ router = APIRouter(prefix="/solutions", tags=["solutions"])
 @router.get("/", response_model=SolutionList)
 def list_solutions(
     org_id: str | None = Query(None, description="Filter by organization ID"),
-    skip: int = 0,
-    limit: int = 100,
+    pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
     """List solutions with optional filters."""
@@ -36,7 +36,7 @@ def list_solutions(
         query = query.filter(Solution.org_id == org_id)
 
     query = query.order_by(Solution.created_at.desc())
-    solutions = query.offset(skip).limit(limit).all()
+    solutions = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()
 
     # Add assignment counts
@@ -47,7 +47,12 @@ def list_solutions(
         response.assignment_count = assignment_count
         solution_responses.append(response)
 
-    return {"solutions": solution_responses, "total": total}
+    return {
+        "items": solution_responses,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{solution_id}", response_model=SolutionResponse)

--- a/api/routers/teams.py
+++ b/api/routers/teams.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.dependencies import get_current_admin_user, get_current_user, verify_org_member
 from api.models import Organization, Person, Team, TeamMember
+from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.team import (
     TeamCreate,
     TeamList,
@@ -84,8 +85,7 @@ def create_team(
 @router.get("/", response_model=TeamList)
 def list_teams(
     org_id: str | None = Query(None, description="Filter by organization ID"),
-    skip: int = 0,
-    limit: int = 100,
+    pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -101,7 +101,7 @@ def list_teams(
         # Default to current user's organization
         query = query.filter(Team.org_id == current_user.org_id)
 
-    teams = query.offset(skip).limit(limit).all()
+    teams = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()
 
     # Add member counts
@@ -112,7 +112,12 @@ def list_teams(
         response.member_count = member_count
         team_responses.append(response)
 
-    return {"teams": team_responses, "total": total}
+    return {
+        "items": team_responses,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/{team_id}", response_model=TeamResponse)

--- a/api/schemas/common.py
+++ b/api/schemas/common.py
@@ -1,0 +1,43 @@
+"""Shared list-response envelope and pagination params for all list endpoints."""
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from fastapi import Query
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class ListResponse(BaseModel, Generic[T]):
+    """Uniform shape for paginated list responses.
+
+    Every `GET /api/v1/<resource>/` endpoint returns this shape so the Flutter
+    client (and any future codegen consumer) gets one envelope to unwrap.
+
+    Fields:
+        items: the page slice
+        total: total rows matching the query, regardless of pagination
+        limit: the page size used to produce `items`
+        offset: the offset applied to produce `items`
+    """
+
+    items: list[T]
+    total: int
+    limit: int
+    offset: int
+
+
+@dataclass
+class PaginationParams:
+    """Page slice carried into list endpoints via Depends."""
+
+    limit: int
+    offset: int
+
+
+def get_pagination_params(
+    limit: int = Query(50, ge=1, le=200, description="Page size, max 200"),
+    offset: int = Query(0, ge=0, description="Number of rows to skip"),
+) -> PaginationParams:
+    return PaginationParams(limit=limit, offset=offset)

--- a/api/schemas/constraint.py
+++ b/api/schemas/constraint.py
@@ -42,8 +42,6 @@ class ConstraintResponse(ConstraintBase):
     updated_at: datetime
 
 
-class ConstraintList(BaseModel):
-    """Schema for listing constraints."""
+from api.schemas.common import ListResponse
 
-    constraints: list[ConstraintResponse]
-    total: int
+ConstraintList = ListResponse[ConstraintResponse]

--- a/api/schemas/event.py
+++ b/api/schemas/event.py
@@ -45,8 +45,6 @@ class EventResponse(BaseResponse, EventBase):
     updated_at: datetime
 
 
-class EventList(BaseModel):
-    """Schema for listing events."""
+from api.schemas.common import ListResponse
 
-    events: list[EventResponse]
-    total: int
+EventList = ListResponse[EventResponse]

--- a/api/schemas/invitation.py
+++ b/api/schemas/invitation.py
@@ -31,11 +31,9 @@ class InvitationResponse(BaseModel):
     accepted_at: datetime | None = None
 
 
-class InvitationList(BaseModel):
-    """Schema for listing invitations."""
+from api.schemas.common import ListResponse
 
-    invitations: list[InvitationResponse]
-    total: int
+InvitationList = ListResponse[InvitationResponse]
 
 
 class InvitationVerify(BaseModel):

--- a/api/schemas/organization.py
+++ b/api/schemas/organization.py
@@ -38,8 +38,6 @@ class OrganizationResponse(BaseResponse, OrganizationBase):
     updated_at: datetime
 
 
-class OrganizationList(BaseModel):
-    """Schema for listing organizations."""
+from api.schemas.common import ListResponse
 
-    organizations: list[OrganizationResponse]
-    total: int
+OrganizationList = ListResponse[OrganizationResponse]

--- a/api/schemas/person.py
+++ b/api/schemas/person.py
@@ -46,8 +46,6 @@ class PersonResponse(BaseResponse, PersonBase):
     updated_at: datetime
 
 
-class PersonList(BaseModel):
-    """Schema for listing people."""
+from api.schemas.common import ListResponse
 
-    people: list[PersonResponse]
-    total: int
+PersonList = ListResponse[PersonResponse]

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -77,11 +77,9 @@ class SolutionResponse(BaseModel):
     assignment_count: int = 0
 
 
-class SolutionList(BaseModel):
-    """Schema for listing solutions."""
+from api.schemas.common import ListResponse
 
-    solutions: list[SolutionResponse]
-    total: int
+SolutionList = ListResponse[SolutionResponse]
 
 
 class ExportFormat(BaseModel):

--- a/api/schemas/team.py
+++ b/api/schemas/team.py
@@ -56,8 +56,6 @@ class TeamResponse(TeamBase):
     member_count: int = Field(0, description="Number of members")
 
 
-class TeamList(BaseModel):
-    """Schema for listing teams."""
+from api.schemas.common import ListResponse
 
-    teams: list[TeamResponse]
-    total: int
+TeamList = ListResponse[TeamResponse]

--- a/tests/api/test_church_scenario.py
+++ b/tests/api/test_church_scenario.py
@@ -386,7 +386,7 @@ class TestChurchScenario:
         # Verify invitation is pending
         resp = client.get(f"/api/v1/invitations?org_id={self.ORG}", headers=hdrs)
         assert resp.status_code == 200
-        pending = [i for i in resp.json()["invitations"] if i["email"] == "rachel.wong@gmail.com"]
+        pending = [i for i in resp.json()["items"] if i["email"] == "rachel.wong@gmail.com"]
         assert len(pending) == 1
         assert pending[0]["status"] == "pending"
 

--- a/tests/api/test_multi_tenant.py
+++ b/tests/api/test_multi_tenant.py
@@ -42,8 +42,8 @@ class TestMultiTenantIsolation:
         resp2 = client.get(f"/api/v1/people/?org_id={self.ORG2}", headers=hdrs2)
         assert resp1.status_code == 200
         assert resp2.status_code == 200
-        assert all(p["org_id"] == self.ORG1 for p in resp1.json()["people"])
-        assert all(p["org_id"] == self.ORG2 for p in resp2.json()["people"])
+        assert all(p["org_id"] == self.ORG1 for p in resp1.json()["items"])
+        assert all(p["org_id"] == self.ORG2 for p in resp2.json()["items"])
 
     def test_cross_org_people_access_denied(self, client):
         """Admin of org1 gets 403 trying to list org2's people."""
@@ -106,8 +106,8 @@ class TestMultiTenantIsolation:
         assert resp1.status_code == 200
         assert resp2.status_code == 200
 
-        ids1 = [e["id"] for e in resp1.json()["events"]]
-        ids2 = [e["id"] for e in resp2.json()["events"]]
+        ids1 = [e["id"] for e in resp1.json()["items"]]
+        ids2 = [e["id"] for e in resp2.json()["items"]]
         assert "evt-alpha-only" in ids1
         assert "evt-alpha-only" not in ids2
         assert "evt-beta-only" in ids2

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -590,28 +590,6 @@
         "title": "ConstraintCreate",
         "type": "object"
       },
-      "ConstraintList": {
-        "description": "Schema for listing constraints.",
-        "properties": {
-          "constraints": {
-            "items": {
-              "$ref": "#/components/schemas/ConstraintResponse"
-            },
-            "title": "Constraints",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "constraints",
-          "total"
-        ],
-        "title": "ConstraintList",
-        "type": "object"
-      },
       "ConstraintResponse": {
         "description": "Schema for constraint response.",
         "properties": {
@@ -818,28 +796,6 @@
           "org_id"
         ],
         "title": "EventCreate",
-        "type": "object"
-      },
-      "EventList": {
-        "description": "Schema for listing events.",
-        "properties": {
-          "events": {
-            "items": {
-              "$ref": "#/components/schemas/EventResponse"
-            },
-            "title": "Events",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "events",
-          "total"
-        ],
-        "title": "EventList",
         "type": "object"
       },
       "EventResponse": {
@@ -1145,28 +1101,6 @@
         "title": "InvitationCreate",
         "type": "object"
       },
-      "InvitationList": {
-        "description": "Schema for listing invitations.",
-        "properties": {
-          "invitations": {
-            "items": {
-              "$ref": "#/components/schemas/InvitationResponse"
-            },
-            "title": "Invitations",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "invitations",
-          "total"
-        ],
-        "title": "InvitationList",
-        "type": "object"
-      },
       "InvitationResponse": {
         "description": "Schema for invitation response.",
         "properties": {
@@ -1278,6 +1212,223 @@
         "title": "InvitationVerify",
         "type": "object"
       },
+      "ListResponse_ConstraintResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConstraintResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[ConstraintResponse]",
+        "type": "object"
+      },
+      "ListResponse_EventResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EventResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[EventResponse]",
+        "type": "object"
+      },
+      "ListResponse_InvitationResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/InvitationResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[InvitationResponse]",
+        "type": "object"
+      },
+      "ListResponse_OrganizationResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[OrganizationResponse]",
+        "type": "object"
+      },
+      "ListResponse_PersonResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[PersonResponse]",
+        "type": "object"
+      },
+      "ListResponse_SolutionResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SolutionResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[SolutionResponse]",
+        "type": "object"
+      },
+      "ListResponse_TeamResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TeamResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[TeamResponse]",
+        "type": "object"
+      },
       "LoginRequest": {
         "description": "Login request.",
         "properties": {
@@ -1345,28 +1496,6 @@
           "id"
         ],
         "title": "OrganizationCreate",
-        "type": "object"
-      },
-      "OrganizationList": {
-        "description": "Schema for listing organizations.",
-        "properties": {
-          "organizations": {
-            "items": {
-              "$ref": "#/components/schemas/OrganizationResponse"
-            },
-            "title": "Organizations",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "organizations",
-          "total"
-        ],
-        "title": "OrganizationList",
         "type": "object"
       },
       "OrganizationResponse": {
@@ -1580,28 +1709,6 @@
           "org_id"
         ],
         "title": "PersonCreate",
-        "type": "object"
-      },
-      "PersonList": {
-        "description": "Schema for listing people.",
-        "properties": {
-          "people": {
-            "items": {
-              "$ref": "#/components/schemas/PersonResponse"
-            },
-            "title": "People",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "people",
-          "total"
-        ],
-        "title": "PersonList",
         "type": "object"
       },
       "PersonResponse": {
@@ -1848,28 +1955,6 @@
         "title": "SignupRequest",
         "type": "object"
       },
-      "SolutionList": {
-        "description": "Schema for listing solutions.",
-        "properties": {
-          "solutions": {
-            "items": {
-              "$ref": "#/components/schemas/SolutionResponse"
-            },
-            "title": "Solutions",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "solutions",
-          "total"
-        ],
-        "title": "SolutionList",
-        "type": "object"
-      },
       "SolutionMetrics": {
         "description": "Schema for solution metrics.",
         "properties": {
@@ -2110,28 +2195,6 @@
           "org_id"
         ],
         "title": "TeamCreate",
-        "type": "object"
-      },
-      "TeamList": {
-        "description": "Schema for listing teams.",
-        "properties": {
-          "teams": {
-            "items": {
-              "$ref": "#/components/schemas/TeamResponse"
-            },
-            "title": "Teams",
-            "type": "array"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "teams",
-          "total"
-        ],
-        "title": "TeamList",
         "type": "object"
       },
       "TeamMemberAdd": {
@@ -3684,22 +3747,29 @@
             }
           },
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -3709,7 +3779,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConstraintList"
+                  "$ref": "#/components/schemas/ListResponse_ConstraintResponse_"
                 }
               }
             },
@@ -3980,22 +4050,29 @@
             }
           },
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -4005,7 +4082,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EventList"
+                  "$ref": "#/components/schemas/ListResponse_EventResponse_"
                 }
               }
             },
@@ -4442,7 +4519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InvitationList"
+                  "$ref": "#/components/schemas/ListResponse_InvitationResponse_"
                 }
               }
             },
@@ -4719,22 +4796,29 @@
         "operationId": "listOrganizations",
         "parameters": [
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -4744,7 +4828,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/OrganizationList"
+                  "$ref": "#/components/schemas/ListResponse_OrganizationResponse_"
                 }
               }
             },
@@ -4977,22 +5061,29 @@
             }
           },
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -5002,7 +5093,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PersonList"
+                  "$ref": "#/components/schemas/ListResponse_PersonResponse_"
                 }
               }
             },
@@ -5314,22 +5405,29 @@
             }
           },
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -5339,7 +5437,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SolutionList"
+                  "$ref": "#/components/schemas/ListResponse_SolutionResponse_"
                 }
               }
             },
@@ -5644,22 +5742,29 @@
             }
           },
           {
-            "in": "query",
-            "name": "skip",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "title": "Skip",
-              "type": "integer"
-            }
-          },
-          {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 100,
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
               "type": "integer"
             }
           }
@@ -5669,7 +5774,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TeamList"
+                  "$ref": "#/components/schemas/ListResponse_TeamResponse_"
                 }
               }
             },

--- a/tests/integration/test_invitations.py
+++ b/tests/integration/test_invitations.py
@@ -247,7 +247,7 @@ class TestListInvitations:
 
         assert response.status_code == 200
         result = response.json()
-        assert all(inv["status"] == "cancelled" for inv in result["invitations"])
+        assert all(inv["status"] == "cancelled" for inv in result["items"])
 
 
 class TestVerifyInvitation:
@@ -566,7 +566,7 @@ class TestInvitationWorkflow:
                 "status_filter": "accepted",
             },
         )
-        accepted_invitations = list_response.json()["invitations"]
+        accepted_invitations = list_response.json()["items"]
         assert any(inv["email"] == invitee_email for inv in accepted_invitations)
 
 

--- a/tests/test_test_data_setup.py
+++ b/tests/test_test_data_setup.py
@@ -38,7 +38,7 @@ class TestSetupTestDataFunction:
         response = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        people = response.json()["people"]
+        people = response.json()["items"]
 
         # Should have at least the test person
         assert len(people) > 0
@@ -61,7 +61,7 @@ class TestSetupTestDataFunction:
         response = requests.get(f"{API_BASE}/events/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        events = response.json()["events"]
+        events = response.json()["items"]
 
         # Should have at least the test event
         assert len(events) > 0
@@ -135,8 +135,8 @@ class TestEnsureTestDataFixture:
         assert people_response.status_code == 200
         assert events_response.status_code == 200
 
-        assert len(people_response.json()["people"]) > 0
-        assert len(events_response.json()["events"]) > 0
+        assert len(people_response.json()["items"]) > 0
+        assert len(events_response.json()["items"]) > 0
 
     def test_test_data_persists_across_tests(self, api_server):
         """Verify test data persists across multiple test runs."""
@@ -164,7 +164,7 @@ class TestFixtureConditionalSkipReplacement:
         response = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        people = response.json()["people"]
+        people = response.json()["items"]
 
         # Should NEVER be empty because setup_test_data() creates at least one person
         assert len(people) > 0, "Test data setup should ensure at least one person exists"
@@ -177,7 +177,7 @@ class TestFixtureConditionalSkipReplacement:
         response = requests.get(f"{API_BASE}/events/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        events = response.json()["events"]
+        events = response.json()["items"]
 
         # Should NEVER be empty because setup_test_data() creates at least one event
         assert len(events) > 0, "Test data setup should ensure at least one event exists"
@@ -190,7 +190,7 @@ class TestFixtureConditionalSkipReplacement:
         response = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
 
         # This is what the fixed tests do - assert with clear message instead of skip
-        people = response.json()["people"]
+        people = response.json()["items"]
         assert len(people) > 0, "No test person available - setup_test_data() may have failed"
 
 
@@ -205,14 +205,14 @@ class TestSetupTestDataIdempotency:
 
         # Get initial state
         response1 = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
-        initial_count = len(response1.json()["people"])
+        initial_count = len(response1.json()["items"])
 
         # Call setup_test_data() again
         setup_test_data()
 
         # Get state after second call
         response2 = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
-        final_count = len(response2.json()["people"])
+        final_count = len(response2.json()["items"])
 
         # Count should be same or similar (setup is idempotent)
         # It might create duplicates but shouldn't error
@@ -232,7 +232,7 @@ class TestTestDataQuality:
         # May be 404 if test person doesn't exist yet, check via list endpoint
         if response.status_code == 404:
             response = requests.get(f"{API_BASE}/people/?org_id=test_org", headers=headers)
-            people = response.json()["people"]
+            people = response.json()["items"]
             test_person = next((p for p in people if "comp" in p["id"].lower()), None)
 
             if test_person:
@@ -247,7 +247,7 @@ class TestTestDataQuality:
         response = requests.get(f"{API_BASE}/events/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        events = response.json()["events"]
+        events = response.json()["items"]
 
         test_event = next((e for e in events if "comp" in e["id"].lower()), None)
 
@@ -267,7 +267,7 @@ class TestTestDataQuality:
         response = requests.get(f"{API_BASE}/events/?org_id=test_org", headers=headers)
 
         assert response.status_code == 200
-        events = response.json()["events"]
+        events = response.json()["items"]
 
         test_event = next((e for e in events if "comp" in e["id"].lower()), None)
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -161,8 +161,8 @@ class TestEventRead:
         response = client.get(f"{API_BASE}/events/?org_id=event_test_org5")
         assert response.status_code == 200
         data = response.json()
-        assert "events" in data
-        assert len(data["events"]) >= 3
+        assert "items" in data
+        assert len(data["items"]) >= 3
 
     def test_list_events_date_range(self, client):
         """Test listing events within date range."""
@@ -190,7 +190,7 @@ class TestEventRead:
         )
         assert response.status_code == 200
         data = response.json()
-        assert len(data["events"]) >= 1
+        assert len(data["items"]) >= 1
 
 
 class TestEventUpdate:

--- a/tests/unit/test_invitations_api.py
+++ b/tests/unit/test_invitations_api.py
@@ -83,7 +83,7 @@ class TestInvitationsAPI:
         # data = response.json()
         # assert "invitations" in data
         # assert "total" in data
-        # assert isinstance(data["invitations"], list)
+        # assert isinstance(data["items"], list)
 
     @pytest.mark.no_mock_auth
     def test_create_invitation_requires_authentication(self, client):

--- a/tests/unit/test_organizations.py
+++ b/tests/unit/test_organizations.py
@@ -79,8 +79,8 @@ class TestOrganizationRead:
         response = client.get(f"{API_BASE}/organizations/")
         assert response.status_code == 200
         data = response.json()
-        assert "organizations" in data
-        assert len(data["organizations"]) >= 3
+        assert "items" in data
+        assert len(data["items"]) >= 3
 
 
 class TestOrganizationUpdate:

--- a/tests/unit/test_people.py
+++ b/tests/unit/test_people.py
@@ -120,8 +120,8 @@ class TestPersonRead:
         response = client.get(f"{API_BASE}/people/?org_id=people_test_org5")
         assert response.status_code == 200
         data = response.json()
-        assert "people" in data
-        assert len(data["people"]) >= 3
+        assert "items" in data
+        assert len(data["items"]) >= 3
 
 
 class TestPersonUpdate:

--- a/tests/unit/test_teams.py
+++ b/tests/unit/test_teams.py
@@ -122,8 +122,8 @@ class TestTeamRead:
         response = client.get(f"{API_BASE}/teams/?org_id=team_test_org_005")
         assert response.status_code == 200
         data = response.json()
-        assert "teams" in data
-        assert len(data["teams"]) >= 3
+        assert "items" in data
+        assert len(data["items"]) >= 3
 
 
 class TestTeamUpdate:


### PR DESCRIPTION
## Summary

- New `api/schemas/common.py` with `ListResponse[T]` generic (`{items, total, limit, offset}`) and `PaginationParams` dependency (`limit` default 50, max 200; `offset` default 0).
- Replace 7 `*List` schemas with one-liner aliases (`PersonList = ListResponse[PersonResponse]`, etc.).
- Update 6 list endpoints (people, events, organizations, teams, constraints, solutions) to use `PaginationParams` via `Depends` and return the uniform envelope; rename `skip` → `offset`.
- Invitations list adopts the new envelope shape.

This is a wire-format break, but the Flutter client doesn't exist yet — that's exactly why we land it now. The OpenAPI snapshot test caught the schema drift; refreshed in the same commit.

## Changed files

- `api/schemas/common.py` (new)
- 7 schema files: `*List` → `ListResponse` alias
- 7 router files: pagination dependency + new return shape
- ~10 test files: mechanical rename `data["resource"]` → `data["items"]`
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 401 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 2 PR 6 (Conflicts GET + constraints/analytics test backfill) is the last PR in this sprint.
- Audit list and `assignments/me` list still return raw lists; can convert to the envelope as a small follow-up.