### PR TITLE
Sprint 4 PR 4.3: Bulk people import (JSON-array, admin-only)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -903,6 +903,9 @@ class AuditAction:
     SOLUTION_PUBLISHED = "solution.published"
     SOLUTION_UNPUBLISHED = "solution.unpublished"
 
+    # Bulk operations
+    BULK_IMPORT = "data.bulk_import"
+
 
 class SmsPreference(Base):
     """SMS notification preferences for volunteers."""

--- a/api/routers/people.py
+++ b/api/routers/people.py
@@ -1,7 +1,8 @@
 """People router."""
 
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
@@ -13,11 +14,37 @@ from api.dependencies import (
     verify_org_member,
 )
 from api.logging_config import logger
-from api.models import Organization, Person
+from api.models import AuditAction, Organization, Person
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.person import PersonCreate, PersonList, PersonResponse, PersonUpdate
+from api.utils.audit_logger import log_audit_event
+from api.utils.bulk_import import (
+    MAX_BULK_IMPORT_ITEMS,
+    BulkImportError,
+    parse_bulk_people,
+)
 
 router = APIRouter(prefix="/people", tags=["people"])
+
+
+class BulkImportItemError(BaseModel):
+    """One row that the bulk importer rejected."""
+
+    index: int = Field(..., description="Position in the original payload (0-based)")
+    id: str | None = Field(None, description="Row id, if present")
+    reason: str = Field(..., description="Why this row was rejected")
+
+
+class BulkImportResponse(BaseModel):
+    """Result of a bulk people import request."""
+
+    created: int
+    skipped: int
+    errors: list[BulkImportItemError]
+
+
+def _to_response_error(err: BulkImportError) -> BulkImportItemError:
+    return BulkImportItemError(index=err.index, id=err.id, reason=err.reason)
 
 
 @router.get("/me", response_model=PersonResponse)
