### PR TITLE
Sprint 4 PR 4.6a: Restore integration api_server fixture + sentinel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
       - name: OpenAPI contract snapshot
         run: poetry run pytest tests/contract/ -v --tb=short
 
+      - name: Integration tests
+        # Sprint 4 PR 4.6a brought back the api_server fixture and a smoke
+        # test. PR 4.6b is reviving the previously-failing files; until then
+        # they're skip-marked at module scope.
+        run: poetry run pytest tests/integration/ -v --tb=short
+
       - name: Alembic upgrade head (PostgreSQL)
         env:
           DATABASE_URL: postgresql+psycopg2://signupflow:signupflow@localhost:5432/signupflow_ci

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,125 @@
+"""Integration-tier fixtures (Sprint 4 PR 4.6a).
+
+Resurrects the `api_server` fixture as a uvicorn.Server running in a daemon
+thread on an ephemeral port. Lifespan events fire normally so the API
+behaves like production.
+
+This is the foundation for PR 4.6b which will revive the previously-failing
+integration files file-by-file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import threading
+import time
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import uvicorn
+
+
+def _pick_free_port() -> int:
+    """Bind to an ephemeral port, close, and return the port number."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+class _ServerHandle:
+    """Tiny container for the running uvicorn instance + connection info."""
+
+    def __init__(self, server: uvicorn.Server, host: str, port: int) -> None:
+        self.server = server
+        self.host = host
+        self.port = port
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+
+@pytest.fixture(scope="session")
+def api_server() -> Iterator[_ServerHandle]:
+    """Start uvicorn in a daemon thread on an ephemeral port for the session.
+
+    Tests can hit the server via `api_server.base_url` (e.g.
+    `f"{api_server.base_url}/health"`).
+    """
+    # Disable CSP / rate limits / outbound side-effects for the test process.
+    os.environ.setdefault("TESTING", "true")
+    os.environ.setdefault("DISABLE_RATE_LIMITS", "true")
+    os.environ.setdefault("EMAIL_ENABLED", "false")
+    os.environ.setdefault("SMS_ENABLED", "false")
+    os.environ.setdefault("SECURITY_CSP_ENABLED", "false")
+
+    # Import the app *after* env is set so module-level config picks it up.
+    from api.main import app
+
+    host = "127.0.0.1"
+    port = _pick_free_port()
+
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="warning",
+        lifespan="on",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True, name="api_server")
+    thread.start()
+
+    # Wait for the server to start accepting connections (or fail fast).
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if server.started:
+            break
+        time.sleep(0.05)
+    else:  # pragma: no cover - defensive
+        raise RuntimeError("api_server failed to start within 10s")
+
+    handle = _ServerHandle(server=server, host=host, port=port)
+    try:
+        yield handle
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+
+@pytest.fixture(scope="session")
+def api_client(api_server: _ServerHandle) -> Iterator[httpx.Client]:
+    """Reusable httpx.Client pinned to the running api_server."""
+    with httpx.Client(base_url=api_server.base_url, timeout=10.0) as client:
+        yield client
+
+
+# Override root conftest's autouse fixtures so the integration tier owns its
+# own lifecycle. Without these, tests/conftest.py's reset_database_between_tests
+# fights uvicorn's session-scoped engine.
+@pytest.fixture(autouse=True)
+def mock_authentication() -> Iterator[None]:
+    """Suppress root conftest auth mocking — integration tier uses real HTTP."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def reset_database_between_tests() -> Iterator[None]:
+    """Suppress root conftest DB reset — integration tier owns the DB lifecycle."""
+    yield
+
+
+@contextlib.contextmanager
+def _suppress_keyboard_interrupt() -> Iterator[None]:
+    """Used by the fixture teardown so a slow shutdown doesn't bubble up."""
+    try:
+        yield
+    except KeyboardInterrupt:  # pragma: no cover
+        pass

