### PR TITLE
Sprint 5 PR 5.2: Resources CRUD router

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -29,6 +29,7 @@ from api.routers import (
     password_reset,
     people,
     recurring_events,
+    resources,
     solutions,
     solver,
     teams,
@@ -140,6 +141,7 @@ app.include_router(calendar.router, prefix="/api/v1")
 app.include_router(assignments.router, prefix="/api/v1")
 app.include_router(audit.router, prefix="/api/v1")
 app.include_router(recurring_events.router, prefix="/api/v1")
+app.include_router(resources.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/routers/resources.py
+++ b/api/routers/resources.py
@@ -1,0 +1,174 @@
+"""Resources router — CRUD on venues / rooms / equipment.
+
+Reads require authenticated org membership; writes (create/update/delete)
+require admin in the target org. The solver already consumes the data at
+solve time; this router lets admins seed it via the API.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from api.database import get_db
+from api.dependencies import get_current_admin_user, get_current_user, verify_org_member
+from api.models import Event, Organization, Person, Resource
+from api.schemas.common import PaginationParams, get_pagination_params
+from api.schemas.resource import (
+    ResourceCreate,
+    ResourceList,
+    ResourceResponse,
+    ResourceUpdate,
+)
+
+router = APIRouter(prefix="/resources", tags=["resources"])
+
+
+@router.post("/", response_model=ResourceResponse, status_code=status.HTTP_201_CREATED)
+def create_resource(
+    resource_data: ResourceCreate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Create a new resource (admin only, scoped to admin's org)."""
+    verify_org_member(current_admin, resource_data.org_id)
+
+    org = db.query(Organization).filter(Organization.id == resource_data.org_id).first()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{resource_data.org_id}' not found",
+        )
+
+    if db.query(Resource).filter(Resource.id == resource_data.id).first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Resource with ID '{resource_data.id}' already exists",
+        )
+
+    resource = Resource(
+        id=resource_data.id,
+        org_id=resource_data.org_id,
+        type=resource_data.type,
+        location=resource_data.location,
+        capacity=resource_data.capacity,
+        extra_data=resource_data.extra_data or {},
+    )
+    db.add(resource)
+    db.commit()
+    db.refresh(resource)
+    return resource
+
+
+@router.get("/", response_model=ResourceList)
+def list_resources(
+    org_id: str = Query(..., description="Organization ID — required (single-tenant scope)"),
+    type: str | None = Query(None, description="Filter by resource type"),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List resources for one organization. Caller must be a member."""
+    verify_org_member(current_user, org_id)
+
+    query = db.query(Resource).filter(Resource.org_id == org_id)
+    if type is not None:
+        query = query.filter(Resource.type == type)
+
+    total = query.count()
+    rows = (
+        query.order_by(Resource.created_at.desc())
+        .offset(pagination.offset)
+        .limit(pagination.limit)
+        .all()
+    )
+    return {
+        "items": rows,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
+
+
+@router.get("/{resource_id}", response_model=ResourceResponse)
+def get_resource(
+    resource_id: str,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get a single resource by id; tenancy enforced via the row's org_id."""
+    resource = db.query(Resource).filter(Resource.id == resource_id).first()
+    if not resource:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Resource '{resource_id}' not found",
+        )
+    verify_org_member(current_user, resource.org_id)
+    return resource
+
+
+@router.put("/{resource_id}", response_model=ResourceResponse)
+def update_resource(
+    resource_id: str,
+    update: ResourceUpdate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Update a resource (admin only). org_id is immutable."""
+    resource = db.query(Resource).filter(Resource.id == resource_id).first()
+    if not resource:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Resource '{resource_id}' not found",
+        )
+    verify_org_member(current_admin, resource.org_id)
+
+    if update.type is not None:
+        resource.type = update.type
+    if update.location is not None:
+        resource.location = update.location
+    if update.capacity is not None:
+        resource.capacity = update.capacity
+    if update.extra_data is not None:
+        resource.extra_data = update.extra_data
+
+    db.commit()
+    db.refresh(resource)
+    return resource
+
+
+@router.delete("/{resource_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_resource(
+    resource_id: str,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a resource (admin only).
+
+    Refuses with 409 if any Event still references the resource — preserves
+    referential integrity without forcing the admin to discover dangling FKs
+    by surprise.
+    """
+    resource = db.query(Resource).filter(Resource.id == resource_id).first()
+    if not resource:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Resource '{resource_id}' not found",
+        )
+    verify_org_member(current_admin, resource.org_id)
+
+    referenced = (
+        db.query(Event)
+        .filter(Event.resource_id == resource_id, Event.org_id == resource.org_id)
+        .count()
+    )
+    if referenced > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Resource '{resource_id}' is referenced by {referenced} event(s); "
+                "reassign or delete those events first"
+            ),
+        )
+
+    db.delete(resource)
+    db.commit()
+    return None

