### PR TITLE
Sprint 4 PR 4.7: mypy strict for api/utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,15 @@ jobs:
       - name: Ruff (lint)
         run: poetry run ruff check api tests
 
+      - name: mypy strict (api/utils)
+        # PR 4.7 made api/utils strict. Failures here block merges.
+        # When you add a new file to api/utils it must satisfy strict mypy.
+        run: poetry run mypy api/utils
+
       - name: mypy (type check, advisory)
-        # mypy is advisory while we work down the legacy backlog (751 errors at last count).
-        # Track remediation in docs/PHASE_2.md before flipping this to required.
+        # mypy is advisory for the rest of api/ while we work down the legacy
+        # backlog (751 errors at last count). Track remediation in
+        # docs/PHASE_2.md before flipping this to required.
         continue-on-error: true
         run: poetry run mypy api
 

--- a/api/utils/audit_logger.py
+++ b/api/utils/audit_logger.py
@@ -171,8 +171,8 @@ def log_permission_change(
     target_user_id: str,
     target_email: str,
     organization_id: str,
-    old_roles: list,
-    new_roles: list,
+    old_roles: list[str],
+    new_roles: list[str],
 ) -> AuditLog:
     """
     Log a permission/role change.

--- a/api/utils/calendar_utils.py
+++ b/api/utils/calendar_utils.py
@@ -8,6 +8,7 @@ This module handles:
 """
 
 from datetime import datetime
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 from icalendar import Calendar, vDatetime
@@ -15,7 +16,9 @@ from icalendar import Event as ICalEvent
 
 
 def generate_ics_from_assignments(
-    assignments: list[dict], calendar_name: str = "My Schedule", timezone: str = "UTC"
+    assignments: list[dict[str, Any]],
+    calendar_name: str = "My Schedule",
+    timezone: str = "UTC",
 ) -> str:
     """
     Generate an ICS calendar file from a list of assignments.
@@ -96,11 +99,11 @@ def generate_ics_from_assignments(
         # Add to calendar
         cal.add_component(event)
 
-    return cal.to_ical().decode("utf-8")
+    return cast(str, cal.to_ical().decode("utf-8"))
 
 
 def generate_ics_from_events(
-    events: list[dict],
+    events: list[dict[str, Any]],
     calendar_name: str = "Organization Events",
     timezone: str = "UTC",
     include_assignments: bool = True,
@@ -184,7 +187,7 @@ def generate_ics_from_events(
         # Add to calendar
         cal.add_component(event)
 
-    return cal.to_ical().decode("utf-8")
+    return cast(str, cal.to_ical().decode("utf-8"))
 
 
 def generate_webcal_url(base_url: str, token: str) -> str:

--- a/api/utils/datetime_utils.py
+++ b/api/utils/datetime_utils.py
@@ -56,7 +56,7 @@ def from_user_timezone(user_datetime: datetime, user_tz: str = "UTC") -> datetim
     return user_datetime.astimezone(ZoneInfo("UTC"))
 
 
-def parse_date_safe(date_string: str) -> date:
+def parse_date_safe(date_string: str) -> date | None:
     """
     Parse date string without timezone issues.
 
@@ -64,7 +64,7 @@ def parse_date_safe(date_string: str) -> date:
         date_string: Date string in format "YYYY-MM-DD" or ISO 8601
 
     Returns:
-        date object
+        date object or None when the input is empty
     """
     if not date_string:
         return None
@@ -113,7 +113,7 @@ def format_datetime_for_api(dt: datetime) -> str:
     return dt.isoformat()
 
 
-def parse_datetime_safe(datetime_string: str) -> datetime:
+def parse_datetime_safe(datetime_string: str) -> datetime | None:
     """
     Parse datetime string to timezone-aware datetime.
 
@@ -121,7 +121,7 @@ def parse_datetime_safe(datetime_string: str) -> datetime:
         datetime_string: ISO 8601 datetime string
 
     Returns:
-        timezone-aware datetime in UTC
+        timezone-aware datetime in UTC, or None when the input is empty
     """
     if not datetime_string:
         return None
@@ -153,7 +153,7 @@ def is_date_in_range(check_date: date, start_date: date, end_date: date) -> bool
     return start_date <= check_date <= end_date
 
 
-def get_common_timezones() -> list[dict]:
+def get_common_timezones() -> list[dict[str, str]]:
     """
     Get list of common timezones for selector UI.
 
@@ -195,6 +195,7 @@ if __name__ == "__main__":
     # Test date parsing (no timezone issues)
     print("=== Date Parsing Tests ===")
     test_date = parse_date_safe("2025-10-11")
+    assert test_date is not None
     print(f"Parsed date: {test_date}")  # 2025-10-11
     print(f"Formatted: {format_date_for_api(test_date)}")  # 2025-10-11
 

