### PR TITLE
Sprint 3 Step A: GET /conflicts/ for org-wide conflict listing

### DIFF
--- a/api/routers/conflicts.py
+++ b/api/routers/conflicts.py
@@ -2,10 +2,11 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from api.database import get_db
+from api.dependencies import get_current_admin_user, verify_org_member
 from api.models import (
     Assignment,
     Availability,
@@ -13,6 +14,7 @@ from api.models import (
     Person,
     VacationPeriod,
 )
+from api.schemas.common import ListResponse, PaginationParams, get_pagination_params
 from api.schemas.conflicts import (
     ConflictCheckRequest,
     ConflictCheckResponse,
@@ -132,4 +134,110 @@ def check_conflicts(
         has_conflicts=len(conflicts) > 0,
         conflicts=conflicts,
         can_assign=not has_blocking_conflicts,
+    )
+
+
+def _person_conflicts(person: Person, db: Session) -> list[ConflictType]:
+    """Detect every conflict on this person's existing assignments.
+
+    Looks at:
+    - time-off overlap with each assignment's event
+    - double-booked: any pair of assignments whose events overlap
+
+    Does NOT raise `already_assigned` (the assignment exists by definition).
+    """
+    rows: list[ConflictType] = []
+
+    assignments = db.query(Assignment).filter(Assignment.person_id == person.id).all()
+    if not assignments:
+        return rows
+
+    # Pre-load events keyed by id
+    event_ids = [a.event_id for a in assignments]
+    events_by_id: dict[str, Event] = {
+        e.id: e for e in db.query(Event).filter(Event.id.in_(event_ids)).all()
+    }
+
+    # Time-off overlaps
+    availability = db.query(Availability).filter(Availability.person_id == person.id).first()
+    if availability:
+        vacations = (
+            db.query(VacationPeriod).filter(VacationPeriod.availability_id == availability.id).all()
+        )
+        for assignment in assignments:
+            event = events_by_id.get(assignment.event_id)
+            if event is None:
+                continue
+            for vacation in vacations:
+                v_start = datetime.combine(vacation.start_date, datetime.min.time())
+                v_end = datetime.combine(vacation.end_date, datetime.max.time())
+                if check_time_overlap(event.start_time, event.end_time, v_start, v_end):
+                    rows.append(
+                        ConflictType(
+                            type="time_off",
+                            message=(
+                                f"{person.name} has time-off from {vacation.start_date} "
+                                f"to {vacation.end_date} but is assigned to {event.type}"
+                            ),
+                            conflicting_event_id=event.id,
+                            start_time=v_start,
+                            end_time=v_end,
+                        )
+                    )
+
+    # Double-booked: any pair of overlapping assignments for this person
+    for i, a in enumerate(assignments):
+        ev_a = events_by_id.get(a.event_id)
+        if ev_a is None:
+            continue
+        for b in assignments[i + 1 :]:
+            ev_b = events_by_id.get(b.event_id)
+            if ev_b is None:
+                continue
+            if check_time_overlap(ev_a.start_time, ev_a.end_time, ev_b.start_time, ev_b.end_time):
+                rows.append(
+                    ConflictType(
+                        type="double_booked",
+                        message=(
+                            f"{person.name} is double-booked: '{ev_a.type}' "
+                            f"and '{ev_b.type}' overlap"
+                        ),
+                        conflicting_event_id=ev_b.id,
+                        start_time=ev_b.start_time,
+                        end_time=ev_b.end_time,
+                    )
+                )
+    return rows
+
+
+@router.get("/", response_model=ListResponse[ConflictType])
+def list_conflicts(
+    org_id: str = Query(..., description="Organization ID"),
+    person_id: str | None = Query(None, description="Optional filter to a single person"),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List currently-detected conflicts across an org (admin-only).
+
+    Scans every Assignment in the org (or just the named person's) and
+    surfaces `time_off` and `double_booked` conflicts. `already_assigned`
+    is intentionally omitted because the assignment exists.
+    """
+    verify_org_member(current_admin, org_id)
+
+    people_query = db.query(Person).filter(Person.org_id == org_id)
+    if person_id is not None:
+        people_query = people_query.filter(Person.id == person_id)
+
+    all_rows: list[ConflictType] = []
+    for person in people_query.all():
+        all_rows.extend(_person_conflicts(person, db))
+
+    page = all_rows[pagination.offset : pagination.offset + pagination.limit]
+    return ListResponse[ConflictType](
+        items=page,
+        total=len(all_rows),
+        limit=pagination.limit,
+        offset=pagination.offset,
     )

--- a/tests/api/test_conflicts_list.py
+++ b/tests/api/test_conflicts_list.py
@@ -1,0 +1,113 @@
+"""Tests for GET /api/v1/conflicts/ — admin-only conflict listing."""
+
+import pytest
+
+from tests.api.conftest import auth_headers, seed_event, seed_org, seed_user
+
+
+def _two_overlapping_events(client, suffix: str):
+    """Create org+admin+volunteer; assign volunteer to two overlapping events."""
+    org_id = f"conflicts-list-org-{suffix}"
+    seed_org(client, org_id)
+    seed_user(client, org_id, email=f"admin-{suffix}@cl.org", name="Admin", password="AdminPass1!")
+    vol = seed_user(
+        client,
+        org_id,
+        email=f"vol-{suffix}@cl.org",
+        name="Vol",
+        password="VolPass1!",
+        roles=["volunteer"],
+    )
+    admin_hdrs = auth_headers(client, email=f"admin-{suffix}@cl.org", password="AdminPass1!")
+    ev_a = seed_event(client, admin_hdrs, org_id, event_id=f"evt-a-{suffix}")
+    ev_b = seed_event(client, admin_hdrs, org_id, event_id=f"evt-b-{suffix}")
+    # Assign volunteer to both
+    for ev in (ev_a, ev_b):
+        client.post(
+            f"/api/v1/events/{ev['id']}/assignments",
+            json={"person_id": vol["person_id"], "action": "assign", "role": "u"},
+            headers=admin_hdrs,
+        )
+    return org_id, admin_hdrs, vol
+
+
+@pytest.mark.no_mock_auth
+class TestListConflictsAuth:
+    def test_volunteer_cannot_list_org_conflicts(self, client, db):
+        org_id = "list-conflicts-vol"
+        seed_org(client, org_id)
+        seed_user(client, org_id, email="admin@lc.org", name="Admin", password="AdminPass1!")
+        seed_user(
+            client,
+            org_id,
+            email="vol@lc.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@lc.org", password="VolPass1!")
+        resp = client.get(f"/api/v1/conflicts/?org_id={org_id}", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestListConflictsScoping:
+    def test_returns_listresponse_envelope(self, client, db):
+        org_id, admin_hdrs, _ = _two_overlapping_events(client, "envelope")
+        resp = client.get(f"/api/v1/conflicts/?org_id={org_id}", headers=admin_hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "items" in body
+        assert "total" in body
+        assert "limit" in body
+        assert "offset" in body
+
+    def test_returns_double_booked_for_overlapping_assignments(self, client, db):
+        org_id, admin_hdrs, vol = _two_overlapping_events(client, "double")
+        resp = client.get(
+            f"/api/v1/conflicts/?org_id={org_id}&person_id={vol['person_id']}",
+            headers=admin_hdrs,
+        )
+        body = resp.json()
+        assert body["total"] >= 1
+        assert any(item["type"] == "double_booked" for item in body["items"])
+
+    def test_empty_org_returns_zero_total(self, client, db):
+        org_id = "empty-conflicts-org"
+        seed_org(client, org_id)
+        seed_user(client, org_id, email="admin@e.org", name="Admin", password="AdminPass1!")
+        admin_hdrs = auth_headers(client, email="admin@e.org", password="AdminPass1!")
+
+        resp = client.get(f"/api/v1/conflicts/?org_id={org_id}", headers=admin_hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["items"] == []
+
+    def test_cross_org_admin_blocked(self, client, db):
+        org_a, admin_hdrs_a, _ = _two_overlapping_events(client, "a")
+        org_b = "conflicts-list-org-other"
+        seed_org(client, org_b)
+
+        # Admin from org_a tries to query org_b
+        resp = client.get(f"/api/v1/conflicts/?org_id={org_b}", headers=admin_hdrs_a)
+        assert resp.status_code in (403, 404)
+
+    def test_person_id_narrows_results(self, client, db):
+        org_id, admin_hdrs, vol = _two_overlapping_events(client, "narrow")
+        # Add another volunteer with no conflicts
+        seed_user(
+            client,
+            org_id,
+            email="other-narrow@cl.org",
+            name="Other",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        # Query for the conflicted volunteer
+        resp = client.get(
+            f"/api/v1/conflicts/?org_id={org_id}&person_id={vol['person_id']}",
+            headers=admin_hdrs,
+        )
+        body = resp.json()
+        assert body["total"] >= 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1212,6 +1212,37 @@
         "title": "InvitationVerify",
         "type": "object"
       },
+      "ListResponse_ConflictType_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConflictType"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[ConflictType]",
+        "type": "object"
+      },
       "ListResponse_ConstraintResponse_": {
         "properties": {
           "items": {
@@ -3660,6 +3691,101 @@
         "summary": "Get Subscription Url",
         "tags": [
           "calendar"
+        ]
+      }
+    },
+    "/api/v1/conflicts/": {
+      "get": {
+        "description": "List currently-detected conflicts across an org (admin-only).\n\nScans every Assignment in the org (or just the named person's) and\nsurfaces `time_off` and `double_booked` conflicts. `already_assigned`\nis intentionally omitted because the assignment exists.",
+        "operationId": "listConflicts",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional filter to a single person",
+            "in": "query",
+            "name": "person_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional filter to a single person",
+              "title": "Person Id"
+            }
+          },
+          {
+            "description": "Page size, max 200",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_ConflictType_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Conflicts",
+        "tags": [
+          "conflicts"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- New `GET /api/v1/conflicts/?org_id=&person_id=&limit=&offset=` returns `ListResponse[ConflictType]` of currently-detected conflicts across an org. Optional `person_id` narrows to one volunteer.
- Detects `time_off` (assignment overlaps with the person's vacation periods) and `double_booked` (any pair of the person's assignments whose events overlap). `already_assigned` is intentionally omitted because the assignment exists by definition.
- Reuses existing `check_time_overlap` helper. Auth via `Depends(get_current_admin_user)` + `verify_org_member`. Pagination via the shared `PaginationParams` dependency.

First Sprint 3 step from the plan.

## Changed files

- `api/routers/conflicts.py`: import additions, new `_person_conflicts` helper, new GET route
- `tests/api/test_conflicts_list.py` (new): 6 tests
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 426 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 3 Step B (convert `assignments/me` + `audit-logs` to ListResponse envelope) is next.
- Existing `POST /conflicts/check` unchanged (pre-assignment use case).