### PR TITLE
Sprint 4 PR 4.4: Session invalidation on password change

### DIFF
--- a/alembic/versions/cf7914ee40c0_add_password_changed_at_to_person.py
+++ b/alembic/versions/cf7914ee40c0_add_password_changed_at_to_person.py
@@ -1,7 +1,7 @@
 """add_password_changed_at_to_person
 
 Revision ID: cf7914ee40c0
-Revises: 7ba388eecd31
+Revises: 739ba7ba574c
 Create Date: 2026-05-06 17:31:28.378854
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'cf7914ee40c0'
-down_revision: Union[str, Sequence[str], None] = '7ba388eecd31'
+down_revision: Union[str, Sequence[str], None] = '739ba7ba574c'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/cf7914ee40c0_add_password_changed_at_to_person.py
+++ b/alembic/versions/cf7914ee40c0_add_password_changed_at_to_person.py
@@ -1,0 +1,30 @@
+"""add_password_changed_at_to_person
+
+Revision ID: cf7914ee40c0
+Revises: 7ba388eecd31
+Create Date: 2026-05-06 17:31:28.378854
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'cf7914ee40c0'
+down_revision: Union[str, Sequence[str], None] = '7ba388eecd31'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('people', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('password_changed_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('people', schema=None) as batch_op:
+        batch_op.drop_column('password_changed_at')

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -116,6 +116,18 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # Session-invalidation-on-password-change: tokens whose pwd_iat is strictly
+    # older than the user's password_changed_at are rejected. Tokens without
+    # the claim still validate (backward compat with pre-rollout tokens).
+    pwd_iat = payload.get("pwd_iat")
+    if pwd_iat is not None and person.password_changed_at is not None:
+        if float(pwd_iat) < person.password_changed_at.timestamp():
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token revoked: password was changed",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
     return person
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -144,6 +144,9 @@ class Person(Base):
         String, unique=True, nullable=True
     )  # Unique token for calendar subscription
     is_sample = Column(Boolean, default=False, nullable=False)  # For sample/demo data
+    password_changed_at = Column(
+        DateTime, nullable=True
+    )  # Tokens with pwd_iat older than this are revoked.
     extra_data = Column(JSONType, nullable=True)
     created_at = Column(DateTime, default=utcnow)
     updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -10,7 +10,16 @@ from api.database import get_db
 from api.dependencies import get_organization_by_id
 from api.models import Person
 from api.security import create_access_token, hash_password, verify_password
+from api.timeutils import utcnow
 from api.utils.rate_limit_middleware import rate_limit
+
+
+def _pwd_iat_for(person: Person) -> float:
+    """Token claim representing the password version this token was issued for."""
+    if person.password_changed_at is not None:
+        return person.password_changed_at.timestamp()
+    return utcnow().timestamp()
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -99,6 +108,7 @@ def signup(request: SignupRequest, db: Session = Depends(get_db)):
         roles=roles,
         timezone=request.timezone,
         language=request.language,
+        password_changed_at=utcnow(),
         extra_data={},
     )
 
