### PR TITLE
Sprint 3 Step E: Solver honors real availability and resources

### DIFF
--- a/api/core/solver/heuristics.py
+++ b/api/core/solver/heuristics.py
@@ -55,6 +55,15 @@ class GreedyHeuristicSolver(SolverAdapter):
             for h in self.context.holidays:
                 holiday_map[h.date] = h.is_long_weekend
 
+        # Build per-person vacation map: person_id -> list[(start_date, end_date)]
+        # so we can filter out unavailable candidates per event.
+        self._vacation_by_person: dict[str, list[tuple[Any, Any]]] = defaultdict(list)
+        for avail in self.context.availability or []:
+            if avail.person_id is None:
+                continue
+            for vac in avail.vacations:
+                self._vacation_by_person[avail.person_id].append((vac.start, vac.end))
+
         # Filter events in range
         events_in_range = [
             e
@@ -168,6 +177,12 @@ class GreedyHeuristicSolver(SolverAdapter):
             for person in candidates:
                 if person.id in assignees:
                     continue  # Already assigned to this event
+
+                # Skip if person is on vacation/time-off covering the event date.
+                # Vacation periods are inclusive on both ends.
+                vacations = getattr(self, "_vacation_by_person", {}).get(person.id, [])
+                if any(v_start <= event_date <= v_end for v_start, v_end in vacations):
+                    continue
 
                 # Check person-level hard constraints
                 ctx.person = person

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -11,6 +11,9 @@ from api.dependencies import get_current_admin_user, verify_org_member
 
 logger = logging.getLogger("rostio")
 from api.core.models import (
+    Availability as AvailabilityModel,
+)
+from api.core.models import (
     Event as EventModel,
 )
 from api.core.models import (
@@ -24,12 +27,21 @@ from api.core.models import (
     Person as PersonModel,
 )
 from api.core.models import (
+    Resource as ResourceModel,
+)
+from api.core.models import (
     Team as TeamModel,
+)
+from api.core.models import (
+    VacationPeriod as VacationPeriodModel,
 )
 from api.core.solver.adapter import SolveContext
 from api.core.solver.heuristics import GreedyHeuristicSolver
 from api.models import (
     Assignment as DBAssignment,
+)
+from api.models import (
+    Availability as DBAvailability,
 )
 from api.models import (
     Constraint as DBConstraint,
@@ -39,10 +51,14 @@ from api.models import (
     Holiday,
     Organization,
     Person,
+    Resource,
     Team,
 )
 from api.models import (
     Solution as DBSolution,
+)
+from api.models import (
+    VacationPeriod as DBVacationPeriod,
 )
 from api.schemas.solver import (
     FairnessMetrics,
@@ -168,15 +184,49 @@ def solve_schedule(
         for h in holidays_db
     ]
 
+    # Load resources for the org
+    resources_db = db.query(Resource).filter(Resource.org_id == solve_request.org_id).all()
+    resources = [
+        ResourceModel(
+            id=r.id,
+            type=r.type,
+            capacity=r.capacity or 1,
+            location=r.location,
+        )
+        for r in resources_db
+    ]
+
+    # Load availability for people in this org. Each Availability row may
+    # carry zero-or-more VacationPeriod children that the solver uses to
+    # block out time-off.
+    person_ids = [p.id for p in people_db]
+    availability: list[AvailabilityModel] = []
+    if person_ids:
+        avail_rows = db.query(DBAvailability).filter(DBAvailability.person_id.in_(person_ids)).all()
+        for a in avail_rows:
+            vacations = [
+                VacationPeriodModel(start=v.start_date, end=v.end_date)
+                for v in db.query(DBVacationPeriod)
+                .filter(DBVacationPeriod.availability_id == a.id)
+                .all()
+            ]
+            availability.append(
+                AvailabilityModel(
+                    person_id=a.person_id,
+                    rrule=a.rrule,
+                    vacations=vacations,
+                )
+            )
+
     # Build solve context
     context = SolveContext(
         org=org_file,
         people=people,
         teams=teams,
-        resources=[],  # TODO: Load resources if needed
+        resources=resources,
         events=events,
         constraints=constraints,
-        availability=[],  # TODO: Load availability if needed
+        availability=availability,
         holidays=holidays,
         from_date=solve_request.from_date,
         to_date=solve_request.to_date,

--- a/tests/api/test_scheduling_workflow.py
+++ b/tests/api/test_scheduling_workflow.py
@@ -209,3 +209,67 @@ class TestSchedulingWorkflow:
             headers=hdrs,
         )
         assert resp.status_code == 200
+
+    def test_solver_honors_volunteer_timeoff(self, client):
+        """A volunteer with time-off covering the event date is NOT assigned by the solver.
+
+        Regression test for the previously hard-coded `availability=[]` in the solver
+        endpoint — the solver now loads real Availability + VacationPeriod records and
+        respects them.
+        """
+        seed_org(client, self.ORG, name="Grace Church")
+        seed_user(client, self.ORG, self.ADMIN_EMAIL, "Pastor", self.ADMIN_PW)
+        # Two volunteers; one will be marked unavailable.
+        away = seed_user(client, self.ORG, "away@grace.church", "Sarah Away", "VolPass123!")
+        present = seed_user(
+            client, self.ORG, "present@grace.church", "James Present", "VolPass123!"
+        )
+        hdrs = auth_headers(client, self.ADMIN_EMAIL, self.ADMIN_PW)
+
+        # Event 14 days from now.
+        event_start = datetime.now() + timedelta(days=14)
+        event = seed_event(
+            client,
+            hdrs,
+            self.ORG,
+            "evt-timeoff",
+            role_counts={"volunteer": 1},
+        )
+
+        # Block the "away" volunteer for a window that covers event_start.
+        timeoff_start = (event_start - timedelta(days=1)).date().isoformat()
+        timeoff_end = (event_start + timedelta(days=1)).date().isoformat()
+        add_timeoff(client, away["person_id"], timeoff_start, timeoff_end, reason="Vacation")
+
+        # Run solver across a wide enough window.
+        from_date = (event_start - timedelta(days=2)).date().isoformat()
+        to_date = (event_start + timedelta(days=2)).date().isoformat()
+        resp = client.post(
+            "/api/v1/solver/solve",
+            json={
+                "org_id": self.ORG,
+                "from_date": from_date,
+                "to_date": to_date,
+                "mode": "strict",
+                "change_min": False,
+            },
+            headers=hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Inspect the assignments produced.
+        resp = client.get(f"/api/v1/events/assignments/all?org_id={self.ORG}", headers=hdrs)
+        assert resp.status_code == 200
+        assignments = resp.json()["assignments"]
+
+        away_assigned = [a for a in assignments if a["person_id"] == away["person_id"]]
+        present_assigned = [a for a in assignments if a["person_id"] == present["person_id"]]
+
+        # The away volunteer must not be on this event.
+        assert all(
+            a["event_id"] != event["id"] for a in away_assigned
+        ), "Solver assigned a volunteer who is on time-off; availability not honored"
+        # The other volunteer should pick up the slot.
+        assert any(
+            a["event_id"] == event["id"] for a in present_assigned
+        ), "Available volunteer was not assigned to the open role"


### PR DESCRIPTION
## Summary

`api/routers/solver.py:176,179` used to pass `availability=[]` and `resources=[]` to the solver. Both now load real DB data:

- **Resources** — every `Resource` row in the org becomes a core `ResourceModel`.
- **Availability** — each `Availability` row + child `VacationPeriod` rows become a core `AvailabilityModel`; only people in the requested org are loaded.

Loading was necessary but not sufficient — the `GreedyHeuristicSolver` previously ignored availability entirely. This PR also wires the consumer side: the solver builds a per-person vacation map and skips candidates whose vacation covers the event date during `_assign_event` filtering.

## Regression test

`tests/api/test_scheduling_workflow.py::test_solver_honors_volunteer_timeoff` — seeds two volunteers (Sarah + James), marks Sarah unavailable for the event window via the existing `add_timeoff` helper, runs the solver, asserts Sarah is **not** assigned and James is.

## Changed files

- `api/routers/solver.py`: import additions; `resources_db` → `resources`; `person_ids` → `availability` with nested vacations
- `api/core/solver/heuristics.py`: build vacation map in `solve()`; filter candidates by vacation overlap
- `tests/api/test_scheduling_workflow.py`: new regression test

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 438 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 3 Step F (migration consolidation) is the last Sprint 3 step.
- Solver still ignores `Availability.rrule` and `AvailabilityException`; current implementation only honors `VacationPeriod` ranges.