--- a/tests/integration/test_api_server_smoke.py
+++ b/tests/integration/test_api_server_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke test for the integration-tier `api_server` fixture (Sprint 4 PR 4.6a).
+
+This test only verifies that:
+  * the uvicorn-in-thread fixture starts on an ephemeral port,
+  * lifespan ran (so the app's startup is complete),
+  * the live server responds over real HTTP.
+
+If this fails, the integration tier's foundation is broken and PR 4.6b
+should not proceed.
+"""
+
+import httpx
+
+
+def test_api_server_starts_and_serves_health(api_server):
+    resp = httpx.get(f"{api_server.base_url}/health", timeout=5.0)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["service"] == "signupflow-api"
+    assert body["status"] == "healthy"
+
+
+def test_api_root_redirects_to_v1(api_client):
+    resp = api_client.get("/api/v1", follow_redirects=False)
+    assert resp.status_code == 200, resp.text
+
+
+def test_openapi_schema_exposed(api_client):
+    resp = api_client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    # The schema should at minimum advertise the /api/v1 prefix that all
+    # routers use.
+    paths = schema.get("paths", {})
+    assert any(path.startswith("/api/v1") for path in paths)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -13,6 +13,10 @@ from datetime import datetime
 import httpx
 import pytest
 
+# Sprint 4 PR 4.6a: file-level skip until PR 4.6b updates these tests to use
+# the new `api_server.base_url` instead of the hard-coded port 8001.
+pytestmark = pytest.mark.skip(reason="awaiting PR 4.6b base-url migration")
+
 API_BASE = "http://localhost:8001/api"
 
 

--- a/tests/integration/test_invitations.py
+++ b/tests/integration/test_invitations.py
@@ -16,6 +16,11 @@ import time
 import httpx
 import pytest
 
+# Sprint 4 PR 4.6a: file-level skip until PR 4.6b updates these tests to use
+# the new `api_server.base_url` and stops depending on the deleted
+# `app_config` fixture.
+pytestmark = pytest.mark.skip(reason="awaiting PR 4.6b base-url + app_config migration")
+
 
 @pytest.fixture
 def setup_test_org(api_server, app_config):


### PR DESCRIPTION
## Summary

Brings back the integration tier with a clean uvicorn-in-thread fixture on an ephemeral port and a 3-test sentinel that proves the fixture works (health, /api/v1 root, /openapi.json). The two pre-existing files that depend on the deleted `app_config` fixture and hard-coded port 8001 are file-level skipped pending **PR 4.6b**. CI now runs the integration tier as a required step.

Per the run brief, this is the **4.6a slice** — fixture + sentinel only — deferring file-by-file revival to **4.6b**.

## Changed files

- `tests/integration/conftest.py` (new) — `api_server` session fixture using uvicorn.Server in a daemon thread, `lifespan="on"`, ephemeral port via `socket.bind("127.0.0.1", 0)`. Reusable `api_client` httpx fixture. Overrides root conftest's auth/db autouse fixtures so the integration tier owns its own lifecycle.
- `tests/integration/test_api_server_smoke.py` (new) — 3 sentinel tests covering `/health`, `/api/v1`, `/openapi.json` reachability.
- `tests/integration/test_auth.py` — `pytestmark = skip` until PR 4.6b ports off the hard-coded port 8001.
- `tests/integration/test_invitations.py` — `pytestmark = skip` until PR 4.6b ports off the deleted `app_config` fixture.
- `.github/workflows/ci.yml` — new "Integration tests" required step between contract snapshot and the alembic Postgres step.

## Test plan

- [x] `poetry run pytest tests/integration -q` — 21 passed (18 tenancy_guard + 3 smoke), 22 skipped (auth + invitations).
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.

## Follow-ups

- **PR 4.6b** — revive the 22 skip-marked tests file-by-file. Once that lands, the base-url + `app_config` migration goes away.
- PR 4.7 (mypy strict for api/utils) deferred — needs ~108 type-annotation fixes which exceeds a single autopilot slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaBYNVL7Yvu2bcCmkfAyzC)_