--- a/api/utils/db_helpers.py
+++ b/api/utils/db_helpers.py
@@ -1,6 +1,7 @@
 """Database helper functions for common query patterns."""
 
 from datetime import datetime
+from typing import cast
 
 from sqlalchemy.orm import Session
 
@@ -135,7 +136,9 @@ def get_available_people_for_event(
         if person.id in assigned_ids:
             continue
 
-        is_blocked, _ = is_person_blocked_on_date(db, person.id, event.start_time)
+        is_blocked, _ = is_person_blocked_on_date(
+            db, str(person.id), cast(datetime, event.start_time)
+        )
         if not is_blocked:
             available.append(person)
 

--- a/api/utils/event_helpers.py
+++ b/api/utils/event_helpers.py
@@ -5,6 +5,7 @@ Extracted from api/routers/events.py to follow DRY principle and single responsi
 """
 
 from datetime import date, datetime
+from typing import Any, cast
 
 from sqlalchemy.orm import Session
 
@@ -55,7 +56,7 @@ def get_assigned_person_ids(db: Session, event_id: str) -> set[str]:
     """
     assignments = db.query(Assignment).filter(Assignment.event_id == event_id).all()
 
-    return {assignment.person_id for assignment in assignments}
+    return {str(assignment.person_id) for assignment in assignments}
 
 
 def person_has_matching_role(person_roles: list[str], required_roles: list[str]) -> bool:
@@ -95,13 +96,13 @@ def get_event_required_roles(event: Event) -> list[str]:
         >>> roles = get_event_required_roles(event)
         >>> # Returns ["usher", "greeter", "sound_tech"]
     """
-    extra_data = event.extra_data or {}
+    extra_data: dict[str, Any] = cast(dict[str, Any], event.extra_data or {})
     role_counts = extra_data.get("role_counts", {})
 
     if role_counts:
         return list(role_counts.keys())
     else:
-        return extra_data.get("roles", [])
+        return cast(list[str], extra_data.get("roles", []))
 
 
 def count_people_with_role(people: list[Person], role: str) -> int:
@@ -156,11 +157,11 @@ def get_blocked_assigned_people(db: Session, event_id: str, event_date: date) ->
     """
     assignments = db.query(Assignment).filter(Assignment.event_id == event_id).all()
 
-    blocked_names = []
+    blocked_names: list[str] = []
     for assignment in assignments:
-        if is_person_blocked_on_date(db, assignment.person_id, event_date):
+        if is_person_blocked_on_date(db, str(assignment.person_id), event_date):
             person = db.query(Person).filter(Person.id == assignment.person_id).first()
             if person:
-                blocked_names.append(person.name)
+                blocked_names.append(str(person.name))
 
     return blocked_names

--- a/api/utils/password_validator.py
+++ b/api/utils/password_validator.py
@@ -27,7 +27,7 @@ class PasswordValidator:
     - PASSWORD_SPECIAL_CHARS: Allowed special characters (default: !@#$%^&*()_+-=[]{}|;:,.<>?)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Load configuration from environment
         self.min_length = int(os.getenv("PASSWORD_MIN_LENGTH", "8"))
         self.require_uppercase = os.getenv("PASSWORD_REQUIRE_UPPERCASE", "true").lower() == "true"

--- a/api/utils/pdf_export.py
+++ b/api/utils/pdf_export.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from io import BytesIO
+from typing import Any
 
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER
@@ -13,11 +14,11 @@ from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, Tabl
 
 def generate_schedule_pdf(
     org_name: str,
-    events: list,
-    people: dict,
-    assignments: dict,
-    events_db_map: dict = None,
-    blocked_dates_map: dict = None,
+    events: list[dict[str, Any]],
+    people: dict[str, dict[str, Any]],
+    assignments: dict[str, list[str]],
+    events_db_map: dict[str, Any] | None = None,
+    blocked_dates_map: dict[str, list[dict[str, Any]]] | None = None,
 ) -> BytesIO:
     """
     Generate a formatted PDF schedule.
@@ -79,7 +80,7 @@ def generate_schedule_pdf(
     sorted_events = sorted(events, key=lambda e: e["start_time"])
 
     # Group events by date
-    events_by_date = {}
+    events_by_date: dict[str, list[dict[str, Any]]] = {}
     for event in sorted_events:
         date_str = event["start_time"].strftime("%A, %B %d, %Y")
         if date_str not in events_by_date:
@@ -121,11 +122,13 @@ def generate_schedule_pdf(
 
                 # Group people by their roles that match event requirements
                 if role_counts:
-                    role_assignments = {role: [] for role in role_counts.keys()}
-                    assigned_people = set()
+                    role_assignments: dict[str, list[str]] = {
+                        role: [] for role in role_counts.keys()
+                    }
+                    assigned_people: set[str] = set()
 
                     # Helper function to check if person is blocked on event date
-                    def is_person_blocked(person_id, event_date):
+                    def is_person_blocked(person_id: str, event_date: datetime) -> bool:
                         if not blocked_dates_map:
                             return False
                         blocked_periods = blocked_dates_map.get(person_id, [])
@@ -177,7 +180,9 @@ def generate_schedule_pdf(
                     assignees_str = "\n".join(role_lines) if role_lines else "Not assigned"
                 else:
                     # No role requirements, just list names
-                    def is_person_blocked(person_id, event_date):
+                    def is_person_blocked(
+                        person_id: str, event_date: datetime
+                    ) -> bool:  # noqa: F811
                         if not blocked_dates_map:
                             return False
                         blocked_periods = blocked_dates_map.get(person_id, [])

--- a/api/utils/quiet_hours.py
+++ b/api/utils/quiet_hours.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 class QuietHours:
     """Quiet hours checker for SMS notifications."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize quiet hours configuration."""
         self.quiet_start = time(22, 0)  # 10:00 PM
         self.quiet_end = time(8, 0)  # 8:00 AM

--- a/api/utils/rate_limit_middleware.py
+++ b/api/utils/rate_limit_middleware.py
@@ -3,6 +3,7 @@ FastAPI dependencies for rate limiting.
 """
 
 import os
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request, status
 
@@ -23,7 +24,7 @@ def get_client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
-def rate_limit(limit_type: str):
+def rate_limit(limit_type: str) -> Callable[[Request], bool]:
     """
     Dependency factory for rate limiting.
 
@@ -39,7 +40,7 @@ def rate_limit(limit_type: str):
         Rate limiting is disabled during tests (when TESTING env var is set).
     """
 
-    def check_rate_limit(request: Request):
+    def check_rate_limit(request: Request) -> bool:
         # Disable rate limiting during tests or when explicitly toggled
         if os.getenv("TESTING") == "true" or os.getenv("DISABLE_RATE_LIMITS") == "true":
             return True

--- a/api/utils/rate_limiter.py
+++ b/api/utils/rate_limiter.py
@@ -29,7 +29,7 @@ class RateLimiter:
     Thread-safe implementation for handling concurrent requests.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # Store format: {key: (tokens, last_refill_time)}
         self._buckets: dict[str, tuple[float, float]] = {}
         self._lock = Lock()
@@ -73,13 +73,13 @@ class RateLimiter:
                 self._buckets[key] = (new_tokens, current_time)
                 return False
 
-    def reset(self, key: str):
+    def reset(self, key: str) -> None:
         """Reset rate limit for a specific key."""
         with self._lock:
             if key in self._buckets:
                 del self._buckets[key]
 
-    def cleanup_old_entries(self, max_age_seconds: int = 3600):
+    def cleanup_old_entries(self, max_age_seconds: int = 3600) -> None:
         """
         Remove old entries to prevent memory bloat.
         Call this periodically (e.g., every hour).

--- a/api/utils/request_id_middleware.py
+++ b/api/utils/request_id_middleware.py
@@ -1,6 +1,7 @@
 """Middleware that attaches an X-Request-ID to every request and response."""
 
 import uuid
+from collections.abc import Awaitable, Callable
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -14,7 +15,9 @@ REQUEST_ID_HEADER = "X-Request-ID"
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Read or generate X-Request-ID; expose via request.state and ContextVar; echo on response."""
 
-    async def dispatch(self, request: Request, call_next) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
         request.state.request_id = request_id
         token = request_id_var.set(request_id)

--- a/api/utils/response_messages.py
+++ b/api/utils/response_messages.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 
 
 def success_response(
-    message_key: str, data: dict[str, Any] | None = None, **params
+    message_key: str, data: dict[str, Any] | None = None, **params: Any
 ) -> dict[str, Any]:
     """
     Create a success response with i18n message key.
@@ -42,7 +42,7 @@ def success_response(
     return response
 
 
-def error_response(message_key: str, status_code: int = 400, **params) -> HTTPException:
+def error_response(message_key: str, status_code: int = 400, **params: Any) -> HTTPException:
     """
     Create an error response with i18n message key.
 
@@ -74,7 +74,7 @@ def error_response(message_key: str, status_code: int = 400, **params) -> HTTPEx
     )
 
 
-def validation_warning(warning_type: str, message_key: str, **params) -> dict[str, Any]:
+def validation_warning(warning_type: str, message_key: str, **params: Any) -> dict[str, Any]:
     """
     Create a validation warning with i18n message key.
 

--- a/api/utils/security_headers_middleware.py
+++ b/api/utils/security_headers_middleware.py
@@ -11,9 +11,13 @@ Adds security-related HTTP headers to all responses:
 """
 
 import os
+from collections.abc import Awaitable, Callable
 
+from fastapi import FastAPI
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -27,7 +31,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     - SECURITY_FRAME_OPTIONS: X-Frame-Options value (default: DENY)
     """
 
-    def __init__(self, app):
+    def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
 
         # Environment-based configuration
@@ -45,7 +49,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         self.csp_enabled = os.getenv("SECURITY_CSP_ENABLED", "true").lower() == "true"
         self.frame_options = os.getenv("SECURITY_FRAME_OPTIONS", "DENY")
 
-    async def dispatch(self, request: Request, call_next):
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         """Add security headers to response."""
         response = await call_next(request)
 
@@ -104,7 +110,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         return "; ".join(policy_directives)
 
 
-def add_security_headers_middleware(app):
+def add_security_headers_middleware(app: FastAPI) -> None:
     """
     Add security headers middleware to FastAPI app.
 

--- a/api/utils/tenancy_guard.py
+++ b/api/utils/tenancy_guard.py
@@ -36,7 +36,7 @@ def _tenant_scoped_entities(state: ORMExecuteState) -> set[str]:
     """Return names of selected entities that have a direct `org_id` column."""
     names: set[str] = set()
     try:
-        descs = state.statement.column_descriptions or []
+        descs = getattr(state.statement, "column_descriptions", None) or []
     except Exception:
         return names
     for desc in descs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,21 @@ disallow_untyped_defs = true
 [[tool.mypy.overrides]]
 module = "ics.*"
 ignore_missing_imports = true
+
+# Third-party libs without published type stubs.
+[[tool.mypy.overrides]]
+module = ["icalendar.*", "reportlab.*", "redis.*", "stripe.*", "twilio.*", "sendgrid.*"]
+ignore_missing_imports = true
+
+# Disabled feature stacks (Stripe billing, SMS) are out-of-scope for the
+# strict step. PR 4.7 strict-checks the active surface of api/utils only;
+# these modules stay on the advisory mypy api step until their features
+# are re-enabled.
+[[tool.mypy.overrides]]
+module = [
+    "api.utils.stripe_client",
+    "api.utils.stripe_error_handler",
+    "api.utils.cost_tracker",
+    "api.utils.sms_rate_limiter",
+]
+ignore_errors = true


### PR DESCRIPTION
## Summary

Make `poetry run mypy api/utils` clean under the existing strict config (`strict = true`, `disallow_untyped_defs = true`) and wire a **required** CI step that fails the job on regression. The legacy `mypy api` step stays advisory while the rest of the backlog gets worked down.

Disabled-feature modules — Stripe billing (`stripe_client`, `stripe_error_handler`), `cost_tracker`, `sms_rate_limiter` — get an `ignore_errors = true` per-module override so they stay parked until the features come back. They will graduate off the override when re-enabled.

## Per-module work

- `__init__` -> `None` on `RateLimiter`, `PasswordValidator`, `QuietHours`.
- `dispatch` / `__init__` callables on Starlette middlewares (`RequestIDMiddleware`, `SecurityHeadersMiddleware`, `rate_limit` factory).
- Typed `**kwargs` in `api/utils/response_messages.*`.
- Tightened `datetime_utils` signatures to reflect `None` returns.
- Cast SQLAlchemy ORM `Column` attribute reads to their runtime python types in `db_helpers` and `event_helpers`.
- Generic `dict`/`list` annotations in `pdf_export` plus typed inline `is_person_blocked` helpers.
- `icalendar` return values cast to `str` in `calendar_utils`.
- `pyproject.toml`: per-module overrides for `icalendar`/`reportlab`/`redis`/`stripe`/`twilio`/`sendgrid` (no published stubs).
- `ci.yml`: new required `mypy strict (api/utils)` step in front of the advisory `mypy api` step.

## Changed files

- `api/utils/{audit_logger,calendar_utils,datetime_utils,db_helpers,event_helpers,password_validator,pdf_export,quiet_hours,rate_limit_middleware,rate_limiter,request_id_middleware,response_messages,security_headers_middleware,tenancy_guard}.py`
- `pyproject.toml`
- `.github/workflows/ci.yml`

## Test plan

- [x] `poetry run mypy api/utils` -> Success: no issues found in 23 source files.
- [x] `poetry run black --check api tests` clean.
- [x] `poetry run ruff check api tests` clean.
- [ ] CI green on the PR.
- [ ] `poetry run pytest tests/unit tests/api` re-verified (running on the branch alongside the push).

## Follow-ups

- Sprint 4 PR 4.6b — file-by-file revival of integration tests.
- Phase 2 — graduate `stripe_*` / `cost_tracker` / `sms_rate_limiter` off the `ignore_errors` override when their features are re-enabled.

https://claude.ai/code/session_01MCMCPEQwkgEDTRhuRPov8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCMCPEQwkgEDTRhuRPov8F)_