@@ -106,8 +116,8 @@ def signup(request: SignupRequest, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(person)
 
-    # Generate JWT access token
-    access_token = create_access_token(data={"sub": person.id})
+    # Generate JWT access token (pwd_iat allows revocation on password change).
+    access_token = create_access_token(data={"sub": person.id, "pwd_iat": _pwd_iat_for(person)})
 
     return AuthResponse(
         person_id=person.id,
@@ -138,8 +148,8 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password"
         )
 
-    # Generate JWT access token
-    access_token = create_access_token(data={"sub": person.id})
+    # Generate JWT access token (pwd_iat allows revocation on password change).
+    access_token = create_access_token(data={"sub": person.id, "pwd_iat": _pwd_iat_for(person)})
 
     return AuthResponse(
         person_id=person.id,

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.models import AuditAction, Person
 from api.security import hash_password
+from api.timeutils import utcnow
 from api.utils.audit_logger import log_audit_event
 from api.utils.rate_limit_middleware import rate_limit
 
@@ -114,6 +115,8 @@ def reset_password(
 
     # Hash new password using bcrypt (same as signup/login)
     person.password_hash = hash_password(request.new_password)
+    # Invalidate any tokens issued before this reset.
+    person.password_changed_at = utcnow()
 
     db.commit()
 

--- a/tests/api/test_jwt_revocation.py
+++ b/tests/api/test_jwt_revocation.py
@@ -1,0 +1,128 @@
+"""JWT session-invalidation-on-password-change tests (Sprint 4 PR 4.4).
+
+Tokens carry a `pwd_iat` claim. `get_current_user` rejects any token whose
+`pwd_iat` is strictly older than the user's `password_changed_at`. Tokens
+without the claim still validate (backward compat).
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from api.models import Person
+from api.security import create_access_token
+from tests.api.conftest import auth_headers, login, seed_org, seed_user
+
+
+@pytest.mark.no_mock_auth
+class TestPasswordChangedAt:
+    def test_signup_sets_password_changed_at(self, client, db):
+        seed_org(client, "rev-signup")
+        seed_user(client, "rev-signup", email="u@o.org", name="U", password="Pass1234!")
+
+        person = db.query(Person).filter(Person.email == "u@o.org").first()
+        assert person.password_changed_at is not None
+
+    def test_token_without_pwd_iat_still_validates(self, client, db):
+        seed_org(client, "rev-legacy")
+        seed_user(client, "rev-legacy", email="l@o.org", name="L", password="Pass1234!")
+        person = db.query(Person).filter(Person.email == "l@o.org").first()
+
+        # Token minted directly without pwd_iat — emulates a pre-rollout token.
+        legacy_token = create_access_token(data={"sub": person.id})
+        resp = client.get(
+            "/api/v1/people/me",
+            headers={"Authorization": f"Bearer {legacy_token}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_login_token_works(self, client, db):
+        seed_org(client, "rev-login")
+        seed_user(client, "rev-login", email="ok@o.org", name="OK", password="Pass1234!")
+        hdrs = auth_headers(client, email="ok@o.org", password="Pass1234!")
+
+        resp = client.get("/api/v1/people/me", headers=hdrs)
+        assert resp.status_code == 200
+
+    def test_token_older_than_password_change_rejected(self, client, db):
+        seed_org(client, "rev-old")
+        seed_user(client, "rev-old", email="x@o.org", name="X", password="Pass1234!")
+        # Mint a token with pwd_iat in the past (pre-password-change).
+        person = db.query(Person).filter(Person.email == "x@o.org").first()
+        old_pwd_iat = (datetime.utcnow() - timedelta(hours=2)).timestamp()
+        old_token = create_access_token(data={"sub": person.id, "pwd_iat": old_pwd_iat})
+
+        # Bump password_changed_at to "now" — newer than the token's pwd_iat.
+        person.password_changed_at = datetime.utcnow()
+        db.commit()
+
+        resp = client.get(
+            "/api/v1/people/me",
+            headers={"Authorization": f"Bearer {old_token}"},
+        )
+        assert resp.status_code == 401
+
+    def test_token_at_or_after_password_change_accepted(self, client, db):
+        seed_org(client, "rev-fresh")
+        seed_user(client, "rev-fresh", email="y@o.org", name="Y", password="Pass1234!")
+        person = db.query(Person).filter(Person.email == "y@o.org").first()
+        # password_changed_at set in the past
+        person.password_changed_at = datetime.utcnow() - timedelta(hours=1)
+        db.commit()
+
+        # Token with pwd_iat AT password change time.
+        token = create_access_token(
+            data={
+                "sub": person.id,
+                "pwd_iat": person.password_changed_at.timestamp(),
+            }
+        )
+        resp = client.get(
+            "/api/v1/people/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_password_reset_invalidates_old_tokens(self, client, db):
+        import os
+
+        seed_org(client, "rev-reset")
+        seed_user(client, "rev-reset", email="r@o.org", name="R", password="OldPass1!")
+        old_hdrs = auth_headers(client, email="r@o.org", password="OldPass1!")
+
+        # Old token works initially.
+        assert client.get("/api/v1/people/me", headers=old_hdrs).status_code == 200
+
+        # Trigger password reset.
+        os.environ["DEBUG_RETURN_RESET_TOKEN"] = "true"
+        try:
+            resp = client.post("/api/v1/auth/forgot-password", json={"email": "r@o.org"})
+            token = resp.json().get("token")
+            assert token, resp.text
+            resp = client.post(
+                "/api/v1/auth/reset-password",
+                json={"token": token, "new_password": "NewPass1!"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            os.environ.pop("DEBUG_RETURN_RESET_TOKEN", None)
+
+        # Old token should now be rejected.
+        resp = client.get("/api/v1/people/me", headers=old_hdrs)
+        assert resp.status_code == 401
+
+        # Fresh login produces a working token.
+        new_hdrs = auth_headers(client, email="r@o.org", password="NewPass1!")
+        assert client.get("/api/v1/people/me", headers=new_hdrs).status_code == 200
+
+    def test_login_includes_pwd_iat_claim(self, client, db):
+        from jose import jwt
+
+        from api.security import ALGORITHM, SECRET_KEY
+
+        seed_org(client, "rev-claim")
+        seed_user(client, "rev-claim", email="c@o.org", name="C", password="Pass1234!")
+        data = login(client, email="c@o.org", password="Pass1234!")
+
+        payload = jwt.decode(data["token"], SECRET_KEY, algorithms=[ALGORITHM])
+        assert "pwd_iat" in payload


### PR DESCRIPTION
## Summary

Adds a `password_changed_at` column to `Person` and a `pwd_iat` claim to JWTs. `get_current_user` rejects any token whose `pwd_iat` is strictly older than the user's `password_changed_at`. Tokens without the claim still validate (backward compat). The column is bumped on signup and on password reset, so resetting a password immediately invalidates all active sessions for that user.

| Path | Behavior |
| --- | --- |
| `auth/signup` | sets `password_changed_at = utcnow()`, mints token with `pwd_iat = password_changed_at.timestamp()` |
| `auth/login` | mints token with `pwd_iat = password_changed_at.timestamp()` (or `utcnow()` fallback) |
| `auth/reset-password` | bumps `password_changed_at = utcnow()` so all prior tokens fail validation |
| `get_current_user` | 401 if `pwd_iat < password_changed_at`; passes if claim absent |

## Changed files

- `api/models.py` — `Person.password_changed_at` column.
- `alembic/versions/cf7914ee40c0_add_password_changed_at_to_person.py` — migration.
- `api/dependencies.py` — token revocation check inside `get_current_user`.
- `api/routers/auth.py` — `_pwd_iat_for(person)` helper, signup/login include the claim.
- `api/routers/password_reset.py` — bumps `password_changed_at` on reset.
- `tests/api/test_jwt_revocation.py` — 7 new tests (signup-sets-it, legacy-token-without-claim, login-token-works, token-older-than-change-rejected, token-at-or-after-change-accepted, password-reset-invalidates-old-tokens, login-token-includes-claim).

**No OpenAPI snapshot refresh** — JWT bodies are opaque, the API contract is unchanged.

## Test plan

- [x] `poetry run pytest tests/api/test_jwt_revocation.py tests/api/test_password_reset.py tests/unit/test_password_reset.py -q` — 15 passed.
- [x] `poetry run pytest tests/api tests/contract -q` — 151 passed.
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.

## Follow-ups

- Sprint 4 PR 4.5 (calendar auth gap + admin override).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaBYNVL7Yvu2bcCmkfAyzC)_