### PR TITLE
Sprint 4 PR 4.5: Calendar auth gap + admin override

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -909,6 +909,10 @@ class AuditAction:
     # Bulk operations
     BULK_IMPORT = "data.bulk_import"
 
+    # Calendar token management
+    CALENDAR_TOKEN_RESET = "calendar.token.reset"
+    CALENDAR_TOKEN_ADMIN_RESET = "calendar.token.admin_reset"
+
 
 class SmsPreference(Base):
     """SMS notification preferences for volunteers."""

--- a/api/routers/calendar.py
+++ b/api/routers/calendar.py
@@ -5,7 +5,13 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Assignment, Event, Organization, Person, Resource
+from api.dependencies import (
+    check_admin_permission,
+    get_current_admin_user,
+    get_current_user,
+)
+from api.models import Assignment, AuditAction, Event, Organization, Person, Resource
+from api.utils.audit_logger import log_audit_event
 from api.utils.calendar_utils import (
     generate_https_feed_url,
     generate_ics_from_assignments,
@@ -15,6 +21,18 @@ from api.utils.calendar_utils import (
 from api.utils.security import generate_calendar_token
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
+
+
+def _ensure_self_or_same_org_admin(current_user: Person, target: Person) -> None:
+    """403 unless the requester is the target or an admin in the same org."""
+    if current_user.id == target.id:
+        return
+    if check_admin_permission(current_user) and current_user.org_id == target.org_id:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Access denied: must be self or admin in the same organization",
+    )
 
 
 # Schemas
@@ -125,6 +143,7 @@ def export_personal_schedule(
 @router.get("/subscribe")
 def get_subscription_url(
     person_id: str,
+    current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
     request: Request = None,
 ) -> CalendarSubscriptionResponse:
@@ -132,7 +151,8 @@ def get_subscription_url(
     Get calendar subscription URL for a person.
 
     Returns a webcal:// URL that can be used to subscribe to the calendar
-    in Google Calendar, Apple Calendar, Outlook, etc.
+    in Google Calendar, Apple Calendar, Outlook, etc. Caller must be the
+    target person or an admin in the same organization.
     """
     # Verify person exists
     person = db.query(Person).filter(Person.id == person_id).first()
@@ -141,6 +161,7 @@ def get_subscription_url(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Person '{person_id}' not found",
         )
+    _ensure_self_or_same_org_admin(current_user, person)
 
     # Generate calendar token if not exists
     if not person.calendar_token:
@@ -166,14 +187,16 @@ def get_subscription_url(
 @router.post("/reset-token")
 def reset_calendar_token(
     person_id: str,
+    current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
     request: Request = None,
 ) -> CalendarTokenResetResponse:
     """
     Reset calendar subscription token for a person.
 
-    This invalidates the old subscription URL and generates a new one.
-    Use this if the subscription URL has been compromised.
+    This invalidates the old subscription URL and generates a new one. Caller
+    must be the target person or an admin in the same organization. Use
+    `/calendar/{person_id}/admin-reset` for the admin-only flow.
     """
     # Verify person exists
     person = db.query(Person).filter(Person.id == person_id).first()
@@ -182,11 +205,24 @@ def reset_calendar_token(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Person '{person_id}' not found",
         )
+    _ensure_self_or_same_org_admin(current_user, person)
 
     # Generate new token
     person.calendar_token = generate_calendar_token()
     db.commit()
     db.refresh(person)
+
+    log_audit_event(
+        db,
+        action=AuditAction.CALENDAR_TOKEN_RESET,
+        user_id=current_user.id,
+        user_email=current_user.email,
+        organization_id=person.org_id,
+        resource_type="person",
+        resource_id=person.id,
+        ip_address=request.client.host if request and request.client else None,
+        user_agent=request.headers.get("user-agent") if request else None,
+    )
 
     # Get base URL
     base_url = get_base_url(request) if request else "http://localhost:8000"
@@ -200,6 +236,59 @@ def reset_calendar_token(
         webcal_url=webcal_url,
         https_url=https_url,
         message="Calendar token has been reset. Update your calendar subscription with the new URL.",
+    )
+
+
+@router.post("/{person_id}/admin-reset")
+def admin_reset_calendar_token(
+    person_id: str,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+    request: Request = None,
+) -> CalendarTokenResetResponse:
+    """
+    Admin-only force-reset of another user's calendar token.
+
+    Same as `/calendar/reset-token` but explicitly an admin override of a
+    target user's token. Always audited as `calendar.token.admin_reset`.
+    """
+    person = db.query(Person).filter(Person.id == person_id).first()
+    if not person:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Person '{person_id}' not found",
+        )
+    if current_admin.org_id != person.org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied: not a member of this organization",
+        )
+
+    person.calendar_token = generate_calendar_token()
+    db.commit()
+    db.refresh(person)
+
+    log_audit_event(
+        db,
+        action=AuditAction.CALENDAR_TOKEN_ADMIN_RESET,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=person.org_id,
+        resource_type="person",
+        resource_id=person.id,
+        ip_address=request.client.host if request and request.client else None,
+        user_agent=request.headers.get("user-agent") if request else None,
+    )
+
+    base_url = get_base_url(request) if request else "http://localhost:8000"
+    webcal_url = generate_webcal_url(base_url, person.calendar_token)
+    https_url = generate_https_feed_url(base_url, person.calendar_token)
+
+    return CalendarTokenResetResponse(
+        token=person.calendar_token,
+        webcal_url=webcal_url,
+        https_url=https_url,
+        message=f"Calendar token for {person.id} has been reset by admin.",
     )
 
 

--- a/tests/api/test_calendar_auth.py
+++ b/tests/api/test_calendar_auth.py
@@ -1,0 +1,211 @@
+"""Calendar auth-gap tests (Sprint 4 PR 4.5).
+
+Previously `/calendar/subscribe` and `/calendar/reset-token` accepted any
+`person_id` query param with no auth check. After this PR they require an
+authenticated user who is either the owner or an admin in the same org. A
+new admin-only `/calendar/{person_id}/admin-reset` endpoint forces a token
+reset on a different user. Both reset paths are audited.
+"""
+
+import pytest
+
+from api.models import AuditAction, AuditLog
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(client, org_id, email=f"admin-{suffix}@o.org", name="Admin", password="AdminPass1!")
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _person_id_for_email(client, headers, email: str) -> str:
+    """Look up the auto-generated person_id for an email via /people/me."""
+    resp = client.get("/api/v1/people/me", headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    if body["email"] == email:
+        return body["id"]
+    raise AssertionError(f"expected {email}, got {body['email']}")
+
+
+@pytest.mark.no_mock_auth
+class TestSubscribeAuth:
+    def test_no_auth_rejected(self, client, db):
+        org_id = "cal-noauth"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "noauth")
+        my_id = _person_id_for_email(client, admin_hdrs, "admin-noauth@o.org")
+
+        resp = client.get(f"/api/v1/calendar/subscribe?person_id={my_id}")
+        assert resp.status_code in (401, 403)
+
+    def test_self_can_subscribe(self, client, db):
+        org_id = "cal-self"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "self")
+        my_id = _person_id_for_email(client, hdrs, "admin-self@o.org")
+
+        resp = client.get(f"/api/v1/calendar/subscribe?person_id={my_id}", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+
+    def test_admin_can_subscribe_other_in_same_org(self, client, db):
+        org_id = "cal-admin-other"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "admin-other-a")
+        seed_user(
+            client,
+            org_id,
+            email="other@o.org",
+            name="Other",
+            password="OtherPass1!",
+            roles=["volunteer"],
+        )
+        other_hdrs = auth_headers(client, email="other@o.org", password="OtherPass1!")
+        other_id = _person_id_for_email(client, other_hdrs, "other@o.org")
+
+        resp = client.get(f"/api/v1/calendar/subscribe?person_id={other_id}", headers=admin_hdrs)
+        assert resp.status_code == 200, resp.text
+
+    def test_volunteer_cannot_subscribe_other(self, client, db):
+        org_id = "cal-vol-block"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "vol-block-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol1@o.org",
+            name="Vol1",
+            password="V1Pass1!",
+            roles=["volunteer"],
+        )
+        seed_user(
+            client,
+            org_id,
+            email="vol2@o.org",
+            name="Vol2",
+            password="V2Pass1!",
+            roles=["volunteer"],
+        )
+        v1_hdrs = auth_headers(client, email="vol1@o.org", password="V1Pass1!")
+        v2_hdrs = auth_headers(client, email="vol2@o.org", password="V2Pass1!")
+        v2_id = _person_id_for_email(client, v2_hdrs, "vol2@o.org")
+
+        resp = client.get(f"/api/v1/calendar/subscribe?person_id={v2_id}", headers=v1_hdrs)
+        assert resp.status_code == 403
+
+    def test_cross_org_admin_blocked(self, client, db):
+        seed_org(client, "cal-org-a")
+        seed_org(client, "cal-org-b")
+        a_hdrs = _admin_for(client, "cal-org-a", "x-a")
+        b_hdrs = _admin_for(client, "cal-org-b", "x-b")
+        b_id = _person_id_for_email(client, b_hdrs, "admin-x-b@o.org")
+
+        resp = client.get(f"/api/v1/calendar/subscribe?person_id={b_id}", headers=a_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestResetToken:
+    def test_self_reset_emits_audit(self, client, db):
+        org_id = "cal-reset-self"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "reset-self")
+        my_id = _person_id_for_email(client, hdrs, "admin-reset-self@o.org")
+
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.CALENDAR_TOKEN_RESET).count()
+        )
+        resp = client.post(f"/api/v1/calendar/reset-token?person_id={my_id}", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        after = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.CALENDAR_TOKEN_RESET).count()
+        )
+        assert after == before + 1
+
+    def test_volunteer_cannot_reset_other(self, client, db):
+        org_id = "cal-reset-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "reset-vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="r1@o.org",
+            name="R1",
+            password="R1Pass1!",
+            roles=["volunteer"],
+        )
+        seed_user(
+            client,
+            org_id,
+            email="r2@o.org",
+            name="R2",
+            password="R2Pass1!",
+            roles=["volunteer"],
+        )
+        r1_hdrs = auth_headers(client, email="r1@o.org", password="R1Pass1!")
+        r2_hdrs = auth_headers(client, email="r2@o.org", password="R2Pass1!")
+        r2_id = _person_id_for_email(client, r2_hdrs, "r2@o.org")
+
+        resp = client.post(f"/api/v1/calendar/reset-token?person_id={r2_id}", headers=r1_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestAdminReset:
+    def test_admin_reset_other_emits_admin_audit(self, client, db):
+        org_id = "cal-admin-reset"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "admin-reset-a")
+        seed_user(
+            client,
+            org_id,
+            email="targ@o.org",
+            name="Target",
+            password="TargPass1!",
+            roles=["volunteer"],
+        )
+        targ_hdrs = auth_headers(client, email="targ@o.org", password="TargPass1!")
+        targ_id = _person_id_for_email(client, targ_hdrs, "targ@o.org")
+
+        before = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.CALENDAR_TOKEN_ADMIN_RESET)
+            .count()
+        )
+        resp = client.post(f"/api/v1/calendar/{targ_id}/admin-reset", headers=admin_hdrs)
+        assert resp.status_code == 200, resp.text
+        after = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == AuditAction.CALENDAR_TOKEN_ADMIN_RESET)
+            .count()
+        )
+        assert after == before + 1
+
+    def test_volunteer_cannot_admin_reset(self, client, db):
+        org_id = "cal-admin-reset-vol"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "vol-block-aadmin")
+        seed_user(
+            client,
+            org_id,
+            email="v3@o.org",
+            name="V3",
+            password="V3Pass1!",
+            roles=["volunteer"],
+        )
+        v3_hdrs = auth_headers(client, email="v3@o.org", password="V3Pass1!")
+        # Target the admin, attempt as volunteer.
+        admin_id = _person_id_for_email(client, admin_hdrs, "admin-vol-block-aadmin@o.org")
+
+        resp = client.post(f"/api/v1/calendar/{admin_id}/admin-reset", headers=v3_hdrs)
+        assert resp.status_code == 403
+
+    def test_admin_cross_org_blocked(self, client, db):
+        seed_org(client, "cal-cr-a")
+        seed_org(client, "cal-cr-b")
+        a_hdrs = _admin_for(client, "cal-cr-a", "cr-a")
+        b_hdrs = _admin_for(client, "cal-cr-b", "cr-b")
+        b_id = _person_id_for_email(client, b_hdrs, "admin-cr-b@o.org")
+
+        resp = client.post(f"/api/v1/calendar/{b_id}/admin-reset", headers=a_hdrs)
+        assert resp.status_code == 403

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -3820,7 +3820,7 @@
     },
     "/api/v1/calendar/reset-token": {
       "post": {
-        "description": "Reset calendar subscription token for a person.\n\nThis invalidates the old subscription URL and generates a new one.\nUse this if the subscription URL has been compromised.",
+        "description": "Reset calendar subscription token for a person.\n\nThis invalidates the old subscription URL and generates a new one. Caller\nmust be the target person or an admin in the same organization. Use\n`/calendar/{person_id}/admin-reset` for the admin-only flow.",
         "operationId": "resetCalendarToken",
         "parameters": [
           {
@@ -3855,6 +3855,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Reset Calendar Token",
         "tags": [
           "calendar"
@@ -3863,7 +3868,7 @@
     },
     "/api/v1/calendar/subscribe": {
       "get": {
-        "description": "Get calendar subscription URL for a person.\n\nReturns a webcal:// URL that can be used to subscribe to the calendar\nin Google Calendar, Apple Calendar, Outlook, etc.",
+        "description": "Get calendar subscription URL for a person.\n\nReturns a webcal:// URL that can be used to subscribe to the calendar\nin Google Calendar, Apple Calendar, Outlook, etc. Caller must be the\ntarget person or an admin in the same organization.",
         "operationId": "getSubscriptionUrl",
         "parameters": [
           {
@@ -3898,7 +3903,60 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Get Subscription Url",
+        "tags": [
+          "calendar"
+        ]
+      }
+    },
+    "/api/v1/calendar/{person_id}/admin-reset": {
+      "post": {
+        "description": "Admin-only force-reset of another user's calendar token.\n\nSame as `/calendar/reset-token` but explicitly an admin override of a\ntarget user's token. Always audited as `calendar.token.admin_reset`.",
+        "operationId": "adminResetCalendarToken",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarTokenResetResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Reset Calendar Token",
         "tags": [
           "calendar"
         ]

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -120,7 +120,7 @@ class TestCalendarExportAPI:
         # Create organization
         client.post(
             f"{API_BASE}/organizations/",
-            json={"id": "calendar_test_org", "name": "Calendar Test Org"},
+            json={"id": "test_org", "name": "Calendar Test Org"},
         )
 
         # Create person
@@ -128,7 +128,7 @@ class TestCalendarExportAPI:
             f"{API_BASE}/people/",
             json={
                 "id": "calendar_person_1",
-                "org_id": "calendar_test_org",
+                "org_id": "test_org",
                 "name": "Test User",
                 "email": "testuser@example.com",
                 "roles": ["volunteer"],
@@ -138,7 +138,7 @@ class TestCalendarExportAPI:
 
         # Create resource
         client.post(
-            f"{API_BASE}/organizations/calendar_test_org/resources",
+            f"{API_BASE}/organizations/test_org/resources",
             json={"id": "resource_1", "type": "venue", "location": "Test Church Building"},
         )
 
@@ -150,7 +150,7 @@ class TestCalendarExportAPI:
             f"{API_BASE}/events/",
             json={
                 "id": "calendar_event_1",
-                "org_id": "calendar_test_org",
+                "org_id": "test_org",
                 "type": "Sunday Service",
                 "start_time": start_time,
                 "end_time": end_time,
@@ -360,9 +360,9 @@ class TestCalendarIntegration:
 
     def test_complete_subscription_workflow(self, client):
         """Test complete workflow: create person -> subscribe -> feed."""
-        # 1. Create organization
+        # 1. Create organization (use mocked admin's org for auth)
         client.post(
-            f"{API_BASE}/organizations/", json={"id": "workflow_org", "name": "Workflow Test Org"}
+            f"{API_BASE}/organizations/", json={"id": "test_org", "name": "Workflow Test Org"}
         )
 
         # 2. Create person
@@ -370,7 +370,7 @@ class TestCalendarIntegration:
             f"{API_BASE}/people/",
             json={
                 "id": "workflow_person",
-                "org_id": "workflow_org",
+                "org_id": "test_org",
                 "name": "Workflow User",
                 "email": "workflow@example.com",
                 "roles": ["volunteer"],


### PR DESCRIPTION
## Summary

`/calendar/subscribe` and `/calendar/reset-token` previously accepted any `person_id` query param with no auth check, leaking subscription URLs of arbitrary users. This PR requires an authenticated user who is either the target or an admin in the same org, adds an admin-only `POST /calendar/{person_id}/admin-reset` that forces a token reset on a different user, and audits both reset paths.

| Endpoint | Method | Auth |
| --- | --- | --- |
| `/calendar/subscribe?person_id=` | GET | self OR admin in same org |
| `/calendar/reset-token?person_id=` | POST | self OR admin in same org → audit `calendar.token.reset` |
| `/calendar/{person_id}/admin-reset` | POST | admin (same org only) → audit `calendar.token.admin_reset` |

## Changed files

- `api/routers/calendar.py` — `_ensure_self_or_same_org_admin` helper, auth deps, new `admin_reset_calendar_token` endpoint, audit logging on both reset paths.
- `api/models.py` — `AuditAction.CALENDAR_TOKEN_RESET`, `CALENDAR_TOKEN_ADMIN_RESET`.
- `tests/api/test_calendar_auth.py` — 10 tests covering no-auth, self, admin-other-same-org, volunteer-blocked, cross-org-blocked, self-reset audited, volunteer-cannot-reset-other, admin-reset-other audited, volunteer-cannot-admin-reset, admin-cross-org-blocked.
- `tests/contract/openapi.snapshot.json` — refreshed.

## Test plan

- [x] `poetry run pytest tests/api/test_calendar_auth.py -q` — 10 passed.
- [x] `poetry run pytest tests/api tests/contract -q` — 163 passed.
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.

## Follow-ups

- Sprint 4 PR 4.6 (resurrect tests/integration tier).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaBYNVL7Yvu2bcCmkfAyzC)_