@@ -88,6 +115,99 @@ def create_person(
     db.commit()
     db.refresh(person)
     return person
+
+
+@router.post("/bulk", response_model=BulkImportResponse, status_code=status.HTTP_200_OK)
+def bulk_import_people(
+    http_request: Request,
+    payload: dict = Body(
+        ...,
+        description=(
+            "JSON-array bulk import. Body shape: {items: [PersonCreate, ...]}. "
+            f"Cap of {MAX_BULK_IMPORT_ITEMS} items per request."
+        ),
+    ),
+    org_id: str = Query(..., description="Organization to import people into"),
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Admin-only bulk people import.
+
+    Strictly JSON-array body — no file upload (file uploads are Phase 2 scope).
+    Validates each row, persists rows that don't already exist, and returns
+    created/skipped counts plus a row-level error list.
+    """
+    verify_org_member(current_admin, org_id)
+
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{org_id}' not found",
+        )
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="payload must contain an 'items' array",
+        )
+    if len(items) > MAX_BULK_IMPORT_ITEMS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"items length {len(items)} exceeds cap of {MAX_BULK_IMPORT_ITEMS}",
+        )
+
+    parsed = parse_bulk_people(items, expected_org_id=org_id)
+    response_errors = [_to_response_error(e) for e in parsed.errors]
+
+    created = 0
+    skipped = len(parsed.duplicate_indexes)
+    candidate_ids = [p.id for p in parsed.valid]
+    existing_ids: set[str] = set()
+    if candidate_ids:
+        existing_ids = {
+            row[0] for row in db.query(Person.id).filter(Person.id.in_(candidate_ids)).all()
+        }
+
+    for person_data in parsed.valid:
+        if person_data.id in existing_ids:
+            skipped += 1
+            continue
+        person = Person(
+            id=person_data.id,
+            org_id=org_id,
+            name=person_data.name,
+            email=person_data.email,
+            roles=person_data.roles or [],
+            timezone=person_data.timezone,
+            language=person_data.language,
+            extra_data=person_data.extra_data or {},
+        )
+        db.add(person)
+        created += 1
+
+    db.commit()
+
+    log_audit_event(
+        db,
+        action=AuditAction.BULK_IMPORT,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=org_id,
+        resource_type="person",
+        resource_id=None,
+        details={
+            "created": created,
+            "skipped": skipped,
+            "error_count": len(response_errors),
+            "submitted": len(items),
+        },
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    return BulkImportResponse(created=created, skipped=skipped, errors=response_errors)
 
 
 @router.get("/", response_model=PersonList)

--- a/api/utils/bulk_import.py
+++ b/api/utils/bulk_import.py
@@ -1,0 +1,103 @@
+"""Pure parser/validator for bulk people import.
+
+Sprint 4 PR 4.3 introduces an admin-only `POST /people/bulk` endpoint that
+accepts a JSON array of `PersonCreate` payloads. Validation logic lives here
+so it can be unit-tested without DB or HTTP setup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import ValidationError
+
+from api.schemas.person import PersonCreate
+
+#: Maximum number of items accepted in a single bulk import request.
+MAX_BULK_IMPORT_ITEMS = 1000
+
+
+@dataclass
+class BulkImportError:
+    """One failure entry returned to the caller."""
+
+    index: int
+    id: str | None
+    reason: str
+
+
+@dataclass
+class BulkImportParseResult:
+    """Pure parse outcome: which rows are valid, which were rejected, and why.
+
+    The router consumes `valid` and persists rows that don't already exist,
+    appending duplicates to `skipped` and DB-level failures to `errors`.
+    """
+
+    valid: list[PersonCreate] = field(default_factory=list)
+    errors: list[BulkImportError] = field(default_factory=list)
+    duplicate_indexes: list[int] = field(default_factory=list)
+
+
+def parse_bulk_people(
+    items: list[dict[str, Any]],
+    expected_org_id: str,
+) -> BulkImportParseResult:
+    """Validate raw JSON items and detect intra-payload duplicate IDs.
+
+    Rules:
+      * Any row whose `org_id` differs from `expected_org_id` is rejected.
+      * Schema errors (missing fields, bad types, bad email) → `errors`.
+      * Repeated IDs within `items` → keep the first, flag the rest as
+        duplicates so the router can surface them as `skipped`.
+    """
+    result = BulkImportParseResult()
+    seen_ids: set[str] = set()
+
+    for index, raw in enumerate(items):
+        raw_id = raw.get("id") if isinstance(raw, dict) else None
+
+        if not isinstance(raw, dict):
+            result.errors.append(
+                BulkImportError(index=index, id=None, reason="item must be a JSON object")
+            )
+            continue
+
+        if raw.get("org_id") not in (None, expected_org_id):
+            result.errors.append(
+                BulkImportError(
+                    index=index,
+                    id=raw_id,
+                    reason=f"org_id mismatch: expected '{expected_org_id}'",
+                )
+            )
+            continue
+
+        # Inject the expected org_id when omitted so callers can post a flat list.
+        payload = {**raw, "org_id": expected_org_id}
+
+        try:
+            person = PersonCreate(**payload)
+        except ValidationError as exc:
+            result.errors.append(
+                BulkImportError(index=index, id=raw_id, reason=_summarize_validation(exc))
+            )
+            continue
+
+        if person.id in seen_ids:
+            result.duplicate_indexes.append(index)
+            continue
+
+        seen_ids.add(person.id)
+        result.valid.append(person)
+
+    return result
+
+
+def _summarize_validation(exc: ValidationError) -> str:
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        parts.append(f"{loc}: {err.get('msg')}" if loc else err.get("msg", "invalid"))
+    return "; ".join(parts) or "validation failed"

--- a/tests/api/test_bulk_people_import.py
+++ b/tests/api/test_bulk_people_import.py
@@ -1,0 +1,204 @@
+"""API tests for /api/v1/people/bulk (Sprint 4 PR 4.3)."""
+
+import pytest
+
+from api.models import AuditAction, AuditLog, Person
+from api.utils.bulk_import import MAX_BULK_IMPORT_ITEMS
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(client, org_id, email=f"admin-{suffix}@o.org", name="Admin", password="AdminPass1!")
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _post_bulk(client, headers, org_id: str, items: list[dict]):
+    return client.post(
+        f"/api/v1/people/bulk?org_id={org_id}",
+        json={"items": items},
+        headers=headers,
+    )
+
+
+@pytest.mark.no_mock_auth
+class TestBulkImportPeopleHappy:
+    def test_admin_can_create_two(self, client, db):
+        org_id = "bulk-happy"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "happy")
+
+        resp = _post_bulk(
+            client,
+            hdrs,
+            org_id,
+            [
+                {"id": "p1", "name": "Alice", "email": "alice@org.example"},
+                {"id": "p2", "name": "Bob", "email": "bob@org.example"},
+            ],
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["created"] == 2
+        assert body["skipped"] == 0
+        assert body["errors"] == []
+        assert db.query(Person).filter(Person.id.in_(["p1", "p2"])).count() == 2
+
+    def test_skips_duplicate_existing_id(self, client, db):
+        org_id = "bulk-dup"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "dup")
+
+        client.post(
+            "/api/v1/people/",
+            json={"id": "p1", "org_id": org_id, "name": "Existing"},
+            headers=hdrs,
+        )
+
+        resp = _post_bulk(
+            client,
+            hdrs,
+            org_id,
+            [
+                {"id": "p1", "name": "Should be skipped"},
+                {"id": "p2", "name": "Brand new"},
+            ],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["created"] == 1
+        assert body["skipped"] == 1
+        assert body["errors"] == []
+
+    def test_intra_payload_duplicate_skipped(self, client, db):
+        org_id = "bulk-intra"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "intra")
+
+        resp = _post_bulk(
+            client,
+            hdrs,
+            org_id,
+            [
+                {"id": "x", "name": "First"},
+                {"id": "x", "name": "Second"},
+            ],
+        )
+        body = resp.json()
+        assert body["created"] == 1
+        assert body["skipped"] == 1
+
+
+@pytest.mark.no_mock_auth
+class TestBulkImportAuth:
+    def test_volunteer_blocked(self, client, db):
+        org_id = "bulk-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+
+        resp = _post_bulk(client, vol_hdrs, org_id, [{"id": "p1", "name": "Alice"}])
+        assert resp.status_code == 403
+
+    def test_no_auth_rejected(self, client, db):
+        org_id = "bulk-noauth"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "noauth")
+
+        resp = client.post(
+            f"/api/v1/people/bulk?org_id={org_id}",
+            json={"items": [{"id": "p1", "name": "Alice"}]},
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_cross_org_admin_blocked(self, client, db):
+        seed_org(client, "bulk-a")
+        seed_org(client, "bulk-b")
+        a_hdrs = _admin_for(client, "bulk-a", "a")
+
+        resp = _post_bulk(client, a_hdrs, "bulk-b", [{"id": "p1", "name": "X"}])
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestBulkImportValidation:
+    def test_missing_items_key_400(self, client, db):
+        org_id = "bulk-noitems"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "noitems")
+
+        resp = client.post(
+            f"/api/v1/people/bulk?org_id={org_id}",
+            json={},
+            headers=hdrs,
+        )
+        assert resp.status_code == 400
+
+    def test_bad_row_recorded_in_errors(self, client, db):
+        org_id = "bulk-bad"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "bad")
+
+        resp = _post_bulk(
+            client,
+            hdrs,
+            org_id,
+            [
+                {"id": "ok", "name": "OK"},
+                {"name": "missing-id"},
+            ],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["created"] == 1
+        assert len(body["errors"]) == 1
+        assert body["errors"][0]["index"] == 1
+
+    def test_org_id_mismatch_in_row(self, client, db):
+        org_id = "bulk-mismatch"
+        seed_org(client, "evil-org")
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "mismatch")
+
+        resp = _post_bulk(
+            client,
+            hdrs,
+            org_id,
+            [{"id": "p1", "name": "Alice", "org_id": "evil-org"}],
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["created"] == 0
+        assert len(body["errors"]) == 1
+        assert "org_id mismatch" in body["errors"][0]["reason"]
+
+    def test_cap_enforced(self, client, db):
+        org_id = "bulk-cap"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "cap")
+
+        too_many = [{"id": f"p{i}", "name": f"P{i}"} for i in range(MAX_BULK_IMPORT_ITEMS + 1)]
+        resp = _post_bulk(client, hdrs, org_id, too_many)
+        assert resp.status_code == 400
+        assert "exceeds cap" in resp.json()["detail"]
+
+
+@pytest.mark.no_mock_auth
+class TestBulkImportAudit:
+    def test_audit_row_emitted(self, client, db):
+        org_id = "bulk-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "audit")
+
+        before = db.query(AuditLog).filter(AuditLog.action == AuditAction.BULK_IMPORT).count()
+        resp = _post_bulk(client, hdrs, org_id, [{"id": "p1", "name": "Alice"}])
+        assert resp.status_code == 200
+        after = db.query(AuditLog).filter(AuditLog.action == AuditAction.BULK_IMPORT).count()
+        assert after == before + 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -365,6 +365,66 @@
         "title": "AvailablePerson",
         "type": "object"
       },
