### PR TITLE
Sprint 3 Step B: ListResponse envelope on assignments/me and audit-logs

### DIFF
--- a/api/routers/assignments.py
+++ b/api/routers/assignments.py
@@ -22,6 +22,7 @@ from api.schemas.assignment import (
     AssignmentResponse,
     AssignmentSwapRequest,
 )
+from api.schemas.common import ListResponse, PaginationParams, get_pagination_params
 from api.utils.audit_logger import log_audit_event
 
 router = APIRouter(prefix="/assignments", tags=["assignments"])
@@ -136,20 +137,31 @@ def request_swap(
     return assignment
 
 
-@router.get("/me", response_model=list[AssignmentResponse])
+@router.get("/me", response_model=ListResponse[AssignmentResponse])
 def list_my_assignments(
+    pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Return every assignment belonging to the caller, scoped to their org via the join."""
-    rows = (
+    """Return assignments belonging to the caller, scoped to their org via the join."""
+    base = (
         db.query(Assignment)
         .join(Event, Assignment.event_id == Event.id)
         .filter(
             Assignment.person_id == current_user.id,
             Event.org_id == current_user.org_id,
         )
-        .order_by(Assignment.assigned_at.desc())
+    )
+    total = base.count()
+    rows = (
+        base.order_by(Assignment.assigned_at.desc())
+        .offset(pagination.offset)
+        .limit(pagination.limit)
         .all()
     )
-    return rows
+    return {
+        "items": rows,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -9,12 +9,13 @@ from api.database import get_db
 from api.dependencies import get_current_admin_user
 from api.models import AuditAction, AuditLog, Person
 from api.schemas.audit import AuditLogResponse
+from api.schemas.common import ListResponse, PaginationParams, get_pagination_params
 from api.utils.audit_logger import log_audit_event
 
 router = APIRouter(prefix="/audit-logs", tags=["audit"])
 
 
-@router.get("", response_model=list[AuditLogResponse])
+@router.get("", response_model=ListResponse[AuditLogResponse])
 def list_audit_logs(
     http_request: Request,
     user_id: str | None = Query(None, description="Filter by user_id"),
@@ -24,8 +25,7 @@ def list_audit_logs(
     end_date: datetime | None = Query(None, description="Inclusive upper bound on timestamp"),
     audit_status: str
     | None = Query(None, alias="status", description="success / failure / denied"),
-    limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0),
+    pagination: PaginationParams = Depends(get_pagination_params),
     current_admin: Person = Depends(get_current_admin_user),
     db: Session = Depends(get_db),
 ):
@@ -49,7 +49,13 @@ def list_audit_logs(
     if audit_status is not None:
         query = query.filter(AuditLog.status == audit_status)
 
-    rows = query.order_by(AuditLog.timestamp.desc()).offset(offset).limit(limit).all()
+    total = query.count()
+    rows = (
+        query.order_by(AuditLog.timestamp.desc())
+        .offset(pagination.offset)
+        .limit(pagination.limit)
+        .all()
+    )
 
     log_audit_event(
         db,
@@ -69,12 +75,17 @@ def list_audit_logs(
                 }.items()
                 if v is not None
             },
-            "limit": limit,
-            "offset": offset,
+            "limit": pagination.limit,
+            "offset": pagination.offset,
             "result_count": len(rows),
         },
         ip_address=http_request.client.host if http_request.client else None,
         user_agent=http_request.headers.get("user-agent"),
     )
 
-    return rows
+    return {
+        "items": rows,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }

--- a/tests/api/test_assignment_self_service.py
+++ b/tests/api/test_assignment_self_service.py
@@ -175,10 +175,10 @@ class TestListMyAssignments:
         vol_hdrs = auth_headers(client, email="vol-list@vss.org", password="VolPass1!")
         resp = client.get("/api/v1/assignments/me", headers=vol_hdrs)
         assert resp.status_code == 200
-        rows = resp.json()
-        assert isinstance(rows, list)
-        assert len(rows) == 1
-        assert rows[0]["event_id"] == ctx["event"]["id"]
+        body = resp.json()
+        assert body["total"] == 1
+        assert len(body["items"]) == 1
+        assert body["items"][0]["event_id"] == ctx["event"]["id"]
 
 
 @pytest.mark.no_mock_auth

--- a/tests/api/test_audit_log_query.py
+++ b/tests/api/test_audit_log_query.py
@@ -75,7 +75,7 @@ class TestAuditLogScoping:
 
         resp = client.get("/api/v1/audit-logs", headers=admin_hdrs)
         assert resp.status_code == 200
-        rows = resp.json()
+        rows = resp.json()["items"]
         assert all(r["organization_id"] == org_id for r in rows)
 
 
@@ -91,7 +91,7 @@ class TestAuditLogFilters:
             f"/api/v1/audit-logs?action={AuditAction.LOGIN_SUCCESS}", headers=admin_hdrs
         )
         assert resp.status_code == 200
-        rows = resp.json()
+        rows = resp.json()["items"]
         assert all(r["action"] == AuditAction.LOGIN_SUCCESS for r in rows)
         assert len(rows) >= 1
 
@@ -107,7 +107,7 @@ class TestAuditLogFilters:
         start = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
         resp = client.get("/api/v1/audit-logs", params={"start_date": start}, headers=admin_hdrs)
         assert resp.status_code == 200
-        rows = resp.json()
+        rows = resp.json()["items"]
         # All returned rows must be within the range
         for r in rows:
             assert r["timestamp"] >= start
@@ -126,7 +126,7 @@ class TestAuditLogFilters:
         resp = client.get(
             f"/api/v1/audit-logs?action={AuditAction.LOGIN_SUCCESS}", headers=admin_hdrs
         )
-        rows = resp.json()
+        rows = resp.json()["items"]
         timestamps = [r["timestamp"] for r in rows]
         assert timestamps == sorted(timestamps, reverse=True)
 
@@ -147,7 +147,7 @@ class TestAuditLogPagination:
 
         resp = client.get("/api/v1/audit-logs?limit=2", headers=admin_hdrs)
         assert resp.status_code == 200
-        rows = resp.json()
+        rows = resp.json()["items"]
         assert len(rows) == 2
 
 

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1212,6 +1212,68 @@
         "title": "InvitationVerify",
         "type": "object"
       },
+      "ListResponse_AssignmentResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AssignmentResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[AssignmentResponse]",
+        "type": "object"
+      },
+      "ListResponse_AuditLogResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AuditLogResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[AuditLogResponse]",
+        "type": "object"
+      },
       "ListResponse_ConflictType_": {
         "properties": {
           "items": {
@@ -2657,22 +2719,57 @@
     },
     "/api/v1/assignments/me": {
       "get": {
-        "description": "Return every assignment belonging to the caller, scoped to their org via the join.",
+        "description": "Return assignments belonging to the caller, scoped to their org via the join.",
         "operationId": "listMyAssignments",
+        "parameters": [
+          {
+            "description": "Page size, max 200",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AssignmentResponse"
-                  },
-                  "title": "Response List My Assignments Api V1 Assignments Me Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/ListResponse_AssignmentResponse_"
                 }
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [
@@ -2966,11 +3063,13 @@
             }
           },
           {
+            "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 50,
+              "description": "Page size, max 200",
               "maximum": 200,
               "minimum": 1,
               "title": "Limit",
@@ -2978,11 +3077,13 @@
             }
           },
           {
+            "description": "Number of rows to skip",
             "in": "query",
             "name": "offset",
             "required": false,
             "schema": {
               "default": 0,
+              "description": "Number of rows to skip",
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
@@ -2994,11 +3095,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AuditLogResponse"
-                  },
-                  "title": "Response List Audit Logs Api V1 Audit Logs Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/ListResponse_AuditLogResponse_"
                 }
               }
             },


### PR DESCRIPTION
## Summary

- `GET /api/v1/assignments/me` now returns `ListResponse[AssignmentResponse]` instead of a raw list. Adds proper pagination via the shared `PaginationParams` dependency.
- `GET /api/v1/audit-logs` now returns `ListResponse[AuditLogResponse]` instead of a raw list. Replaces the local `limit`/`offset` `Query()` params with the shared `PaginationParams` dependency for consistency.
- Both endpoints now match the uniform list envelope used by people/events/orgs/teams/etc., so codegen consumers (Flutter client) get one shape to unwrap across every list endpoint in the API.

## Changed files

- `api/routers/assignments.py`: GET /me returns envelope; uses pagination dep
- `api/routers/audit.py`: GET /audit-logs returns envelope; replaces local limit/offset with PaginationParams
- `tests/api/test_assignment_self_service.py`: list test reads `body["items"]` / `body["total"]`
- `tests/api/test_audit_log_query.py`: 5 tests updated to read `response.json()["items"]`
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 426 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 3 Step C (constraints router auth gap) is next.