### PR TITLE
Sprint 4 PR 4.2: Solution publish/active flag

### DIFF
--- a/alembic/versions/739ba7ba574c_add_solution_publish_columns.py
+++ b/alembic/versions/739ba7ba574c_add_solution_publish_columns.py
@@ -1,0 +1,43 @@
+"""add_solution_publish_columns
+
+Revision ID: 739ba7ba574c
+Revises: 7ba388eecd31
+Create Date: 2026-05-06 17:10:22.735104
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '739ba7ba574c'
+down_revision: Union[str, Sequence[str], None] = '7ba388eecd31'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('solutions', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'is_published',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text('0'),
+            )
+        )
+        batch_op.add_column(sa.Column('published_at', sa.DateTime(), nullable=True))
+        batch_op.create_index(
+            'idx_solutions_org_published', ['org_id', 'is_published']
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('solutions', schema=None) as batch_op:
+        batch_op.drop_index('idx_solutions_org_published')
+        batch_op.drop_column('published_at')
+        batch_op.drop_column('is_published')

--- a/alembic/versions/739ba7ba574c_add_solution_publish_columns.py
+++ b/alembic/versions/739ba7ba574c_add_solution_publish_columns.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
                 'is_published',
                 sa.Boolean(),
                 nullable=False,
-                server_default=sa.text('0'),
+                server_default=sa.false(),
             )
         )
         batch_op.add_column(sa.Column('published_at', sa.DateTime(), nullable=True))

--- a/api/models.py
+++ b/api/models.py
@@ -534,6 +534,8 @@ class Solution(Base):
     health_score = Column(Float, nullable=False)
     metrics = Column(JSONType, nullable=True)
     created_at = Column(DateTime, default=utcnow)
+    is_published = Column(Boolean, nullable=False, default=False, server_default="0")
+    published_at = Column(DateTime, nullable=True)
 
     # Relationships
     organization = relationship("Organization", back_populates="solutions")
@@ -545,6 +547,7 @@ class Solution(Base):
     __table_args__ = (
         Index("idx_solutions_org_id", "org_id"),
         Index("idx_solutions_created_at", "created_at"),
+        Index("idx_solutions_org_published", "org_id", "is_published"),
     )
 
 
@@ -895,6 +898,10 @@ class AuditAction:
     ASSIGNMENT_ACCEPTED = "assignment.accepted"
     ASSIGNMENT_DECLINED = "assignment.declined"
     ASSIGNMENT_SWAP_REQUESTED = "assignment.swap_requested"
+
+    # Solution lifecycle
+    SOLUTION_PUBLISHED = "solution.published"
+    SOLUTION_UNPUBLISHED = "solution.unpublished"
 
 
 class SmsPreference(Base):

--- a/api/routers/solutions.py
+++ b/api/routers/solutions.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.orm import Session
 
 from api.core.models import (
@@ -15,9 +15,12 @@ from api.core.models import (
     Person as PersonModel,
 )
 from api.database import get_db
-from api.models import Assignment, Event, Organization, Person, Solution
+from api.dependencies import get_current_admin_user, verify_org_member
+from api.models import Assignment, AuditAction, Event, Organization, Person, Solution
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.solver import ExportFormat, SolutionList, SolutionResponse
+from api.timeutils import utcnow
+from api.utils.audit_logger import log_audit_event
 from api.utils.pdf_export import generate_schedule_pdf
 
 router = APIRouter(prefix="/solutions", tags=["solutions"])
@@ -351,6 +354,100 @@ def export_solution(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Unknown format: {export_format.format}. Must be json, csv, ics, or pdf",
         )
+
+
+@router.post("/{solution_id}/publish", response_model=SolutionResponse)
+def publish_solution(
+    solution_id: int,
+    http_request: Request,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Publish a solution (admin only). Unpublishes any prior published in the same org."""
+    solution = db.query(Solution).filter(Solution.id == solution_id).first()
+    if not solution:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_id} not found",
+        )
+    verify_org_member(current_admin, solution.org_id)
+
+    # Unpublish any prior in the same org.
+    prior = (
+        db.query(Solution)
+        .filter(
+            Solution.org_id == solution.org_id,
+            Solution.is_published.is_(True),
+            Solution.id != solution.id,
+        )
+        .all()
+    )
+    for s in prior:
+        s.is_published = False
+        s.published_at = None
+
+    now = utcnow()
+    solution.is_published = True
+    solution.published_at = now
+    db.commit()
+    db.refresh(solution)
+
+    log_audit_event(
+        db,
+        action=AuditAction.SOLUTION_PUBLISHED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=solution.org_id,
+        resource_type="solution",
+        resource_id=str(solution.id),
+        details={"unpublished_prior_ids": [s.id for s in prior]},
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    assignment_count = db.query(Assignment).filter(Assignment.solution_id == solution.id).count()
+    response = SolutionResponse.model_validate(solution)
+    response.assignment_count = assignment_count
+    return response
+
+
+@router.post("/{solution_id}/unpublish", response_model=SolutionResponse)
+def unpublish_solution(
+    solution_id: int,
+    http_request: Request,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Unpublish a solution (admin only)."""
+    solution = db.query(Solution).filter(Solution.id == solution_id).first()
+    if not solution:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_id} not found",
+        )
+    verify_org_member(current_admin, solution.org_id)
+
+    solution.is_published = False
+    solution.published_at = None
+    db.commit()
+    db.refresh(solution)
+
+    log_audit_event(
+        db,
+        action=AuditAction.SOLUTION_UNPUBLISHED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=solution.org_id,
+        resource_type="solution",
+        resource_id=str(solution.id),
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    assignment_count = db.query(Assignment).filter(Assignment.solution_id == solution.id).count()
+    response = SolutionResponse.model_validate(solution)
+    response.assignment_count = assignment_count
+    return response
 
 
 @router.delete("/{solution_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -74,6 +74,8 @@ class SolutionResponse(BaseModel):
     health_score: float
     metrics: dict[str, Any] | None
     created_at: datetime
+    is_published: bool = False
+    published_at: datetime | None = None
     assignment_count: int = 0
 
 

--- a/tests/api/test_solution_publish.py
+++ b/tests/api/test_solution_publish.py
@@ -1,0 +1,164 @@
+"""Solution publish/unpublish tests for /api/v1/solutions/.
+
+Sprint 4 PR 4.2 adds an `is_published`/`published_at` flag to Solution and
+admin-only POST `/solutions/{id}/publish` and `/solutions/{id}/unpublish`
+endpoints. Publishing a solution unpublishes any previously published one in
+the same organization. Both transitions are audited.
+"""
+
+import pytest
+
+from api.models import AuditAction, AuditLog, Solution
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(client, org_id, email=f"admin-{suffix}@o.org", name="Admin", password="AdminPass1!")
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _seed_solution(db, org_id: str) -> Solution:
+    sol = Solution(
+        org_id=org_id,
+        solve_ms=10.0,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=1.0,
+        metrics={},
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    return sol
+
+
+@pytest.mark.no_mock_auth
+class TestPublishSolution:
+    def test_admin_can_publish(self, client, db):
+        org_id = "pub-admin-ok"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "ok")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/publish", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_published"] is True
+        assert body["published_at"] is not None
+
+    def test_volunteer_cannot_publish(self, client, db):
+        org_id = "pub-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/publish", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+    def test_publish_requires_auth(self, client, db):
+        org_id = "pub-noauth"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "noauth")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/publish")
+        # HTTPBearer without credentials returns 403 by FastAPI default.
+        assert resp.status_code in (401, 403)
+
+    def test_cross_org_admin_blocked(self, client, db):
+        seed_org(client, "pub-a")
+        seed_org(client, "pub-b")
+        a_hdrs = _admin_for(client, "pub-a", "a")
+        sol_b = _seed_solution(db, "pub-b")
+
+        resp = client.post(f"/api/v1/solutions/{sol_b.id}/publish", headers=a_hdrs)
+        assert resp.status_code == 403
+
+    def test_publish_unpublishes_prior(self, client, db):
+        """Publishing one solution should unpublish any prior published in the same org."""
+        org_id = "pub-replace"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "replace")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        client.post(f"/api/v1/solutions/{sol_a.id}/publish", headers=hdrs)
+        client.post(f"/api/v1/solutions/{sol_b.id}/publish", headers=hdrs)
+
+        a_after = client.get(f"/api/v1/solutions/{sol_a.id}", headers=hdrs).json()
+        b_after = client.get(f"/api/v1/solutions/{sol_b.id}", headers=hdrs).json()
+        assert a_after["is_published"] is False
+        assert b_after["is_published"] is True
+
+    def test_publish_emits_audit_row(self, client, db):
+        org_id = "pub-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "pub-audit")
+        sol = _seed_solution(db, org_id)
+
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_PUBLISHED).count()
+        )
+        client.post(f"/api/v1/solutions/{sol.id}/publish", headers=hdrs)
+        after = db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_PUBLISHED).count()
+        assert after == before + 1
+
+
+@pytest.mark.no_mock_auth
+class TestUnpublishSolution:
+    def test_admin_can_unpublish(self, client, db):
+        org_id = "unpub-ok"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "unpub-ok")
+        sol = _seed_solution(db, org_id)
+        client.post(f"/api/v1/solutions/{sol.id}/publish", headers=hdrs)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/unpublish", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_published"] is False
+        assert body["published_at"] is None
+
+    def test_unpublish_emits_audit_row(self, client, db):
+        org_id = "unpub-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "unpub-audit")
+        sol = _seed_solution(db, org_id)
+        client.post(f"/api/v1/solutions/{sol.id}/publish", headers=hdrs)
+
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_UNPUBLISHED).count()
+        )
+        client.post(f"/api/v1/solutions/{sol.id}/unpublish", headers=hdrs)
+        after = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_UNPUBLISHED).count()
+        )
+        assert after == before + 1
+
+    def test_volunteer_cannot_unpublish(self, client, db):
+        org_id = "unpub-vol"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "unpub-vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+        sol = _seed_solution(db, org_id)
+        client.post(f"/api/v1/solutions/{sol.id}/publish", headers=admin_hdrs)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/unpublish", headers=vol_hdrs)
+        assert resp.status_code == 403

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -2142,6 +2142,11 @@
             "title": "Id",
             "type": "integer"
           },
+          "is_published": {
+            "default": false,
+            "title": "Is Published",
+            "type": "boolean"
+          },
           "metrics": {
             "anyOf": [
               {
@@ -2157,6 +2162,18 @@
           "org_id": {
             "title": "Org Id",
             "type": "string"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
           },
           "soft_score": {
             "title": "Soft Score",
@@ -6166,6 +6183,102 @@
           }
         },
         "summary": "Export Solution",
+        "tags": [
+          "solutions"
+        ]
+      }
+    },
+    "/api/v1/solutions/{solution_id}/publish": {
+      "post": {
+        "description": "Publish a solution (admin only). Unpublishes any prior published in the same org.",
+        "operationId": "publishSolution",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "solution_id",
+            "required": true,
+            "schema": {
+              "title": "Solution Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Publish Solution",
+        "tags": [
+          "solutions"
+        ]
+      }
+    },
+    "/api/v1/solutions/{solution_id}/unpublish": {
+      "post": {
+        "description": "Unpublish a solution (admin only).",
+        "operationId": "unpublishSolution",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "solution_id",
+            "required": true,
+            "schema": {
+              "title": "Solution Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unpublish Solution",
         "tags": [
           "solutions"
         ]


### PR DESCRIPTION
## Summary

Adds an admin-only publish/unpublish workflow on `/api/v1/solutions/` so an org can mark exactly one Solution as the active schedule. Publishing one solution unpublishes any prior published one in the same org. Both transitions emit audit rows.

| Endpoint | Method | Auth | Behavior |
| --- | --- | --- | --- |
| `/solutions/{id}/publish` | POST | admin (verify_org_member) | Sets `is_published=True`, `published_at=now`. Unpublishes prior. Audits via `SOLUTION_PUBLISHED`. |
| `/solutions/{id}/unpublish` | POST | admin (verify_org_member) | Clears flag and timestamp. Audits via `SOLUTION_UNPUBLISHED`. |

## Changed files

- `api/models.py` — `Solution.is_published` + `published_at` columns, composite `(org_id, is_published)` index, two new `AuditAction` constants.
- `api/routers/solutions.py` — admin-only publish + unpublish handlers with replace-prior semantics, audit logging, `verify_org_member` cross-tenant guard.
- `api/schemas/solver.py` — new fields surfaced on `SolutionResponse`.
- `alembic/versions/739ba7ba574c_add_solution_publish_columns.py` — adds the two columns + index (batch_alter_table for SQLite).
- `tests/api/test_solution_publish.py` — 9 new tests covering admin/volunteer gating, no-auth rejection, cross-tenant, replace-prior semantics, audit rows.
- `tests/contract/openapi.snapshot.json` — refreshed via `make update-openapi-snapshot`.

## Test plan

- [x] `poetry run pytest tests/api/test_solution_publish.py -q` — 9 passed.
- [x] `make test-unit` — 291 passed, 21 skipped.
- [x] `poetry run pytest tests/api tests/contract -q` — 153 passed.
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.

## Follow-ups

- Next planned task: Sprint 4 PR 4.3 (bulk people import, JSON-array body — NOT file upload).
- Phase 2 features (file uploads, sync, refresh tokens, etc.) remain deferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaBYNVL7Yvu2bcCmkfAyzC)_