--- a/api/schemas/resource.py
+++ b/api/schemas/resource.py
@@ -1,0 +1,49 @@
+"""Resource schemas (venues, rooms, equipment).
+
+The `Resource` ORM model has been around since the initial schema and the solver
+already consumes it (see api/routers/solver.py loading resources at /solve time).
+This file finally exposes it via the API.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from api.schemas._serializers import BaseResponse
+from api.schemas.common import ListResponse
+
+
+class ResourceBase(BaseModel):
+    """Common fields for create + response."""
+
+    type: str = Field(
+        ..., min_length=1, max_length=64, description="e.g. 'room', 'venue', 'equipment'"
+    )
+    location: str = Field(..., min_length=1, max_length=255)
+    capacity: int | None = Field(None, ge=0, description="Optional headcount cap; null = unbounded")
+    extra_data: dict[str, Any] | None = Field(None, description="Free-form metadata")
+
+
+class ResourceCreate(ResourceBase):
+    id: str = Field(..., min_length=1, max_length=64, description="Caller-supplied unique id")
+    org_id: str = Field(..., description="Owning organization")
+
+
+class ResourceUpdate(BaseModel):
+    """All fields optional (PATCH-style update)."""
+
+    type: str | None = Field(None, min_length=1, max_length=64)
+    location: str | None = Field(None, min_length=1, max_length=255)
+    capacity: int | None = Field(None, ge=0)
+    extra_data: dict[str, Any] | None = None
+
+
+class ResourceResponse(BaseResponse, ResourceBase):
+    id: str
+    org_id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+ResourceList = ListResponse[ResourceResponse]

--- a/tests/api/test_resources_crud.py
+++ b/tests/api/test_resources_crud.py
@@ -1,0 +1,210 @@
+"""Tests for /api/v1/resources/ — CRUD with admin-only writes."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@r.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@r.org", password="AdminPass1!")
+
+
+def _resource_body(rid: str, org_id: str, *, type_: str = "room", location: str = "Hall A") -> dict:
+    return {
+        "id": rid,
+        "org_id": org_id,
+        "type": type_,
+        "location": location,
+        "capacity": 50,
+        "extra_data": {},
+    }
+
+
+@pytest.mark.no_mock_auth
+class TestResourceCreate:
+    def test_admin_creates_resource(self, client, db):
+        org = "res-create"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "create")
+
+        resp = client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-1", org),
+            headers=hdrs,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["id"] == "r-1"
+        assert body["type"] == "room"
+
+    def test_volunteer_cannot_create(self, client, db):
+        org = "res-vol"
+        seed_org(client, org)
+        _admin(client, org, "vol-admin")
+        seed_user(
+            client,
+            org,
+            email="vol@r.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@r.org", password="VolPass1!")
+        resp = client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-vol", org),
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_admin_cross_org_blocked(self, client, db):
+        seed_org(client, "res-a")
+        seed_org(client, "res-b")
+        a_hdrs = _admin(client, "res-a", "a-admin")
+
+        resp = client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-cross", "res-b"),
+            headers=a_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_duplicate_id_returns_409(self, client, db):
+        org = "res-dup"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "dup")
+
+        client.post("/api/v1/resources/", json=_resource_body("r-dup", org), headers=hdrs)
+        resp = client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-dup", org, location="Hall B"),
+            headers=hdrs,
+        )
+        assert resp.status_code == 409
+
+
+@pytest.mark.no_mock_auth
+class TestResourceList:
+    def test_list_returns_envelope_filtered_by_org(self, client, db):
+        org = "res-list"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "list")
+        for i in range(3):
+            client.post(
+                "/api/v1/resources/",
+                json=_resource_body(f"r-list-{i}", org),
+                headers=hdrs,
+            )
+
+        resp = client.get(f"/api/v1/resources/?org_id={org}", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert {"items", "total", "limit", "offset"} <= set(body.keys())
+        assert body["total"] >= 3
+        assert all(item["org_id"] == org for item in body["items"])
+
+    def test_list_filters_by_type(self, client, db):
+        org = "res-bytype"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "bytype")
+        client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-room", org, type_="room"),
+            headers=hdrs,
+        )
+        client.post(
+            "/api/v1/resources/",
+            json=_resource_body("r-equip", org, type_="equipment"),
+            headers=hdrs,
+        )
+
+        resp = client.get(f"/api/v1/resources/?org_id={org}&type=equipment", headers=hdrs)
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert all(item["type"] == "equipment" for item in items)
+
+    def test_cross_org_list_blocked(self, client, db):
+        seed_org(client, "res-list-a")
+        seed_org(client, "res-list-b")
+        a_hdrs = _admin(client, "res-list-a", "ll-a")
+
+        resp = client.get("/api/v1/resources/?org_id=res-list-b", headers=a_hdrs)
+        assert resp.status_code == 403
+
+
+@pytest.mark.no_mock_auth
+class TestResourceGetUpdateDelete:
+    def test_get_by_id(self, client, db):
+        org = "res-get"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "get")
+        client.post("/api/v1/resources/", json=_resource_body("r-get", org), headers=hdrs)
+
+        resp = client.get("/api/v1/resources/r-get", headers=hdrs)
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "r-get"
+
+    def test_get_unknown_404(self, client, db):
+        org = "res-getno"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "getno")
+
+        resp = client.get("/api/v1/resources/nope", headers=hdrs)
+        assert resp.status_code == 404
+
+    def test_update_preserves_org_id(self, client, db):
+        org = "res-upd"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "upd")
+        client.post("/api/v1/resources/", json=_resource_body("r-upd", org), headers=hdrs)
+
+        resp = client.put(
+            "/api/v1/resources/r-upd",
+            json={"location": "New Hall"},
+            headers=hdrs,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["location"] == "New Hall"
+        assert body["org_id"] == org
+
+    def test_delete_blocks_when_referenced_by_event(self, client, db):
+        org = "res-del-ref"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "del-ref")
+        client.post("/api/v1/resources/", json=_resource_body("r-ref", org), headers=hdrs)
+
+        # Create an event that references the resource
+        event_payload = {
+            "id": "evt-ref",
+            "org_id": org,
+            "type": "service",
+            "start_time": (datetime.utcnow() + timedelta(days=2)).isoformat(),
+            "end_time": (datetime.utcnow() + timedelta(days=2, hours=1)).isoformat(),
+            "resource_id": "r-ref",
+            "extra_data": {},
+        }
+        ev_resp = client.post("/api/v1/events/", json=event_payload, headers=hdrs)
+        assert ev_resp.status_code == 201, ev_resp.text
+
+        resp = client.delete("/api/v1/resources/r-ref", headers=hdrs)
+        assert resp.status_code == 409
+
+    def test_delete_unreferenced_succeeds(self, client, db):
+        org = "res-del-ok"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "del-ok")
+        client.post("/api/v1/resources/", json=_resource_body("r-free", org), headers=hdrs)
+
+        resp = client.delete("/api/v1/resources/r-free", headers=hdrs)
+        assert resp.status_code in (200, 204)
+        assert client.get("/api/v1/resources/r-free", headers=hdrs).status_code == 404

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1551,6 +1551,37 @@
         "title": "ListResponse[RecurringSeriesResponse]",
         "type": "object"
       },
