### PR TITLE
Sprint 3 Step C: Close constraints router auth gap

### DIFF
--- a/api/routers/constraints.py
+++ b/api/routers/constraints.py
@@ -1,11 +1,11 @@
-"""Constraints router."""
-
+"""Constraints router. Read requires authentication; create/update/delete require admin."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Constraint, Organization
+from api.dependencies import get_current_admin_user, get_current_user, verify_org_member
+from api.models import Constraint, Organization, Person
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.constraint import (
     ConstraintCreate,
@@ -18,8 +18,15 @@ router = APIRouter(prefix="/constraints", tags=["constraints"])
 
 
 @router.post("/", response_model=ConstraintResponse, status_code=status.HTTP_201_CREATED)
-def create_constraint(constraint_data: ConstraintCreate, db: Session = Depends(get_db)):
-    """Create a new constraint."""
+def create_constraint(
+    constraint_data: ConstraintCreate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Create a new constraint (admin only, scoped to admin's org)."""
+    # Admins may only create constraints for their own org
+    verify_org_member(current_admin, constraint_data.org_id)
+
     # Verify organization exists
     org = db.query(Organization).filter(Organization.id == constraint_data.org_id).first()
     if not org:
@@ -55,13 +62,15 @@ def list_constraints(
     org_id: str | None = Query(None, description="Filter by organization ID"),
     constraint_type: str | None = Query(None, description="Filter by type (hard/soft)"),
     pagination: PaginationParams = Depends(get_pagination_params),
+    current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List constraints with optional filters."""
-    query = db.query(Constraint)
+    """List constraints. Always scoped to the caller's organization."""
+    # Default to caller's org if not specified; admins/members can only query their own org
+    target_org = org_id or current_user.org_id
+    verify_org_member(current_user, target_org)
 
-    if org_id:
-        query = query.filter(Constraint.org_id == org_id)
+    query = db.query(Constraint).filter(Constraint.org_id == target_org)
     if constraint_type:
         query = query.filter(Constraint.type == constraint_type)
 
@@ -76,28 +85,37 @@ def list_constraints(
 
 
 @router.get("/{constraint_id}", response_model=ConstraintResponse)
-def get_constraint(constraint_id: int, db: Session = Depends(get_db)):
-    """Get constraint by ID."""
+def get_constraint(
+    constraint_id: int,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get constraint by ID; org isolation enforced."""
     constraint = db.query(Constraint).filter(Constraint.id == constraint_id).first()
     if not constraint:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Constraint {constraint_id} not found",
         )
+    verify_org_member(current_user, constraint.org_id)
     return constraint
 
 
 @router.put("/{constraint_id}", response_model=ConstraintResponse)
 def update_constraint(
-    constraint_id: int, constraint_data: ConstraintUpdate, db: Session = Depends(get_db)
+    constraint_id: int,
+    constraint_data: ConstraintUpdate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
 ):
-    """Update constraint."""
+    """Update constraint (admin only, scoped to admin's org)."""
     constraint = db.query(Constraint).filter(Constraint.id == constraint_id).first()
     if not constraint:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Constraint {constraint_id} not found",
         )
+    verify_org_member(current_admin, constraint.org_id)
 
     # Update fields
     if constraint_data.type is not None:
@@ -120,14 +138,19 @@ def update_constraint(
 
 
 @router.delete("/{constraint_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_constraint(constraint_id: int, db: Session = Depends(get_db)):
-    """Delete constraint."""
+def delete_constraint(
+    constraint_id: int,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Delete constraint (admin only, scoped to admin's org)."""
     constraint = db.query(Constraint).filter(Constraint.id == constraint_id).first()
     if not constraint:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Constraint {constraint_id} not found",
         )
+    verify_org_member(current_admin, constraint.org_id)
 
     db.delete(constraint)
     db.commit()

--- a/tests/api/test_constraints.py
+++ b/tests/api/test_constraints.py
@@ -1,4 +1,4 @@
-"""Tests for /api/v1/constraints/ — covers CRUD on the previously zero-test router."""
+"""Tests for /api/v1/constraints/ — admin-only CRUD with auth and tenancy enforcement."""
 
 import pytest
 
@@ -7,7 +7,7 @@ from tests.api.conftest import auth_headers, seed_org, seed_user
 
 @pytest.fixture
 def admin_setup(client):
-    """Create an org and an admin, return (org_id, headers)."""
+    """Create an org and an admin, return (org_id, admin_hdrs)."""
     org_id = "constraint-test-org"
     seed_org(client, org_id)
     seed_user(client, org_id, email="admin@c.org", name="Admin", password="AdminPass1!")
@@ -15,9 +15,70 @@ def admin_setup(client):
 
 
 @pytest.mark.no_mock_auth
+class TestConstraintAuth:
+    def test_unauthenticated_create_rejected(self, client, db, admin_setup):
+        org_id, _ = admin_setup
+        resp = client.post(
+            "/api/v1/constraints/",
+            json={
+                "org_id": org_id,
+                "key": "x",
+                "type": "hard",
+                "weight": 1,
+                "predicate": "p",
+                "params": {},
+            },
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_volunteer_cannot_create(self, client, db, admin_setup):
+        org_id, _ = admin_setup
+        seed_user(
+            client,
+            org_id,
+            email="vol@c.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@c.org", password="VolPass1!")
+        resp = client.post(
+            "/api/v1/constraints/",
+            json={
+                "org_id": org_id,
+                "key": "x",
+                "type": "hard",
+                "weight": 1,
+                "predicate": "p",
+                "params": {},
+            },
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_admin_cross_org_create_blocked(self, client, db, admin_setup):
+        org_a, admin_a_hdrs = admin_setup
+        # Create another org
+        seed_org(client, "constraint-other-org")
+        resp = client.post(
+            "/api/v1/constraints/",
+            json={
+                "org_id": "constraint-other-org",
+                "key": "x",
+                "type": "hard",
+                "weight": 1,
+                "predicate": "p",
+                "params": {},
+            },
+            headers=admin_a_hdrs,
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
 class TestConstraintCrud:
     def test_create_hard_constraint(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         resp = client.post(
             "/api/v1/constraints/",
             json={
@@ -28,6 +89,7 @@ class TestConstraintCrud:
                 "predicate": "no_overlap",
                 "params": {},
             },
+            headers=hdrs,
         )
         assert resp.status_code == 201, resp.text
         body = resp.json()
@@ -35,7 +97,7 @@ class TestConstraintCrud:
         assert body["type"] == "hard"
 
     def test_create_rejects_invalid_type(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         resp = client.post(
             "/api/v1/constraints/",
             json={
@@ -46,10 +108,13 @@ class TestConstraintCrud:
                 "predicate": "x",
                 "params": {},
             },
+            headers=hdrs,
         )
         assert resp.status_code == 400
 
-    def test_create_rejects_unknown_org(self, client, db):
+    def test_create_rejects_unknown_org(self, client, db, admin_setup):
+        # Even an admin can't target an org they don't belong to
+        _, hdrs = admin_setup
         resp = client.post(
             "/api/v1/constraints/",
             json={
@@ -60,11 +125,13 @@ class TestConstraintCrud:
                 "predicate": "x",
                 "params": {},
             },
+            headers=hdrs,
         )
-        assert resp.status_code == 404
+        # verify_org_member fires before the org-existence check, so 403 is correct
+        assert resp.status_code in (403, 404)
 
     def test_list_filter_by_org(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         for key in ("a", "b"):
             client.post(
                 "/api/v1/constraints/",
@@ -76,16 +143,17 @@ class TestConstraintCrud:
                     "predicate": "p",
                     "params": {},
                 },
+                headers=hdrs,
             )
 
-        resp = client.get(f"/api/v1/constraints/?org_id={org_id}")
+        resp = client.get(f"/api/v1/constraints/?org_id={org_id}", headers=hdrs)
         assert resp.status_code == 200
         body = resp.json()
         assert body["total"] >= 2
         assert all(item["org_id"] == org_id for item in body["items"])
 
     def test_list_filter_by_type(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         client.post(
             "/api/v1/constraints/",
             json={
@@ -96,6 +164,7 @@ class TestConstraintCrud:
                 "predicate": "p",
                 "params": {},
             },
+            headers=hdrs,
         )
         client.post(
             "/api/v1/constraints/",
@@ -107,14 +176,17 @@ class TestConstraintCrud:
                 "predicate": "p",
                 "params": {},
             },
+            headers=hdrs,
         )
-        resp = client.get(f"/api/v1/constraints/?org_id={org_id}&constraint_type=hard")
+        resp = client.get(
+            f"/api/v1/constraints/?org_id={org_id}&constraint_type=hard", headers=hdrs
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert all(item["type"] == "hard" for item in body["items"])
 
     def test_get_by_id(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         created = client.post(
             "/api/v1/constraints/",
             json={
@@ -125,18 +197,20 @@ class TestConstraintCrud:
                 "predicate": "p",
                 "params": {},
             },
+            headers=hdrs,
         ).json()
         cid = created["id"]
-        resp = client.get(f"/api/v1/constraints/{cid}")
+        resp = client.get(f"/api/v1/constraints/{cid}", headers=hdrs)
         assert resp.status_code == 200
         assert resp.json()["id"] == cid
 
-    def test_get_returns_404_for_unknown(self, client, db):
-        resp = client.get("/api/v1/constraints/999999")
+    def test_get_returns_404_for_unknown(self, client, db, admin_setup):
+        _, hdrs = admin_setup
+        resp = client.get("/api/v1/constraints/999999", headers=hdrs)
         assert resp.status_code == 404
 
     def test_delete_constraint(self, client, db, admin_setup):
-        org_id, _ = admin_setup
+        org_id, hdrs = admin_setup
         created = client.post(
             "/api/v1/constraints/",
             json={
@@ -147,8 +221,9 @@ class TestConstraintCrud:
                 "predicate": "p",
                 "params": {},
             },
+            headers=hdrs,
         ).json()
         cid = created["id"]
-        resp = client.delete(f"/api/v1/constraints/{cid}")
+        resp = client.delete(f"/api/v1/constraints/{cid}", headers=hdrs)
         assert resp.status_code in (200, 204)
-        assert client.get(f"/api/v1/constraints/{cid}").status_code == 404
+        assert client.get(f"/api/v1/constraints/{cid}", headers=hdrs).status_code == 404

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -3930,7 +3930,7 @@
     },
     "/api/v1/constraints/": {
       "get": {
-        "description": "List constraints with optional filters.",
+        "description": "List constraints. Always scoped to the caller's organization.",
         "operationId": "listConstraints",
         "parameters": [
           {
@@ -4019,13 +4019,18 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "List Constraints",
         "tags": [
           "constraints"
         ]
       },
       "post": {
-        "description": "Create a new constraint.",
+        "description": "Create a new constraint (admin only, scoped to admin's org).",
         "operationId": "createConstraint",
         "requestBody": {
           "content": {
@@ -4059,6 +4064,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Create Constraint",
         "tags": [
           "constraints"
@@ -4067,7 +4077,7 @@
     },
     "/api/v1/constraints/{constraint_id}": {
       "delete": {
-        "description": "Delete constraint.",
+        "description": "Delete constraint (admin only, scoped to admin's org).",
         "operationId": "deleteConstraint",
         "parameters": [
           {
@@ -4095,13 +4105,18 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Delete Constraint",
         "tags": [
           "constraints"
         ]
       },
       "get": {
-        "description": "Get constraint by ID.",
+        "description": "Get constraint by ID; org isolation enforced.",
         "operationId": "getConstraint",
         "parameters": [
           {
@@ -4136,13 +4151,18 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Get Constraint",
         "tags": [
           "constraints"
         ]
       },
       "put": {
-        "description": "Update constraint.",
+        "description": "Update constraint (admin only, scoped to admin's org).",
         "operationId": "updateConstraint",
         "parameters": [
           {
@@ -4187,6 +4207,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Update Constraint",
         "tags": [
           "constraints"


### PR DESCRIPTION
## Summary

Pre-existing security gap: `api/routers/constraints.py` exposed CRUD with **no authentication at all**. Anyone could create/update/delete constraints for any org.

This PR adds:
- `POST /constraints/` — admin-only; `verify_org_member` ensures admins only target their own org
- `GET /constraints/` — authenticated; always scoped to the caller's org
- `GET /constraints/{id}` — authenticated; tenancy verified per row
- `PUT /constraints/{id}` — admin-only
- `DELETE /constraints/{id}` — admin-only

The strict tenancy guard in `tests/api/` confirms the new queries don't leak across orgs.

## Changed files

- `api/routers/constraints.py`: auth dependencies + `verify_org_member` on all 5 endpoints
- `tests/api/test_constraints.py`: new `TestConstraintAuth` class (unauth/volunteer/cross-org rejection); existing CRUD tests now send admin headers
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 429 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 3 Step D (soft-delete on Organization) is next.