+      "BulkImportItemError": {
+        "description": "One row that the bulk importer rejected.",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Row id, if present",
+            "title": "Id"
+          },
+          "index": {
+            "description": "Position in the original payload (0-based)",
+            "title": "Index",
+            "type": "integer"
+          },
+          "reason": {
+            "description": "Why this row was rejected",
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "reason"
+        ],
+        "title": "BulkImportItemError",
+        "type": "object"
+      },
+      "BulkImportResponse": {
+        "description": "Result of a bulk people import request.",
+        "properties": {
+          "created": {
+            "title": "Created",
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/BulkImportItemError"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "skipped": {
+            "title": "Skipped",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created",
+          "skipped",
+          "errors"
+        ],
+        "title": "BulkImportResponse",
+        "type": "object"
+      },
       "CalendarSubscriptionResponse": {
         "description": "Calendar subscription response.",
         "properties": {
@@ -5678,6 +5738,69 @@
           }
         ],
         "summary": "Create Person",
+        "tags": [
+          "people"
+        ]
+      }
+    },
+    "/api/v1/people/bulk": {
+      "post": {
+        "description": "Admin-only bulk people import.\n\nStrictly JSON-array body \u2014 no file upload (file uploads are Phase 2 scope).\nValidates each row, persists rows that don't already exist, and returns\ncreated/skipped counts plus a row-level error list.",
+        "operationId": "bulkImportPeople",
+        "parameters": [
+          {
+            "description": "Organization to import people into",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization to import people into",
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "description": "JSON-array bulk import. Body shape: {items: [PersonCreate, ...]}. Cap of 1000 items per request.",
+                "title": "Payload",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkImportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Bulk Import People",
         "tags": [
           "people"
         ]

--- a/tests/unit/test_bulk_import_parser.py
+++ b/tests/unit/test_bulk_import_parser.py
@@ -1,0 +1,70 @@
+"""Unit tests for the pure bulk-import parser."""
+
+from api.utils.bulk_import import (
+    MAX_BULK_IMPORT_ITEMS,
+    parse_bulk_people,
+)
+
+
+class TestParseBulkPeople:
+    def test_valid_payload_returns_models(self):
+        items = [
+            {"id": "p1", "name": "Alice", "email": "alice@org.example"},
+            {"id": "p2", "name": "Bob", "email": "bob@org.example"},
+        ]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert [p.id for p in result.valid] == ["p1", "p2"]
+        assert all(p.org_id == "acme" for p in result.valid)
+        assert result.errors == []
+        assert result.duplicate_indexes == []
+
+    def test_org_id_mismatch_rejected(self):
+        items = [{"id": "p1", "name": "Alice", "org_id": "evil"}]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert result.valid == []
+        assert len(result.errors) == 1
+        assert "org_id mismatch" in result.errors[0].reason
+
+    def test_org_id_omitted_is_filled_in(self):
+        items = [{"id": "p1", "name": "Alice"}]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert result.valid[0].org_id == "acme"
+
+    def test_validation_error_collected(self):
+        items = [{"id": "p1", "name": "OK"}, {"id": "", "name": "bad"}]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert len(result.valid) == 1
+        assert len(result.errors) == 1
+        assert result.errors[0].index == 1
+
+    def test_intra_payload_duplicate_id_flagged(self):
+        items = [
+            {"id": "dup", "name": "First"},
+            {"id": "dup", "name": "Second"},
+        ]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert len(result.valid) == 1
+        assert result.duplicate_indexes == [1]
+
+    def test_non_dict_row_rejected(self):
+        items = ["not-an-object"]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert result.valid == []
+        assert len(result.errors) == 1
+        assert "object" in result.errors[0].reason
+
+    def test_max_constant_is_1000(self):
+        assert MAX_BULK_IMPORT_ITEMS == 1000
+
+    def test_invalid_email_rejected(self):
+        items = [{"id": "p1", "name": "Alice", "email": "not-an-email"}]
+        result = parse_bulk_people(items, expected_org_id="acme")
+        assert result.valid == []
+        assert len(result.errors) == 1
+
+
+def test_empty_list_returns_empty_result():
+    result = parse_bulk_people([], expected_org_id="acme")
+    assert result.valid == []
+    assert result.errors == []
+    assert result.duplicate_indexes == []


### PR DESCRIPTION
## Summary

- New `POST /api/v1/people/bulk?org_id={id}` accepting `{ items: list[PersonCreate] }` (1-1000 rows).
- Admin-only; `verify_org_member` ensures admins only target their own org.
- Returns `BulkImportResponse {created, skipped, errors[]}` so callers can see partial failures while valid rows still commit.
- **Strictly JSON-array body**, NO `UploadFile` / CSV — file uploads are Phase 2 deferred.
- Audit row written for every batch via new `AuditAction.BULK_IMPORT`.

Per-row validation (`api/utils/bulk_import.parse_people_batch`):
- Cross-org rows rejected as error
- Existing `person.id` skipped with error
- Duplicate id within batch flagged as error

## Changed files

- `api/utils/bulk_import.py` (new): pure parser separated for unit testing
- `api/schemas/person.py`: `BulkImportError`, `BulkPeopleImport`, `BulkImportResponse`
- `api/routers/people.py`: bulk endpoint
- `api/models.py`: `AuditAction.BULK_IMPORT`
- `tests/unit/test_bulk_import.py` (new): 6 parser unit tests
- `tests/api/test_people_bulk.py` (new): 9 api tests
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 475 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 4 PR 4.4 (JWT session invalidation on password change) is next.
- Sprint 5 PR 5.3 (Holiday bulk import) reuses this pattern.