### PR TITLE
Sprint 5 PR 5.1: Register recurring_events router + Pydantic 2 cleanup

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,7 @@ from api.routers import (
     organizations,
     password_reset,
     people,
+    recurring_events,
     solutions,
     solver,
     teams,
@@ -138,6 +139,7 @@ app.include_router(invitations.router, prefix="/api/v1")
 app.include_router(calendar.router, prefix="/api/v1")
 app.include_router(assignments.router, prefix="/api/v1")
 app.include_router(audit.router, prefix="/api/v1")
+app.include_router(recurring_events.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/routers/recurring_events.py
+++ b/api/routers/recurring_events.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.dependencies import get_current_admin_user, get_current_user, verify_org_member
 from api.models import Event, Person, RecurringSeries
+from api.schemas.common import ListResponse, PaginationParams, get_pagination_params
 from api.services.recurrence_generator import (
     RecurrenceGenerationError,
     detect_holiday_conflicts,
@@ -149,7 +150,7 @@ def create_recurring_series(
         id=str(uuid.uuid4()),
         org_id=org_id,
         created_by=current_admin.id,
-        **request.dict(exclude={"start_time"}),
+        **request.model_dump(exclude={"start_time"}),
     )
 
     # Validate series duration
@@ -178,7 +179,7 @@ def create_recurring_series(
         id=temp_series.id,
         org_id=org_id,
         created_by=current_admin.id,
-        **request.dict(exclude={"start_time"}),
+        **request.model_dump(exclude={"start_time"}),
     )
 
     db.add(series)
@@ -205,46 +206,48 @@ def create_recurring_series(
     db.refresh(series)
 
     # Add occurrence count to response
-    response = RecurringSeriesResponse.from_orm(series)
+    response = RecurringSeriesResponse.model_validate(series)
     response.occurrence_preview_count = len(occurrences)
 
     return response
 
 
-@router.get("/recurring-series", response_model=list[RecurringSeriesResponse])
+@router.get("/recurring-series", response_model=ListResponse[RecurringSeriesResponse])
 def list_recurring_series(
     org_id: str = Query(..., description="Organization ID"),
     active_only: bool = Query(True, description="Only return active series"),
+    pagination: PaginationParams = Depends(get_pagination_params),
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """
-    List all recurring series for an organization.
-
-    Returns all series the user has access to (must be in same organization).
-    """
-    # Verify user belongs to organization
+    """List all recurring series for an organization, scoped to the caller's org."""
     verify_org_member(current_user, org_id)
 
     query = db.query(RecurringSeries).filter(RecurringSeries.org_id == org_id)
-
     if active_only:
-        query = query.filter(RecurringSeries.active is True)
+        query = query.filter(RecurringSeries.active.is_(True))
 
-    series_list = query.order_by(RecurringSeries.created_at.desc()).all()
+    total = query.count()
+    series_list = (
+        query.order_by(RecurringSeries.created_at.desc())
+        .offset(pagination.offset)
+        .limit(pagination.limit)
+        .all()
+    )
 
-    # Add occurrence count for each series
     response_list = []
     for series in series_list:
-        response = RecurringSeriesResponse.from_orm(series)
-
-        # Count occurrences
+        response = RecurringSeriesResponse.model_validate(series)
         occurrence_count = db.query(Event).filter(Event.series_id == series.id).count()
         response.occurrence_preview_count = occurrence_count
-
         response_list.append(response)
 
-    return response_list
+    return {
+        "items": response_list,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
 
 
 @router.get("/recurring-series/{series_id}", response_model=RecurringSeriesResponse)
@@ -265,7 +268,7 @@ def get_recurring_series(
     verify_org_member(current_user, series.org_id)
 
     # Add occurrence count
-    response = RecurringSeriesResponse.from_orm(series)
+    response = RecurringSeriesResponse.model_validate(series)
     occurrence_count = db.query(Event).filter(Event.series_id == series.id).count()
     response.occurrence_preview_count = occurrence_count
 
@@ -395,8 +398,11 @@ def delete_recurring_series(
     # Verify admin belongs to same organization
     verify_org_member(current_admin, series.org_id)
 
-    # Delete all occurrences (cascade will delete exceptions)
-    occurrences = db.query(Event).filter(Event.series_id == series_id).all()
+    # Delete all occurrences (cascade will delete exceptions). Scope by both
+    # series_id and org_id so the tenancy guard sees an org_id filter.
+    occurrences = (
+        db.query(Event).filter(Event.series_id == series_id, Event.org_id == series.org_id).all()
+    )
     occurrence_count = len(occurrences)
 
     for occ in occurrences:
@@ -453,4 +459,4 @@ def update_series_template(
     db.commit()
     db.refresh(series)
 
-    return RecurringSeriesResponse.from_orm(series)
+    return RecurringSeriesResponse.model_validate(series)

--- a/tests/api/test_recurring_events.py
+++ b/tests/api/test_recurring_events.py
@@ -1,0 +1,223 @@
+"""Tests for /api/v1/recurring-series — admin-only CRUD on the recurring_events router."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from api.models import Event, RecurringSeries
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@r.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@r.org", password="AdminPass1!")
+
+
+def _weekly_series_payload(title: str = "Weekly Service") -> dict:
+    """Body for a 4-week Sunday series."""
+    today = date.today()
+    return {
+        "title": title,
+        "duration": 60,
+        "location": "Sanctuary",
+        "role_requirements": None,
+        "pattern_type": "weekly",
+        "frequency_interval": 1,
+        "selected_days": ["sunday"],
+        "weekday_position": None,
+        "weekday_name": None,
+        "start_date": today.isoformat(),
+        "start_time": "10:00:00",
+        "end_condition_type": "date",
+        "end_date": (today + timedelta(days=28)).isoformat(),
+        "occurrence_count": None,
+    }
+
+
+@pytest.mark.no_mock_auth
+class TestRecurringSeriesCreate:
+    def test_admin_creates_weekly_series(self, client, db):
+        org = "rec-org-create"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "create")
+
+        resp = client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload(),
+            headers=hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["title"] == "Weekly Service"
+        assert body["occurrence_preview_count"] >= 4
+
+        # Confirm rows landed in the DB and are linked
+        series = db.query(RecurringSeries).filter(RecurringSeries.org_id == org).first()
+        assert series is not None
+        events = db.query(Event).filter(Event.series_id == series.id).count()
+        assert events >= 4
+
+    def test_volunteer_cannot_create(self, client, db):
+        org = "rec-org-vol"
+        seed_org(client, org)
+        _admin(client, org, "vol-admin")
+        seed_user(
+            client,
+            org,
+            email="vol@r.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@r.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload(),
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestRecurringSeriesList:
+    def test_list_returns_listresponse_envelope(self, client, db):
+        org = "rec-org-envelope"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "envelope")
+        client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload(),
+            headers=hdrs,
+        )
+
+        resp = client.get(f"/api/v1/recurring-series?org_id={org}", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "items" in body
+        assert "total" in body
+        assert "limit" in body
+        assert "offset" in body
+        assert body["total"] >= 1
+
+    def test_active_only_filter_actually_filters(self, client, db):
+        """Regression for the `active is True` Python identity bug.
+
+        Before the fix, this filter always evaluated to False in SQL and the
+        endpoint returned an empty list regardless of `active` column values.
+        """
+        org = "rec-org-activefilter"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "activefilter")
+        client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload("Active Series"),
+            headers=hdrs,
+        )
+
+        # Default active_only=True must include the active series
+        resp = client.get(f"/api/v1/recurring-series?org_id={org}&active_only=true", headers=hdrs)
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
+
+    def test_cross_org_blocked(self, client, db):
+        seed_org(client, "rec-a")
+        seed_org(client, "rec-b")
+        a_hdrs = _admin(client, "rec-a", "rec-a-admin")
+
+        resp = client.get("/api/v1/recurring-series?org_id=rec-b", headers=a_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestRecurringSeriesGetAndDelete:
+    def test_get_by_id_returns_series(self, client, db):
+        org = "rec-org-get"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "get")
+        created = client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload(),
+            headers=hdrs,
+        ).json()
+        sid = created["id"]
+
+        resp = client.get(f"/api/v1/recurring-series/{sid}", headers=hdrs)
+        assert resp.status_code == 200
+        assert resp.json()["id"] == sid
+
+    def test_get_nonexistent_returns_404(self, client, db):
+        org = "rec-org-getnone"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "getnone")
+
+        resp = client.get("/api/v1/recurring-series/no-such", headers=hdrs)
+        assert resp.status_code == 404
+
+    def test_delete_cascades_to_occurrences(self, client, db):
+        org = "rec-org-delete"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "delete")
+        created = client.post(
+            f"/api/v1/recurring-series?org_id={org}",
+            json=_weekly_series_payload(),
+            headers=hdrs,
+        ).json()
+        sid = created["id"]
+
+        # Confirm occurrences exist
+        before = db.query(Event).filter(Event.series_id == sid).count()
+        assert before >= 4
+
+        resp = client.delete(f"/api/v1/recurring-series/{sid}", headers=hdrs)
+        assert resp.status_code in (200, 204)
+
+        # The series row is gone (or soft-deleted); its events should be removed
+        # or detached. We accept either: the cascade is the contract.
+        after_series = db.query(RecurringSeries).filter(RecurringSeries.id == sid).first()
+        if after_series is not None:
+            # Soft-delete path: at minimum, occurrences linked by series_id are gone
+            after_events = db.query(Event).filter(Event.series_id == sid).count()
+            assert after_events == 0
+
+
+@pytest.mark.no_mock_auth
+class TestRecurringSeriesPreview:
+    def test_preview_does_not_create_db_rows(self, client, db):
+        org = "rec-org-preview"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "preview")
+
+        # Preview accepts a narrower PreviewRequest body (subset of create payload)
+        today = date.today()
+        preview_body = {
+            "pattern_type": "weekly",
+            "selected_days": ["sunday"],
+            "frequency_interval": 1,
+            "start_date": today.isoformat(),
+            "start_time": "10:00:00",
+            "duration": 60,
+            "end_condition_type": "date",
+            "end_date": (today + timedelta(days=28)).isoformat(),
+        }
+
+        before_series = db.query(RecurringSeries).count()
+        before_events = db.query(Event).count()
+
+        resp = client.post(
+            f"/api/v1/recurring-series/preview?org_id={org}",
+            json=preview_body,
+            headers=hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+        # Preview returns occurrences but persists nothing
+        assert isinstance(resp.json(), list)
+
+        assert db.query(RecurringSeries).count() == before_series
+        assert db.query(Event).count() == before_events

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1520,6 +1520,37 @@
         "title": "ListResponse[PersonResponse]",
         "type": "object"
       },
+      "ListResponse_RecurringSeriesResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RecurringSeriesResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[RecurringSeriesResponse]",
+        "type": "object"
+      },
       "ListResponse_SolutionResponse_": {
         "properties": {
           "items": {
@@ -1602,6 +1633,78 @@
           "password"
         ],
         "title": "LoginRequest",
+        "type": "object"
+      },
+      "OccurrencePreview": {
+        "description": "Preview of generated occurrences.",
+        "properties": {
+          "end_time": {
+            "format": "date-time",
+            "title": "End Time",
+            "type": "string"
+          },
+          "holiday_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Holiday Label"
+          },
+          "is_holiday_conflict": {
+            "default": false,
+            "title": "Is Holiday Conflict",
+            "type": "boolean"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "occurrence_sequence": {
+            "title": "Occurrence Sequence",
+            "type": "integer"
+          },
+          "role_requirements": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role Requirements"
+          },
+          "start_time": {
+            "format": "date-time",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "occurrence_sequence",
+          "start_time",
+          "end_time",
+          "title",
+          "location",
+          "role_requirements"
+        ],
+        "title": "OccurrencePreview",
         "type": "object"
       },
       "OrganizationCreate": {
@@ -2066,6 +2169,436 @@
           }
         },
         "title": "PersonUpdate",
+        "type": "object"
+      },
+      "PreviewRequest": {
+        "description": "Request for previewing occurrences without saving.",
+        "properties": {
+          "duration": {
+            "title": "Duration",
+            "type": "integer"
+          },
+          "end_condition_type": {
+            "title": "End Condition Type",
+            "type": "string"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "frequency_interval": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Interval"
+          },
+          "occurrence_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occurrence Count"
+          },
+          "pattern_type": {
+            "title": "Pattern Type",
+            "type": "string"
+          },
+          "selected_days": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Days"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "start_time": {
+            "format": "time",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "weekday_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Name"
+          },
+          "weekday_position": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Position"
+          }
+        },
+        "required": [
+          "pattern_type",
+          "start_date",
+          "start_time",
+          "duration",
+          "end_condition_type"
+        ],
+        "title": "PreviewRequest",
+        "type": "object"
+      },
+      "RecurringSeriesCreate": {
+        "description": "Request model for creating recurring series.",
+        "properties": {
+          "duration": {
+            "description": "Duration in minutes",
+            "exclusiveMinimum": 0.0,
+            "title": "Duration",
+            "type": "integer"
+          },
+          "end_condition_type": {
+            "pattern": "^(date|count|indefinite)$",
+            "title": "End Condition Type",
+            "type": "string"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "frequency_interval": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Interval"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "occurrence_count": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "maximum": 200.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occurrence Count"
+          },
+          "pattern_type": {
+            "pattern": "^(weekly|biweekly|monthly|custom)$",
+            "title": "Pattern Type",
+            "type": "string"
+          },
+          "role_requirements": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role Requirements"
+          },
+          "selected_days": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Days"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "start_time": {
+            "format": "time",
+            "title": "Start Time",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "weekday_name": {
+            "anyOf": [
+              {
+                "pattern": "^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Name"
+          },
+          "weekday_position": {
+            "anyOf": [
+              {
+                "pattern": "^(first|second|third|fourth|last)$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Position"
+          }
+        },
+        "required": [
+          "title",
+          "duration",
+          "pattern_type",
+          "start_date",
+          "start_time",
+          "end_condition_type"
+        ],
+        "title": "RecurringSeriesCreate",
+        "type": "object"
+      },
+      "RecurringSeriesResponse": {
+        "description": "Response model for recurring series.",
+        "properties": {
+          "active": {
+            "title": "Active",
+            "type": "boolean"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "title": "Created By",
+            "type": "string"
+          },
+          "duration": {
+            "title": "Duration",
+            "type": "integer"
+          },
+          "end_condition_type": {
+            "title": "End Condition Type",
+            "type": "string"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "frequency_interval": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Interval"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "occurrence_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occurrence Count"
+          },
+          "occurrence_preview_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occurrence Preview Count"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          },
+          "pattern_type": {
+            "title": "Pattern Type",
+            "type": "string"
+          },
+          "role_requirements": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role Requirements"
+          },
+          "selected_days": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected Days"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "weekday_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Name"
+          },
+          "weekday_position": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weekday Position"
+          }
+        },
+        "required": [
+          "id",
+          "org_id",
+          "created_by",
+          "title",
+          "duration",
+          "location",
+          "role_requirements",
+          "pattern_type",
+          "frequency_interval",
+          "selected_days",
+          "weekday_position",
+          "weekday_name",
+          "start_date",
+          "end_condition_type",
+          "end_date",
+          "occurrence_count",
+          "active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "RecurringSeriesResponse",
         "type": "object"
       },
       "SignupRequest": {
@@ -6018,6 +6551,449 @@
         "summary": "Update Person",
         "tags": [
           "people"
+        ]
+      }
+    },
+    "/api/v1/recurring-series": {
+      "get": {
+        "description": "List all recurring series for an organization, scoped to the caller's org.",
+        "operationId": "listRecurringSeries",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only return active series",
+            "in": "query",
+            "name": "active_only",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "Only return active series",
+              "title": "Active Only",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Page size, max 200",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_RecurringSeriesResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Recurring Series",
+        "tags": [
+          "recurring-events"
+        ]
+      },
+      "post": {
+        "description": "Create a new recurring event series and generate all occurrences.\n\nRequires admin access. Creates:\n1. RecurringSeries template\n2. Individual Event occurrences based on pattern\n3. Links occurrences to series\n\nReturns the created series with occurrence count.",
+        "operationId": "createRecurringSeries",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecurringSeriesCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecurringSeriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Recurring Series",
+        "tags": [
+          "recurring-events"
+        ]
+      }
+    },
+    "/api/v1/recurring-series/preview": {
+      "post": {
+        "description": "Preview occurrences for a recurring pattern WITHOUT creating them.\n\nUsed by the UI calendar preview to show occurrences before saving.\nReturns up to 100 occurrences for preview.",
+        "operationId": "previewOccurrences",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OccurrencePreview"
+                  },
+                  "title": "Response Preview Occurrences Api V1 Recurring Series Preview Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Preview Occurrences",
+        "tags": [
+          "recurring-events"
+        ]
+      }
+    },
+    "/api/v1/recurring-series/{series_id}": {
+      "delete": {
+        "description": "Delete a recurring series and all its occurrences.\n\nRequires admin access. Deletes:\n1. All event occurrences linked to series\n2. All exceptions for those occurrences\n3. The series itself\n\nWarning: This is irreversible!",
+        "operationId": "deleteRecurringSeries",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "series_id",
+            "required": true,
+            "schema": {
+              "title": "Series Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Recurring Series",
+        "tags": [
+          "recurring-events"
+        ]
+      },
+      "get": {
+        "description": "Get a specific recurring series by ID.\n\nReturns series details with occurrence count.",
+        "operationId": "getRecurringSeries",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "series_id",
+            "required": true,
+            "schema": {
+              "title": "Series Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecurringSeriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Recurring Series",
+        "tags": [
+          "recurring-events"
+        ]
+      },
+      "put": {
+        "description": "Update the series template (affects future occurrences).\n\nOnly updates the template - existing occurrences are NOT changed.\nUse this to modify what future occurrences will look like.\n\nNote: To modify recurrence pattern, delete and recreate the series.",
+        "operationId": "updateSeriesTemplate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "series_id",
+            "required": true,
+            "schema": {
+              "title": "Series Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "title",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Title"
+            }
+          },
+          {
+            "in": "query",
+            "name": "location",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Location"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Role Requirements"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Series Template",
+        "tags": [
+          "recurring-events"
+        ]
+      }
+    },
+    "/api/v1/recurring-series/{series_id}/occurrences": {
+      "get": {
+        "description": "Get all event occurrences for a recurring series.\n\nReturns list of Event objects with exception indicators.",
+        "operationId": "getSeriesOccurrences",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "series_id",
+            "required": true,
+            "schema": {
+              "title": "Series Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Series Occurrences",
+        "tags": [
+          "recurring-events"
         ]
       }
     },


### PR DESCRIPTION
## Summary

The `api/routers/recurring_events.py` router (~457 LOC of CRUD) existed but was never registered in `api/main.py` — entire surface was dead code. This PR wires it in.

Bonus fixes:
- **Real bug:** `RecurringSeries.active is True` (Python identity check, line 232) → replaced with SQLAlchemy `.is_(True)` so the `active_only` filter actually filters.
- **Pydantic 2 migration:** `request.dict()` → `request.model_dump()` (2 sites); `from_orm` → `model_validate` (5 sites).
- **List envelope:** `GET /recurring-series` now returns `ListResponse[RecurringSeriesResponse]` with shared `PaginationParams`.
- **Tenancy:** Scoped the delete-cascade query by `org_id` so the strict tenancy guard accepts it.

## Changed files

- `api/routers/recurring_events.py`: Pydantic 2 cleanup, active filter bugfix, ListResponse envelope, tenancy-safe delete
- `api/main.py`: import + register router
- `tests/api/test_recurring_events.py` (new): 9 tests
- `tests/contract/openapi.snapshot.json`: refreshed (7 new endpoints exposed)

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 496 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 5 PR 5.2 (Resources CRUD router) is next.
- Holiday CRUD (5.3) follows immediately after.