### PR TITLE
Sprint 3 Step D: Organization soft-delete (cancel/restore)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -883,6 +883,8 @@ class AuditAction:
     ORG_CREATED = "org.created"
     ORG_UPDATED = "org.updated"
     ORG_SETTINGS_CHANGED = "org.settings.changed"
+    ORG_CANCELLED = "org.cancelled"
+    ORG_RESTORED = "org.restored"
 
     # Sensitive operations
     BULK_DELETE = "data.bulk_delete"

--- a/api/routers/organizations.py
+++ b/api/routers/organizations.py
@@ -1,10 +1,13 @@
 """Organization router."""
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Organization
+from api.dependencies import get_current_admin_user, verify_org_member
+from api.models import AuditAction, Organization, Person
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.organization import (
     OrganizationCreate,
@@ -12,6 +15,8 @@ from api.schemas.organization import (
     OrganizationResponse,
     OrganizationUpdate,
 )
+from api.timeutils import utcnow
+from api.utils.audit_logger import log_audit_event
 from api.utils.rate_limit_middleware import rate_limit
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -52,12 +57,19 @@ def create_organization(org_data: OrganizationCreate, db: Session = Depends(get_
 
 @router.get("/", response_model=OrganizationList)
 def list_organizations(
+    include_cancelled: bool = Query(
+        False, description="Include organizations that have been cancelled (admin view)"
+    ),
     pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
-    """List all organizations."""
-    orgs = db.query(Organization).offset(pagination.offset).limit(pagination.limit).all()
-    total = db.query(Organization).count()
+    """List all organizations. Excludes cancelled by default."""
+    query = db.query(Organization)
+    if not include_cancelled:
+        query = query.filter(Organization.cancelled_at.is_(None))
+
+    orgs = query.offset(pagination.offset).limit(pagination.limit).all()
+    total = query.count()
     return {
         "items": orgs,
         "total": total,
@@ -114,3 +126,81 @@ def delete_organization(org_id: str, db: Session = Depends(get_db)):
     db.delete(org)
     db.commit()
     return None
+
+
+@router.post("/{org_id}/cancel", response_model=OrganizationResponse)
+def cancel_organization(
+    org_id: str,
+    http_request: Request,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Soft-cancel the organization (admin only).
+
+    Sets `cancelled_at` to now and schedules a 30-day data-retention window
+    via `data_retention_until`. The org is excluded from the default list
+    until restored.
+    """
+    verify_org_member(current_admin, org_id)
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{org_id}' not found",
+        )
+
+    now = utcnow()
+    org.cancelled_at = now
+    org.data_retention_until = now + timedelta(days=30)
+    db.commit()
+    db.refresh(org)
+
+    log_audit_event(
+        db,
+        action=AuditAction.ORG_CANCELLED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=org_id,
+        resource_type="organization",
+        resource_id=org_id,
+        details={"data_retention_until": org.data_retention_until.isoformat()},
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+    return org
+
+
+@router.post("/{org_id}/restore", response_model=OrganizationResponse)
+def restore_organization(
+    org_id: str,
+    http_request: Request,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Restore a cancelled organization (admin only). Clears cancellation fields."""
+    verify_org_member(current_admin, org_id)
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{org_id}' not found",
+        )
+
+    org.cancelled_at = None
+    org.data_retention_until = None
+    org.deletion_scheduled_at = None
+    db.commit()
+    db.refresh(org)
+
+    log_audit_event(
+        db,
+        action=AuditAction.ORG_RESTORED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=org_id,
+        resource_type="organization",
+        resource_id=org_id,
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+    return org

--- a/api/schemas/organization.py
+++ b/api/schemas/organization.py
@@ -36,6 +36,9 @@ class OrganizationResponse(BaseResponse, OrganizationBase):
     id: str
     created_at: datetime
     updated_at: datetime
+    cancelled_at: datetime | None = None
+    deletion_scheduled_at: datetime | None = None
+    data_retention_until: datetime | None = None
 
 
 from api.schemas.common import ListResponse

--- a/tests/api/test_org_soft_delete.py
+++ b/tests/api/test_org_soft_delete.py
@@ -1,0 +1,116 @@
+"""Soft-delete (cancel/restore) tests for /api/v1/organizations/.
+
+The Organization model has `cancelled_at`/`deletion_scheduled_at`/`data_retention_until`
+fields. This sprint exposes an admin-only cancel/restore workflow that sets the
+fields and a `?include_cancelled=true` query param on the list endpoint.
+"""
+
+import pytest
+
+from api.models import AuditAction, AuditLog
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(client, org_id, email=f"admin-{suffix}@o.org", name="Admin", password="AdminPass1!")
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+@pytest.mark.no_mock_auth
+class TestOrgCancel:
+    def test_admin_can_cancel_own_org(self, client, db):
+        org_id = "soft-del-cancel"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "cancel")
+
+        resp = client.post(f"/api/v1/organizations/{org_id}/cancel", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["cancelled_at"] is not None
+
+    def test_volunteer_cannot_cancel(self, client, db):
+        org_id = "soft-del-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+
+        resp = client.post(f"/api/v1/organizations/{org_id}/cancel", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+    def test_cross_org_admin_blocked(self, client, db):
+        seed_org(client, "soft-del-a")
+        seed_org(client, "soft-del-b")
+        a_hdrs = _admin_for(client, "soft-del-a", "a")
+
+        resp = client.post("/api/v1/organizations/soft-del-b/cancel", headers=a_hdrs)
+        assert resp.status_code == 403
+
+    def test_cancel_emits_audit_row(self, client, db):
+        org_id = "soft-del-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "audit")
+
+        before = db.query(AuditLog).filter(AuditLog.action == AuditAction.ORG_CANCELLED).count()
+        client.post(f"/api/v1/organizations/{org_id}/cancel", headers=hdrs)
+        after = db.query(AuditLog).filter(AuditLog.action == AuditAction.ORG_CANCELLED).count()
+        assert after == before + 1
+
+
+@pytest.mark.no_mock_auth
+class TestOrgRestore:
+    def test_admin_can_restore(self, client, db):
+        org_id = "soft-del-restore"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "restore")
+
+        client.post(f"/api/v1/organizations/{org_id}/cancel", headers=hdrs)
+        resp = client.post(f"/api/v1/organizations/{org_id}/restore", headers=hdrs)
+        assert resp.status_code == 200
+        assert resp.json()["cancelled_at"] is None
+
+    def test_restore_emits_audit_row(self, client, db):
+        org_id = "soft-del-restore-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "restore-audit")
+        client.post(f"/api/v1/organizations/{org_id}/cancel", headers=hdrs)
+
+        before = db.query(AuditLog).filter(AuditLog.action == AuditAction.ORG_RESTORED).count()
+        client.post(f"/api/v1/organizations/{org_id}/restore", headers=hdrs)
+        after = db.query(AuditLog).filter(AuditLog.action == AuditAction.ORG_RESTORED).count()
+        assert after == before + 1
+
+
+@pytest.mark.no_mock_auth
+class TestListExcludesCancelled:
+    def test_list_excludes_cancelled_by_default(self, client, db):
+        # Two orgs, one cancelled
+        seed_org(client, "list-active")
+        seed_org(client, "list-cancelled")
+        active_hdrs = _admin_for(client, "list-active", "active")
+        cancelled_hdrs = _admin_for(client, "list-cancelled", "cancelled")
+        client.post("/api/v1/organizations/list-cancelled/cancel", headers=cancelled_hdrs)
+
+        resp = client.get("/api/v1/organizations/", headers=active_hdrs)
+        assert resp.status_code == 200
+        ids = [item["id"] for item in resp.json()["items"]]
+        assert "list-active" in ids
+        assert "list-cancelled" not in ids
+
+    def test_include_cancelled_returns_them(self, client, db):
+        seed_org(client, "incl-active")
+        seed_org(client, "incl-cancelled")
+        active_hdrs = _admin_for(client, "incl-active", "incl-active")
+        cancelled_hdrs = _admin_for(client, "incl-cancelled", "incl-cancelled")
+        client.post("/api/v1/organizations/incl-cancelled/cancel", headers=cancelled_hdrs)
+
+        resp = client.get("/api/v1/organizations/?include_cancelled=true", headers=active_hdrs)
+        ids = [item["id"] for item in resp.json()["items"]]
+        assert "incl-cancelled" in ids

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1594,6 +1594,18 @@
       "OrganizationResponse": {
         "description": "Schema for organization response.",
         "properties": {
+          "cancelled_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cancelled At"
+          },
           "config": {
             "anyOf": [
               {
@@ -1611,6 +1623,30 @@
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "data_retention_until": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Retention Until"
+          },
+          "deletion_scheduled_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deletion Scheduled At"
           },
           "id": {
             "title": "Id",
@@ -5040,9 +5076,21 @@
     },
     "/api/v1/organizations/": {
       "get": {
-        "description": "List all organizations.",
+        "description": "List all organizations. Excludes cancelled by default.",
         "operationId": "listOrganizations",
         "parameters": [
+          {
+            "description": "Include organizations that have been cancelled (admin view)",
+            "in": "query",
+            "name": "include_cancelled",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include organizations that have been cancelled (admin view)",
+              "title": "Include Cancelled",
+              "type": "boolean"
+            }
+          },
           {
             "description": "Page size, max 200",
             "in": "query",
@@ -5262,6 +5310,102 @@
           }
         },
         "summary": "Update Organization",
+        "tags": [
+          "organizations"
+        ]
+      }
+    },
+    "/api/v1/organizations/{org_id}/cancel": {
+      "post": {
+        "description": "Soft-cancel the organization (admin only).\n\nSets `cancelled_at` to now and schedules a 30-day data-retention window\nvia `data_retention_until`. The org is excluded from the default list\nuntil restored.",
+        "operationId": "cancelOrganization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Cancel Organization",
+        "tags": [
+          "organizations"
+        ]
+      }
+    },
+    "/api/v1/organizations/{org_id}/restore": {
+      "post": {
+        "description": "Restore a cancelled organization (admin only). Clears cancellation fields.",
+        "operationId": "restoreOrganization",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Restore Organization",
         "tags": [
           "organizations"
         ]


### PR DESCRIPTION
## Summary

The Organization model already had `cancelled_at`, `data_retention_until`, and `deletion_scheduled_at` columns; this PR finally exposes them via an admin-only cancel/restore workflow.

- `POST /organizations/{org_id}/cancel` — sets `cancelled_at = utcnow()` and `data_retention_until = utcnow() + 30 days`. Admin-only, scoped.
- `POST /organizations/{org_id}/restore` — clears all three soft-delete fields. Admin-only, scoped.
- `GET /organizations/` — excludes cancelled by default; `?include_cancelled=true` opts in.
- `OrganizationResponse` exposes the soft-delete state via 3 new optional fields.
- Audits each transition: `AuditAction.ORG_CANCELLED`, `ORG_RESTORED`.

No schema migration needed — the columns already exist.

## Changed files

- `api/models.py`: 2 new `AuditAction` constants
- `api/routers/organizations.py`: cancel + restore endpoints, list filter
- `api/schemas/organization.py`: 3 new optional fields on `OrganizationResponse`
- `tests/api/test_org_soft_delete.py` (new): 8 tests
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 437 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 3 Step E (solver TODO fix) is next.
- A scheduled cleanup job that hard-deletes orgs past `data_retention_until` is Phase 2.