### PR TITLE
Sprint 5 PR 5.3: Holidays CRUD router + bulk import

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ from api.routers import (
     conflicts,
     constraints,
     events,
+    holidays,
     invitations,
     organizations,
     password_reset,
@@ -142,6 +143,7 @@ app.include_router(assignments.router, prefix="/api/v1")
 app.include_router(audit.router, prefix="/api/v1")
 app.include_router(recurring_events.router, prefix="/api/v1")
 app.include_router(resources.router, prefix="/api/v1")
+app.include_router(holidays.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/models.py
+++ b/api/models.py
@@ -908,6 +908,7 @@ class AuditAction:
 
     # Bulk operations
     BULK_IMPORT = "data.bulk_import"
+    HOLIDAY_BULK_IMPORTED = "data.holiday_bulk_imported"
 
     # Calendar token management
     CALENDAR_TOKEN_RESET = "calendar.token.reset"

--- a/api/routers/holidays.py
+++ b/api/routers/holidays.py
@@ -1,0 +1,221 @@
+"""Holidays router — admin-managed dates the solver can flag or skip.
+
+Reads require authenticated org membership; writes (create / update / delete /
+bulk-import) require admin in the target org.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.orm import Session
+
+from api.database import get_db
+from api.dependencies import get_current_admin_user, get_current_user, verify_org_member
+from api.models import AuditAction, Holiday, Organization, Person
+from api.schemas.common import PaginationParams, get_pagination_params
+from api.schemas.holiday import (
+    HolidayBulkImport,
+    HolidayBulkImportError,
+    HolidayBulkImportResponse,
+    HolidayCreate,
+    HolidayList,
+    HolidayResponse,
+    HolidayUpdate,
+)
+from api.utils.audit_logger import log_audit_event
+
+router = APIRouter(prefix="/holidays", tags=["holidays"])
+
+
+@router.post("/", response_model=HolidayResponse, status_code=status.HTTP_201_CREATED)
+def create_holiday(
+    body: HolidayCreate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Create a single holiday (admin only)."""
+    verify_org_member(current_admin, body.org_id)
+
+    if not db.query(Organization).filter(Organization.id == body.org_id).first():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{body.org_id}' not found",
+        )
+
+    holiday = Holiday(
+        org_id=body.org_id,
+        date=body.date,
+        label=body.label,
+        is_long_weekend=body.is_long_weekend,
+    )
+    db.add(holiday)
+    db.commit()
+    db.refresh(holiday)
+    return holiday
+
+
+@router.post("/bulk", response_model=HolidayBulkImportResponse)
+def bulk_import_holidays(
+    body: HolidayBulkImport,
+    http_request: Request,
+    org_id: str = Query(..., description="Organization to import into"),
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Admin-only bulk-create holidays for one org.
+
+    Common pattern for importing a full year's federal/diocesan calendar in one
+    request. Skips dates that already have a holiday row in the target org;
+    returns those as errors so the caller can decide whether to retry.
+    """
+    verify_org_member(current_admin, org_id)
+    if not db.query(Organization).filter(Organization.id == org_id).first():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organization '{org_id}' not found",
+        )
+
+    incoming_dates = [item.date for item in body.items]
+    existing_dates = {
+        d
+        for (d,) in db.query(Holiday.date)
+        .filter(Holiday.org_id == org_id, Holiday.date.in_(incoming_dates))
+        .all()
+    }
+
+    created = 0
+    skipped = 0
+    errors: list[HolidayBulkImportError] = []
+    seen_in_batch: set = set()
+
+    for index, item in enumerate(body.items):
+        if item.date in seen_in_batch:
+            skipped += 1
+            errors.append(
+                HolidayBulkImportError(
+                    row=index,
+                    label=item.label,
+                    message=f"date {item.date.isoformat()} duplicated within this batch",
+                )
+            )
+            continue
+        if item.date in existing_dates:
+            skipped += 1
+            errors.append(
+                HolidayBulkImportError(
+                    row=index,
+                    label=item.label,
+                    message=f"holiday on {item.date.isoformat()} already exists for this org",
+                )
+            )
+            continue
+        seen_in_batch.add(item.date)
+
+        db.add(
+            Holiday(
+                org_id=org_id,
+                date=item.date,
+                label=item.label,
+                is_long_weekend=item.is_long_weekend,
+            )
+        )
+        created += 1
+
+    db.commit()
+
+    log_audit_event(
+        db,
+        action=AuditAction.HOLIDAY_BULK_IMPORTED,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=org_id,
+        resource_type="holiday",
+        details={"created": created, "skipped": skipped, "errors": len(errors)},
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    return HolidayBulkImportResponse(created=created, skipped=skipped, errors=errors)
+
+
+@router.get("/", response_model=HolidayList)
+def list_holidays(
+    org_id: str = Query(..., description="Organization ID"),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List holidays for one org. Caller must be a member."""
+    verify_org_member(current_user, org_id)
+
+    query = db.query(Holiday).filter(Holiday.org_id == org_id)
+    total = query.count()
+    rows = (
+        query.order_by(Holiday.date.asc()).offset(pagination.offset).limit(pagination.limit).all()
+    )
+    return {
+        "items": rows,
+        "total": total,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+    }
+
+
+@router.get("/{holiday_id}", response_model=HolidayResponse)
+def get_holiday(
+    holiday_id: int,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    holiday = db.query(Holiday).filter(Holiday.id == holiday_id).first()
+    if not holiday:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Holiday {holiday_id} not found",
+        )
+    verify_org_member(current_user, holiday.org_id)
+    return holiday
+
+
+@router.put("/{holiday_id}", response_model=HolidayResponse)
+def update_holiday(
+    holiday_id: int,
+    body: HolidayUpdate,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    holiday = db.query(Holiday).filter(Holiday.id == holiday_id).first()
+    if not holiday:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Holiday {holiday_id} not found",
+        )
+    verify_org_member(current_admin, holiday.org_id)
+
+    if body.date is not None:
+        holiday.date = body.date
+    if body.label is not None:
+        holiday.label = body.label
+    if body.is_long_weekend is not None:
+        holiday.is_long_weekend = body.is_long_weekend
+
+    db.commit()
+    db.refresh(holiday)
+    return holiday
+
+
+@router.delete("/{holiday_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_holiday(
+    holiday_id: int,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    holiday = db.query(Holiday).filter(Holiday.id == holiday_id).first()
+    if not holiday:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Holiday {holiday_id} not found",
+        )
+    verify_org_member(current_admin, holiday.org_id)
+
+    db.delete(holiday)
+    db.commit()
+    return None

--- a/api/schemas/holiday.py
+++ b/api/schemas/holiday.py
@@ -1,0 +1,58 @@
+"""Holiday schemas. Holidays are admin-managed exceptions used by the solver."""
+
+from datetime import (
+    date as DateType,  # noqa: N812 - field is named `date` to match the Holiday model column
+)
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from api.schemas._serializers import BaseResponse
+from api.schemas.common import ListResponse
+
+
+class HolidayBase(BaseModel):
+    date: DateType
+    label: str = Field(..., min_length=1, max_length=255)
+    is_long_weekend: bool = False
+
+
+class HolidayCreate(HolidayBase):
+    org_id: str = Field(..., description="Organization ID")
+
+
+class HolidayUpdate(BaseModel):
+    date: DateType | None = None
+    label: str | None = Field(None, min_length=1, max_length=255)
+    is_long_weekend: bool | None = None
+
+
+class HolidayResponse(BaseResponse, HolidayBase):
+    id: int
+    org_id: str
+    created_at: datetime
+
+
+HolidayList = ListResponse[HolidayResponse]
+
+
+class HolidayBulkImportItem(HolidayBase):
+    """One item in a holiday bulk-import payload (no `id`; assigned by DB)."""
+
+
+class HolidayBulkImport(BaseModel):
+    items: list[HolidayBulkImportItem] = Field(
+        ..., min_length=1, max_length=500, description="Holidays to create (1-500 rows)"
+    )
+
+
+class HolidayBulkImportError(BaseModel):
+    row: int
+    label: str | None
+    message: str
+
+
+class HolidayBulkImportResponse(BaseModel):
+    created: int
+    skipped: int
+    errors: list[HolidayBulkImportError] = Field(default_factory=list)

--- a/tests/api/test_holidays_crud.py
+++ b/tests/api/test_holidays_crud.py
@@ -1,0 +1,212 @@
+"""Tests for /api/v1/holidays/ — admin-managed dates with bulk import."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from api.models import AuditAction, AuditLog
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@h.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@h.org", password="AdminPass1!")
+
+
+@pytest.mark.no_mock_auth
+class TestHolidayCrud:
+    def test_admin_creates_holiday(self, client, db):
+        org = "hol-create"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "create")
+
+        resp = client.post(
+            "/api/v1/holidays/",
+            json={
+                "org_id": org,
+                "date": "2026-12-25",
+                "label": "Christmas Day",
+                "is_long_weekend": False,
+            },
+            headers=hdrs,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["label"] == "Christmas Day"
+        assert body["org_id"] == org
+
+    def test_volunteer_cannot_create(self, client, db):
+        org = "hol-vol"
+        seed_org(client, org)
+        _admin(client, org, "vol-admin")
+        seed_user(
+            client,
+            org,
+            email="vol@h.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@h.org", password="VolPass1!")
+
+        resp = client.post(
+            "/api/v1/holidays/",
+            json={"org_id": org, "date": "2026-07-04", "label": "July 4"},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_admin_cross_org_blocked(self, client, db):
+        seed_org(client, "hol-a")
+        seed_org(client, "hol-b")
+        a_hdrs = _admin(client, "hol-a", "a")
+
+        resp = client.post(
+            "/api/v1/holidays/",
+            json={"org_id": "hol-b", "date": "2026-01-01", "label": "New Year"},
+            headers=a_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_list_returns_envelope(self, client, db):
+        org = "hol-list"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "list")
+        for d, label in [("2026-01-01", "New Year"), ("2026-07-04", "July 4")]:
+            client.post(
+                "/api/v1/holidays/",
+                json={"org_id": org, "date": d, "label": label},
+                headers=hdrs,
+            )
+
+        resp = client.get(f"/api/v1/holidays/?org_id={org}", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] >= 2
+        assert {"items", "total", "limit", "offset"} <= set(body.keys())
+
+    def test_get_update_delete(self, client, db):
+        org = "hol-cycle"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "cycle")
+        created = client.post(
+            "/api/v1/holidays/",
+            json={"org_id": org, "date": "2026-11-26", "label": "Thanksgiving"},
+            headers=hdrs,
+        ).json()
+        hid = created["id"]
+
+        # GET by id
+        assert client.get(f"/api/v1/holidays/{hid}", headers=hdrs).status_code == 200
+
+        # PUT
+        upd = client.put(
+            f"/api/v1/holidays/{hid}",
+            json={"is_long_weekend": True},
+            headers=hdrs,
+        )
+        assert upd.status_code == 200
+        assert upd.json()["is_long_weekend"] is True
+
+        # DELETE
+        delete = client.delete(f"/api/v1/holidays/{hid}", headers=hdrs)
+        assert delete.status_code in (200, 204)
+        assert client.get(f"/api/v1/holidays/{hid}", headers=hdrs).status_code == 404
+
+
+@pytest.mark.no_mock_auth
+class TestHolidayBulkImport:
+    def test_bulk_creates_multiple(self, client, db):
+        org = "hol-bulk"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "bulk")
+
+        items = [
+            {
+                "date": (date(2026, 1, 1) + timedelta(days=i * 30)).isoformat(),
+                "label": f"Holiday {i}",
+            }
+            for i in range(5)
+        ]
+        resp = client.post(
+            f"/api/v1/holidays/bulk?org_id={org}",
+            json={"items": items},
+            headers=hdrs,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["created"] == 5
+        assert body["skipped"] == 0
+        assert body["errors"] == []
+
+    def test_bulk_partial_failure_on_duplicate_date(self, client, db):
+        org = "hol-bulk-dup"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "bulk-dup")
+        # Pre-create one
+        client.post(
+            "/api/v1/holidays/",
+            json={"org_id": org, "date": "2026-12-25", "label": "Christmas"},
+            headers=hdrs,
+        )
+
+        resp = client.post(
+            f"/api/v1/holidays/bulk?org_id={org}",
+            json={
+                "items": [
+                    {"date": "2026-12-25", "label": "Xmas dup"},  # already exists
+                    {"date": "2026-12-31", "label": "NYE"},
+                ]
+            },
+            headers=hdrs,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["created"] == 1
+        assert body["skipped"] == 1
+        assert any("already exists" in e["message"] for e in body["errors"])
+
+    def test_bulk_volunteer_403(self, client, db):
+        org = "hol-bulk-vol"
+        seed_org(client, org)
+        _admin(client, org, "bulk-vol-admin")
+        seed_user(
+            client,
+            org,
+            email="vol-bulk@h.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol-bulk@h.org", password="VolPass1!")
+
+        resp = client.post(
+            f"/api/v1/holidays/bulk?org_id={org}",
+            json={"items": [{"date": "2026-01-01", "label": "X"}]},
+            headers=vol_hdrs,
+        )
+        assert resp.status_code == 403
+
+    def test_bulk_audit_row_written(self, client, db):
+        org = "hol-bulk-audit"
+        seed_org(client, org)
+        hdrs = _admin(client, org, "bulk-audit")
+
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.HOLIDAY_BULK_IMPORTED).count()
+        )
+        client.post(
+            f"/api/v1/holidays/bulk?org_id={org}",
+            json={"items": [{"date": "2026-01-01", "label": "New Year"}]},
+            headers=hdrs,
+        )
+        after = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.HOLIDAY_BULK_IMPORTED).count()
+        )
+        assert after == before + 1

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1055,6 +1055,223 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "HolidayBulkImport": {
+        "properties": {
+          "items": {
+            "description": "Holidays to create (1-500 rows)",
+            "items": {
+              "$ref": "#/components/schemas/HolidayBulkImportItem"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "HolidayBulkImport",
+        "type": "object"
+      },
+      "HolidayBulkImportError": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "row": {
+            "title": "Row",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "row",
+          "label",
+          "message"
+        ],
+        "title": "HolidayBulkImportError",
+        "type": "object"
+      },
+      "HolidayBulkImportItem": {
+        "description": "One item in a holiday bulk-import payload (no `id`; assigned by DB).",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "is_long_weekend": {
+            "default": false,
+            "title": "Is Long Weekend",
+            "type": "boolean"
+          },
+          "label": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "label"
+        ],
+        "title": "HolidayBulkImportItem",
+        "type": "object"
+      },
+      "HolidayBulkImportResponse": {
+        "properties": {
+          "created": {
+            "title": "Created",
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/HolidayBulkImportError"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "skipped": {
+            "title": "Skipped",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created",
+          "skipped"
+        ],
+        "title": "HolidayBulkImportResponse",
+        "type": "object"
+      },
+      "HolidayCreate": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "is_long_weekend": {
+            "default": false,
+            "title": "Is Long Weekend",
+            "type": "boolean"
+          },
+          "label": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          },
+          "org_id": {
+            "description": "Organization ID",
+            "title": "Org Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "label",
+          "org_id"
+        ],
+        "title": "HolidayCreate",
+        "type": "object"
+      },
+      "HolidayResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_long_weekend": {
+            "default": false,
+            "title": "Is Long Weekend",
+            "type": "boolean"
+          },
+          "label": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Label",
+            "type": "string"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "label",
+          "id",
+          "org_id",
+          "created_at"
+        ],
+        "title": "HolidayResponse",
+        "type": "object"
+      },
+      "HolidayUpdate": {
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "is_long_weekend": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Long Weekend"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          }
+        },
+        "title": "HolidayUpdate",
+        "type": "object"
+      },
       "InvitationAccept": {
         "description": "Schema for accepting an invitation.",
         "properties": {
@@ -1425,6 +1642,37 @@
           "offset"
         ],
         "title": "ListResponse[EventResponse]",
+        "type": "object"
+      },
+      "ListResponse_HolidayResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/HolidayResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ListResponse[HolidayResponse]",
         "type": "object"
       },
       "ListResponse_InvitationResponse_": {
@@ -5686,6 +5934,328 @@
         "summary": "Validate Event",
         "tags": [
           "events"
+        ]
+      }
+    },
+    "/api/v1/holidays/": {
+      "get": {
+        "description": "List holidays for one org. Caller must be a member.",
+        "operationId": "listHolidays",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, max 200",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Page size, max 200",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of rows to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of rows to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_HolidayResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Holidays",
+        "tags": [
+          "holidays"
+        ]
+      },
+      "post": {
+        "description": "Create a single holiday (admin only).",
+        "operationId": "createHoliday",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HolidayCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HolidayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Holiday",
+        "tags": [
+          "holidays"
+        ]
+      }
+    },
+    "/api/v1/holidays/bulk": {
+      "post": {
+        "description": "Admin-only bulk-create holidays for one org.\n\nCommon pattern for importing a full year's federal/diocesan calendar in one\nrequest. Skips dates that already have a holiday row in the target org;\nreturns those as errors so the caller can decide whether to retry.",
+        "operationId": "bulkImportHolidays",
+        "parameters": [
+          {
+            "description": "Organization to import into",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization to import into",
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HolidayBulkImport"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HolidayBulkImportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Bulk Import Holidays",
+        "tags": [
+          "holidays"
+        ]
+      }
+    },
+    "/api/v1/holidays/{holiday_id}": {
+      "delete": {
+        "operationId": "deleteHoliday",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "holiday_id",
+            "required": true,
+            "schema": {
+              "title": "Holiday Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Holiday",
+        "tags": [
+          "holidays"
+        ]
+      },
+      "get": {
+        "operationId": "getHoliday",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "holiday_id",
+            "required": true,
+            "schema": {
+              "title": "Holiday Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HolidayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Holiday",
+        "tags": [
+          "holidays"
+        ]
+      },
+      "put": {
+        "operationId": "updateHoliday",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "holiday_id",
+            "required": true,
+            "schema": {
+              "title": "Holiday Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HolidayUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HolidayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Holiday",
+        "tags": [
+          "holidays"
         ]
       }
     },


### PR DESCRIPTION
## Summary

The `Holiday` ORM model has been around since the initial schema and the solver/recurring-events `skip_holidays` flag consumes it, but had no API. This PR adds it.

- `POST/GET/GET-by-id/PUT/DELETE /api/v1/holidays/` — admin-only writes
- `POST /holidays/bulk` — admin-only batch import (cap 500). Partial-success report: rows whose date already exists OR is duplicated within the batch are listed in `errors`; remaining valid rows still commit.
- New `AuditAction.HOLIDAY_BULK_IMPORTED` audit row per bulk request.

Pattern matches Sprint 4 PR 4.3 (bulk people import) and Sprint 5 PR 5.2 (resources CRUD).

## Changed files

- `api/schemas/holiday.py` (new)
- `api/routers/holidays.py` (new): 6 endpoints
- `api/main.py`: register router
- `api/models.py`: new audit constant
- `tests/api/test_holidays_crud.py` (new): 9 tests
- `tests/contract/openapi.snapshot.json`: refreshed

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 527 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 5 PR 5.4 (solver honors rrule + AvailabilityException) is next.