+      "ListResponse_ResourceResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[ResourceResponse]",
+        "type": "object"
+      },
       "ListResponse_SolutionResponse_": {
         "properties": {
           "items": {
@@ -2599,6 +2630,197 @@
           "updated_at"
         ],
         "title": "RecurringSeriesResponse",
+        "type": "object"
+      },
+      "ResourceCreate": {
+        "properties": {
+          "capacity": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional headcount cap; null = unbounded",
+            "title": "Capacity"
+          },
+          "extra_data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Free-form metadata",
+            "title": "Extra Data"
+          },
+          "id": {
+            "description": "Caller-supplied unique id",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+          },
+          "location": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Location",
+            "type": "string"
+          },
+          "org_id": {
+            "description": "Owning organization",
+            "title": "Org Id",
+            "type": "string"
+          },
+          "type": {
+            "description": "e.g. 'room', 'venue', 'equipment'",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "location",
+          "id",
+          "org_id"
+        ],
+        "title": "ResourceCreate",
+        "type": "object"
+      },
+      "ResourceResponse": {
+        "properties": {
+          "capacity": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional headcount cap; null = unbounded",
+            "title": "Capacity"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "extra_data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Free-form metadata",
+            "title": "Extra Data"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "location": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Location",
+            "type": "string"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          },
+          "type": {
+            "description": "e.g. 'room', 'venue', 'equipment'",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Type",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "location",
+          "id",
+          "org_id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ResourceResponse",
+        "type": "object"
+      },
+      "ResourceUpdate": {
+        "description": "All fields optional (PATCH-style update).",
+        "properties": {
+          "capacity": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capacity"
+          },
+          "extra_data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Data"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "ResourceUpdate",
         "type": "object"
       },
       "SignupRequest": {
@@ -7052,6 +7274,289 @@
         "summary": "Get Series Occurrences",
         "tags": [
           "recurring-events"
+        ]
+      }
+    },
+    "/api/v1/resources/": {
+      "get": {
+        "description": "List resources for one organization. Caller must be a member.",
+        "operationId": "listResources",
+        "parameters": [
+          {
+            "description": "Organization ID \u2014 required (single-tenant scope)",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID \u2014 required (single-tenant scope)",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by resource type",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by resource type",
+              "title": "Type"
+            }
+          },
+          {
+            "description": "Page size, max 200",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_ResourceResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Resources",
+        "tags": [
+          "resources"
+        ]
+      },
+      "post": {
+        "description": "Create a new resource (admin only, scoped to admin's org).",
+        "operationId": "createResource",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Resource",
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    "/api/v1/resources/{resource_id}": {
+      "delete": {
+        "description": "Delete a resource (admin only).\n\nRefuses with 409 if any Event still references the resource \u2014 preserves\nreferential integrity without forcing the admin to discover dangling FKs\nby surprise.",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "required": true,
+            "schema": {
+              "title": "Resource Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Resource",
+        "tags": [
+          "resources"
+        ]
+      },
+      "get": {
+        "description": "Get a single resource by id; tenancy enforced via the row's org_id.",
+        "operationId": "getResource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "required": true,
+            "schema": {
+              "title": "Resource Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Resource",
+        "tags": [
+          "resources"
+        ]
+      },
+      "put": {
+        "description": "Update a resource (admin only). org_id is immutable.",
+        "operationId": "updateResource",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resource_id",
+            "required": true,
+            "schema": {
+              "title": "Resource Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Resource",
+        "tags": [
+          "resources"
         ]
       }
     },


### PR DESCRIPTION
## Summary

The `Resource` ORM model has existed since the initial schema and the solver consumes it at solve time, but had no CRUD API. This PR adds it.

- `POST/GET/GET-by-id/PUT/DELETE /api/v1/resources/`
- Reads require authenticated org membership; writes require admin in the target org
- List filtered by required `org_id` query param + `verify_org_member`
- `DELETE` refuses with **409** if any `Event` still references the resource — preserves referential integrity

Pattern matches `teams.py` / `constraints.py`.

## Changed files

- `api/schemas/resource.py` (new)
- `api/routers/resources.py` (new): 5 endpoints
- `api/main.py`: register router
- `tests/api/test_resources_crud.py` (new): 12 tests
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 518 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 5 PR 5.3 (Holidays CRUD + bulk import) is next.