### PR TITLE
Sprint 4 PR 4.1: q + status filters on list endpoints

### DIFF
--- a/api/routers/events.py
+++ b/api/routers/events.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -18,6 +19,7 @@ from api.models import (
 )
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.event import EventCreate, EventList, EventResponse, EventUpdate
+from api.timeutils import utcnow
 from api.utils.event_helpers import (
     count_people_with_role,
     get_assigned_person_ids,
@@ -125,6 +127,13 @@ def list_events(
     | None = Query(None, description="Filter events starting after this time"),
     start_before: datetime
     | None = Query(None, description="Filter events starting before this time"),
+    q: str | None = Query(None, description="Case-insensitive search on event type and id"),
+    status_filter: str
+    | None = Query(
+        None,
+        alias="status",
+        description="Filter by computed status: 'upcoming', 'past', or 'ongoing'",
+    ),
     pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
@@ -139,6 +148,24 @@ def list_events(
         query = query.filter(Event.start_time >= start_after)
     if start_before:
         query = query.filter(Event.start_time <= start_before)
+
+    if q:
+        like = f"%{q}%"
+        query = query.filter(or_(Event.type.ilike(like), Event.id.ilike(like)))
+
+    if status_filter:
+        now = utcnow()
+        if status_filter == "upcoming":
+            query = query.filter(Event.start_time > now)
+        elif status_filter == "past":
+            query = query.filter(Event.end_time < now)
+        elif status_filter == "ongoing":
+            query = query.filter(Event.start_time <= now, Event.end_time >= now)
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid status '{status_filter}'. Must be 'upcoming', 'past', or 'ongoing'",
+            )
 
     query = query.order_by(Event.start_time)
     events = query.offset(pagination.offset).limit(pagination.limit).all()

--- a/api/routers/invitations.py
+++ b/api/routers/invitations.py
@@ -5,6 +5,7 @@ import time
 from datetime import timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -106,7 +107,12 @@ async def list_invitations(
     org_id: str = Query(..., description="Organization ID"),
     admin: Person = Depends(get_current_admin_user),
     status_filter: str
-    | None = Query(None, description="Filter by status (pending, accepted, expired, cancelled)"),
+    | None = Query(
+        None,
+        alias="status",
+        description="Filter by status (pending, accepted, expired, cancelled)",
+    ),
+    q: str | None = Query(None, description="Case-insensitive search on email and name"),
     db: Session = Depends(get_db),
 ):
     """
@@ -122,6 +128,10 @@ async def list_invitations(
 
     if status_filter:
         query = query.filter(Invitation.status == status_filter)
+
+    if q:
+        like = f"%{q}%"
+        query = query.filter(or_(Invitation.email.ilike(like), Invitation.name.ilike(like)))
 
     # Update expired invitations
     now = utcnow()

--- a/api/routers/organizations.py
+++ b/api/routers/organizations.py
@@ -60,6 +60,7 @@ def list_organizations(
     include_cancelled: bool = Query(
         False, description="Include organizations that have been cancelled (admin view)"
     ),
+    q: str | None = Query(None, description="Case-insensitive search on organization name"),
     pagination: PaginationParams = Depends(get_pagination_params),
     db: Session = Depends(get_db),
 ):
@@ -67,6 +68,9 @@ def list_organizations(
     query = db.query(Organization)
     if not include_cancelled:
         query = query.filter(Organization.cancelled_at.is_(None))
+
+    if q:
+        query = query.filter(Organization.name.ilike(f"%{q}%"))
 
     orgs = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()

--- a/api/routers/people.py
+++ b/api/routers/people.py
@@ -2,6 +2,7 @@
 
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -93,6 +94,11 @@ def create_person(
 def list_people(
     org_id: str | None = Query(None, description="Filter by organization ID"),
     role: str | None = Query(None, description="Filter by role"),
+    q: str | None = Query(None, description="Case-insensitive search across name and email"),
+    status_filter: str
+    | None = Query(
+        None, alias="status", description="Filter by Person.status (active/inactive/invited)"
+    ),
     pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -108,6 +114,13 @@ def list_people(
     else:
         # Default to current user's organization
         query = query.filter(Person.org_id == current_user.org_id)
+
+    if q:
+        like = f"%{q}%"
+        query = query.filter(or_(Person.name.ilike(like), Person.email.ilike(like)))
+
+    if status_filter:
+        query = query.filter(Person.status == status_filter)
 
     # Note: For JSON field filtering in SQLite, we'd need to load and filter in memory
     # For production with PostgreSQL, we could use JSON operators

--- a/api/routers/teams.py
+++ b/api/routers/teams.py
@@ -2,6 +2,7 @@
 
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -85,6 +86,7 @@ def create_team(
 @router.get("/", response_model=TeamList)
 def list_teams(
     org_id: str | None = Query(None, description="Filter by organization ID"),
+    q: str | None = Query(None, description="Case-insensitive search on name and description"),
     pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -100,6 +102,10 @@ def list_teams(
     else:
         # Default to current user's organization
         query = query.filter(Team.org_id == current_user.org_id)
+
+    if q:
+        like = f"%{q}%"
+        query = query.filter(or_(Team.name.ilike(like), Team.description.ilike(like)))
 
     teams = query.offset(pagination.offset).limit(pagination.limit).all()
     total = query.count()

--- a/tests/api/test_list_search_filters.py
+++ b/tests/api/test_list_search_filters.py
@@ -1,0 +1,279 @@
+"""Search and status filters on list endpoints (Sprint 4 PR 4.1).
+
+Covers:
+- GET /api/v1/people/        — q on name/email, status on Person.status
+- GET /api/v1/events/        — q on type, status mapping to upcoming/past/ongoing
+- GET /api/v1/invitations    — q on email/name, status (renamed from status_filter)
+- GET /api/v1/teams/         — q on name/description
+- GET /api/v1/organizations/ — q on name
+"""
+
+
+import pytest
+
+from api.models import Person
+from tests.api.conftest import (
+    auth_headers,
+    seed_event,
+    seed_invitation,
+    seed_org,
+    seed_team,
+    seed_user,
+)
+
+
+def _admin_headers(client, org_id: str, suffix: str) -> dict:
+    """Create org+admin and return auth headers."""
+    seed_org(client, org_id)
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@lf.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@lf.org", password="AdminPass1!")
+
+
+# ---------------------------------------------------------------------------
+# People
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestPeopleSearchAndStatus:
+    def test_q_matches_name_substring(self, client, db):
+        org_id = "lf-people-q-name"
+        hdrs = _admin_headers(client, org_id, "pn")
+        # Add a couple more volunteers
+        seed_user(
+            client,
+            org_id,
+            email="alice.smith@lf.org",
+            name="Alice Smith",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        seed_user(
+            client,
+            org_id,
+            email="bob.jones@lf.org",
+            name="Bob Jones",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        resp = client.get(f"/api/v1/people/?org_id={org_id}&q=alice", headers=hdrs)
+        assert resp.status_code == 200
+        names = [p["name"] for p in resp.json()["items"]]
+        assert "Alice Smith" in names
+        assert "Bob Jones" not in names
+
+    def test_q_matches_email_substring(self, client, db):
+        org_id = "lf-people-q-email"
+        hdrs = _admin_headers(client, org_id, "pe")
+        seed_user(
+            client,
+            org_id,
+            email="carol@unique-domain.org",
+            name="Carol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        resp = client.get(f"/api/v1/people/?org_id={org_id}&q=unique-domain", headers=hdrs)
+        assert resp.status_code == 200
+        emails = [p["email"] for p in resp.json()["items"]]
+        assert "carol@unique-domain.org" in emails
+
+    def test_q_no_match_returns_empty(self, client, db):
+        org_id = "lf-people-q-empty"
+        hdrs = _admin_headers(client, org_id, "px")
+        resp = client.get(f"/api/v1/people/?org_id={org_id}&q=zzzz-no-such-person", headers=hdrs)
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+        assert resp.json()["total"] == 0
+
+    def test_status_filter(self, client, db):
+        org_id = "lf-people-status"
+        hdrs = _admin_headers(client, org_id, "ps")
+        active = seed_user(
+            client,
+            org_id,
+            email="active@lf.org",
+            name="Active Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        inactive = seed_user(
+            client,
+            org_id,
+            email="inactive@lf.org",
+            name="Inactive Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        # Mark the second one as inactive directly via DB
+        person = db.query(Person).filter(Person.id == inactive["person_id"]).first()
+        assert person is not None
+        person.status = "inactive"
+        db.commit()
+
+        resp = client.get(f"/api/v1/people/?org_id={org_id}&status=inactive", headers=hdrs)
+        assert resp.status_code == 200
+        ids = [p["id"] for p in resp.json()["items"]]
+        assert inactive["person_id"] in ids
+        assert active["person_id"] not in ids
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestEventsSearchAndStatus:
+    def test_q_matches_type_substring(self, client, db):
+        org_id = "lf-events-q"
+        hdrs = _admin_headers(client, org_id, "eq")
+        seed_event(client, hdrs, org_id, event_id="evt-sun", event_type="Sunday Service")
+        seed_event(client, hdrs, org_id, event_id="evt-wed", event_type="Wednesday Bible Study")
+
+        resp = client.get(f"/api/v1/events/?org_id={org_id}&q=sunday", headers=hdrs)
+        assert resp.status_code == 200
+        types = [e["type"] for e in resp.json()["items"]]
+        assert "Sunday Service" in types
+        assert "Wednesday Bible Study" not in types
+
+    def test_status_upcoming(self, client, db):
+        org_id = "lf-events-upcoming"
+        hdrs = _admin_headers(client, org_id, "eu")
+        seed_event(
+            client, hdrs, org_id, event_id="evt-future", event_type="Future", days_from_now=10
+        )
+        seed_event(client, hdrs, org_id, event_id="evt-past", event_type="Past", days_from_now=-10)
+        resp = client.get(f"/api/v1/events/?org_id={org_id}&status=upcoming", headers=hdrs)
+        assert resp.status_code == 200
+        ids = [e["id"] for e in resp.json()["items"]]
+        assert "evt-future" in ids
+        assert "evt-past" not in ids
+
+    def test_status_past(self, client, db):
+        org_id = "lf-events-past"
+        hdrs = _admin_headers(client, org_id, "ep")
+        seed_event(
+            client, hdrs, org_id, event_id="evt-future-2", event_type="Future", days_from_now=10
+        )
+        seed_event(
+            client, hdrs, org_id, event_id="evt-past-2", event_type="Past", days_from_now=-10
+        )
+        resp = client.get(f"/api/v1/events/?org_id={org_id}&status=past", headers=hdrs)
+        assert resp.status_code == 200
+        ids = [e["id"] for e in resp.json()["items"]]
+        assert "evt-past-2" in ids
+        assert "evt-future-2" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Invitations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestInvitationsSearchAndStatus:
+    def test_q_matches_email(self, client, db):
+        org_id = "lf-inv-q-email"
+        hdrs = _admin_headers(client, org_id, "ie")
+        seed_invitation(client, hdrs, org_id, email="match@lf.org", name="A")
+        seed_invitation(client, hdrs, org_id, email="other@lf.org", name="B")
+        resp = client.get(f"/api/v1/invitations?org_id={org_id}&q=match", headers=hdrs)
+        assert resp.status_code == 200
+        emails = [i["email"] for i in resp.json()["items"]]
+        assert "match@lf.org" in emails
+        assert "other@lf.org" not in emails
+
+    def test_status_filter_renamed(self, client, db):
+        org_id = "lf-inv-status"
+        hdrs = _admin_headers(client, org_id, "is")
+        inv = seed_invitation(client, hdrs, org_id, email="cancel@lf.org", name="C")
+        # Cancel one
+        client.delete(f"/api/v1/invitations/{inv['id']}", headers=hdrs)
+        # And keep one pending
+        seed_invitation(client, hdrs, org_id, email="pending@lf.org", name="P")
+
+        resp = client.get(f"/api/v1/invitations?org_id={org_id}&status=cancelled", headers=hdrs)
+        assert resp.status_code == 200
+        emails = [i["email"] for i in resp.json()["items"]]
+        assert "cancel@lf.org" in emails
+        assert "pending@lf.org" not in emails
+
+
+# ---------------------------------------------------------------------------
+# Teams
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestTeamsSearch:
+    def test_q_matches_name(self, client, db):
+        org_id = "lf-teams-q-name"
+        hdrs = _admin_headers(client, org_id, "tn")
+        seed_team(client, hdrs, org_id, team_id="t1", name="Worship Team")
+        seed_team(client, hdrs, org_id, team_id="t2", name="Hospitality Team")
+        resp = client.get(f"/api/v1/teams/?org_id={org_id}&q=worship", headers=hdrs)
+        assert resp.status_code == 200
+        names = [t["name"] for t in resp.json()["items"]]
+        assert "Worship Team" in names
+        assert "Hospitality Team" not in names
+
+    def test_q_matches_description(self, client, db):
+        org_id = "lf-teams-q-desc"
+        hdrs = _admin_headers(client, org_id, "td")
+        # Create with description via direct POST (helper uses default member_ids only)
+        client.post(
+            "/api/v1/teams/",
+            json={
+                "id": "t-desc",
+                "org_id": org_id,
+                "name": "Generic Team",
+                "description": "Handles audio-visual setup",
+            },
+            headers=hdrs,
+        )
+        client.post(
+            "/api/v1/teams/",
+            json={
+                "id": "t-other",
+                "org_id": org_id,
+                "name": "Other",
+                "description": "Some other notes",
+            },
+            headers=hdrs,
+        )
+        resp = client.get(f"/api/v1/teams/?org_id={org_id}&q=audio-visual", headers=hdrs)
+        assert resp.status_code == 200
+        ids = [t["id"] for t in resp.json()["items"]]
+        assert "t-desc" in ids
+        assert "t-other" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Organizations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestOrganizationsSearch:
+    def test_q_matches_name(self, client, db):
+        seed_org(client, "lf-orgs-alpha", name="Alpha Church")
+        seed_org(client, "lf-orgs-beta", name="Beta League")
+        resp = client.get("/api/v1/organizations/?q=alpha")
+        assert resp.status_code == 200
+        names = [o["name"] for o in resp.json()["items"]]
+        assert "Alpha Church" in names
+        assert "Beta League" not in names
+
+    def test_q_no_match_returns_empty(self, client, db):
+        seed_org(client, "lf-orgs-zzz", name="Zeta Org")
+        resp = client.get("/api/v1/organizations/?q=nomatchhere")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+        assert resp.json()["total"] == 0

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -4334,6 +4334,42 @@
             }
           },
           {
+            "description": "Case-insensitive search on event type and id",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive search on event type and id",
+              "title": "Q"
+            }
+          },
+          {
+            "description": "Filter by computed status: 'upcoming', 'past', or 'ongoing'",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by computed status: 'upcoming', 'past', or 'ongoing'",
+              "title": "Status"
+            }
+          },
+          {
             "description": "Page size, max 200",
             "in": "query",
             "name": "limit",
@@ -4782,7 +4818,7 @@
           {
             "description": "Filter by status (pending, accepted, expired, cancelled)",
             "in": "query",
-            "name": "status_filter",
+            "name": "status",
             "required": false,
             "schema": {
               "anyOf": [
@@ -4794,7 +4830,25 @@
                 }
               ],
               "description": "Filter by status (pending, accepted, expired, cancelled)",
-              "title": "Status Filter"
+              "title": "Status"
+            }
+          },
+          {
+            "description": "Case-insensitive search on email and name",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive search on email and name",
+              "title": "Q"
             }
           }
         ],
@@ -5089,6 +5143,24 @@
               "description": "Include organizations that have been cancelled (admin view)",
               "title": "Include Cancelled",
               "type": "boolean"
+            }
+          },
+          {
+            "description": "Case-insensitive search on organization name",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive search on organization name",
+              "title": "Q"
             }
           },
           {
@@ -5450,6 +5522,42 @@
               ],
               "description": "Filter by role",
               "title": "Role"
+            }
+          },
+          {
+            "description": "Case-insensitive search across name and email",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive search across name and email",
+              "title": "Q"
+            }
+          },
+          {
+            "description": "Filter by Person.status (active/inactive/invited)",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by Person.status (active/inactive/invited)",
+              "title": "Status"
             }
           },
           {
@@ -6131,6 +6239,24 @@
               ],
               "description": "Filter by organization ID",
               "title": "Org Id"
+            }
+          },
+          {
+            "description": "Case-insensitive search on name and description",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case-insensitive search on name and description",
+              "title": "Q"
             }
           },
           {


### PR DESCRIPTION
## Summary

Add `q` (case-insensitive ILIKE) and `status` query params across the five primary list endpoints so callers can search/filter without pulling full collections.

| Endpoint | `q` matches | `status` |
| --- | --- | --- |
| `GET /api/v1/people/` | `name` OR `email` | filters `Person.status` (active/inactive/invited) |
| `GET /api/v1/events/` | `type` OR `id` | computed: `upcoming` / `past` / `ongoing` (invalid → 400) |
| `GET /api/v1/invitations` | `email` OR `name` | renamed param `status_filter` → `status` (kept as alias on the same field, no breakage in the type) |
| `GET /api/v1/teams/` | `name` OR `description` | n/a (no status column) |
| `GET /api/v1/organizations/` | `name` | n/a (`include_cancelled` already covers cancelled/active) |

## Changed files

- `api/routers/people.py` — `q` + `status` (Person.status), `or_` import.
- `api/routers/events.py` — `q` + computed `status`, `or_` import, `utcnow`.
- `api/routers/invitations.py` — `q` + alias `status_filter`→`status`.
- `api/routers/teams.py` — `q` on name/description.
- `api/routers/organizations.py` — `q` on name.
- `tests/api/test_list_search_filters.py` (new) — 13 tests covering all five endpoints.
- `tests/contract/openapi.snapshot.json` — refreshed (new `q`/`status` params, status_filter renamed).

## Test plan

- [x] `poetry run pytest tests/api/test_list_search_filters.py -q` — 13 passed.
- [x] `poetry run pytest tests/unit tests/api -q` — 433 passed, 21 skipped (one pre-existing test-order flake not in changed files).
- [x] `poetry run pytest tests/contract -q` — 1 passed.
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.

## Follow-ups

- Next planned task: Sprint 4 PR 4.2 (Solution publish/active flag).
- Phase 2 features (file uploads, sync, refresh tokens, etc.) remain deferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaBYNVL7Yvu2bcCmkfAyzC)_