### PR TITLE
Sprint 5 PR 5.4: Solver honors rrule + AvailabilityException

### DIFF
--- a/api/core/solver/heuristics.py
+++ b/api/core/solver/heuristics.py
@@ -58,11 +58,15 @@ class GreedyHeuristicSolver(SolverAdapter):
         # Build per-person vacation map: person_id -> list[(start_date, end_date)]
         # so we can filter out unavailable candidates per event.
         self._vacation_by_person: dict[str, list[tuple[Any, Any]]] = defaultdict(list)
+        # Per-person exception dates (rrule expansions + one-off AvailabilityException rows).
+        self._exception_dates_by_person: dict[str, set[Any]] = defaultdict(set)
         for avail in self.context.availability or []:
             if avail.person_id is None:
                 continue
             for vac in avail.vacations:
                 self._vacation_by_person[avail.person_id].append((vac.start, vac.end))
+            for exc_date in avail.exceptions:
+                self._exception_dates_by_person[avail.person_id].add(exc_date)
 
         # Filter events in range
         events_in_range = [
@@ -182,6 +186,13 @@ class GreedyHeuristicSolver(SolverAdapter):
                 # Vacation periods are inclusive on both ends.
                 vacations = getattr(self, "_vacation_by_person", {}).get(person.id, [])
                 if any(v_start <= event_date <= v_end for v_start, v_end in vacations):
+                    continue
+                # Skip if event date matches a one-off AvailabilityException OR
+                # any rrule-expanded blocked date for the person.
+                exception_dates = getattr(self, "_exception_dates_by_person", {}).get(
+                    person.id, set()
+                )
+                if event_date in exception_dates:
                     continue
 
                 # Check person-level hard constraints

--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -37,11 +37,15 @@ from api.core.models import (
 )
 from api.core.solver.adapter import SolveContext
 from api.core.solver.heuristics import GreedyHeuristicSolver
+from api.core.timeutils import parse_rrule
 from api.models import (
     Assignment as DBAssignment,
 )
 from api.models import (
     Availability as DBAvailability,
+)
+from api.models import (
+    AvailabilityException as DBAvailabilityException,
 )
 from api.models import (
     Constraint as DBConstraint,
@@ -196,13 +200,18 @@ def solve_schedule(
         for r in resources_db
     ]
 
-    # Load availability for people in this org. Each Availability row may
-    # carry zero-or-more VacationPeriod children that the solver uses to
-    # block out time-off.
+    # Load availability for people in this org. Each Availability row carries:
+    #   - VacationPeriod children: ranges the solver blocks (Sprint 3-E)
+    #   - AvailabilityException children: one-off blocked dates
+    #   - rrule string: recurring blocked dates expanded over the solve window
     person_ids = [p.id for p in people_db]
     availability: list[AvailabilityModel] = []
     if person_ids:
         avail_rows = db.query(DBAvailability).filter(DBAvailability.person_id.in_(person_ids)).all()
+        # Compute the solve window once for rrule expansion
+        from_dt = datetime.combine(solve_request.from_date, datetime.min.time())
+        to_dt = datetime.combine(solve_request.to_date, datetime.max.time())
+
         for a in avail_rows:
             vacations = [
                 VacationPeriodModel(start=v.start_date, end=v.end_date)
@@ -210,11 +219,34 @@ def solve_schedule(
                 .filter(DBVacationPeriod.availability_id == a.id)
                 .all()
             ]
+            # One-off exception dates from AvailabilityException
+            exception_dates: list = [
+                row.exception_date
+                for row in db.query(DBAvailabilityException)
+                .filter(DBAvailabilityException.availability_id == a.id)
+                .all()
+            ]
+            # Expand rrule to concrete blocked dates within [from_date, to_date].
+            # Malformed rrule strings are logged and treated as no-op so a single
+            # bad rule doesn't break the entire solve.
+            if a.rrule:
+                try:
+                    for occ in parse_rrule(a.rrule, from_dt, to_dt):
+                        exception_dates.append(occ.date())
+                except Exception as exc:  # noqa: BLE001 — solver must not crash on bad input
+                    logger.warning(
+                        "Skipping malformed rrule for person=%s availability=%s: %s",
+                        a.person_id,
+                        a.id,
+                        exc,
+                    )
+
             availability.append(
                 AvailabilityModel(
                     person_id=a.person_id,
                     rrule=a.rrule,
                     vacations=vacations,
+                    exceptions=exception_dates,
                 )
             )
 

--- a/tests/unit/test_solver_rrule_honoring.py
+++ b/tests/unit/test_solver_rrule_honoring.py
@@ -1,0 +1,200 @@
+"""Unit tests: solver honors rrule-expanded blocks and AvailabilityException dates.
+
+Sprint 3-E hooked up VacationPeriod ranges. Sprint 5-4 extends the solver to also
+honor:
+- Availability.rrule (e.g. FREQ=WEEKLY;BYDAY=MO blocks every Monday)
+- AvailabilityException single-date rows
+
+This is a unit test on the GreedyHeuristicSolver — no FastAPI / DB layer.
+"""
+
+from datetime import date, datetime, timedelta
+
+from api.core.models import (
+    Availability,
+    Event,
+    Org,
+    OrgDefaults,
+    Person,
+    RequiredRole,
+)
+from api.core.solver.adapter import SolveContext
+from api.core.solver.heuristics import GreedyHeuristicSolver
+
+
+def _ctx_with(
+    *,
+    people: list[Person],
+    events: list[Event],
+    availability: list[Availability],
+    from_date: date,
+    to_date: date,
+) -> SolveContext:
+    return SolveContext(
+        org=Org(org_id="t-org", region="US", defaults=OrgDefaults()),
+        people=people,
+        teams=[],
+        resources=[],
+        events=events,
+        constraints=[],
+        availability=availability,
+        holidays=[],
+        from_date=from_date,
+        to_date=to_date,
+        mode="strict",
+        change_min=False,
+    )
+
+
+def _solve(ctx: SolveContext):
+    solver = GreedyHeuristicSolver()
+    solver.build_model(ctx)
+    return solver.solve()
+
+
+def _person(pid: str) -> Person:
+    return Person(id=pid, name=pid, roles=["volunteer"], skills=[], teams=[])
+
+
+def _event(eid: str, on: date, *, count: int = 1) -> Event:
+    return Event(
+        id=eid,
+        type="service",
+        start=datetime.combine(on, datetime.min.time().replace(hour=10)),
+        end=datetime.combine(on, datetime.min.time().replace(hour=11)),
+        required_roles=[RequiredRole(role="volunteer", count=count)],
+    )
+
+
+def test_weekly_rrule_blocks_matching_weekday():
+    """A volunteer with FREQ=WEEKLY;BYDAY=MO is not assigned to Monday events."""
+    monday = date(2026, 5, 4)  # Monday
+    next_tue = monday + timedelta(days=1)
+    tomorrow_dt = datetime.combine(next_tue, datetime.min.time())
+    one_year = tomorrow_dt + timedelta(days=365)
+
+    # Pre-expand the rrule the way solver.py does in production:
+    # the unit test passes already-expanded `exceptions` since the solver heuristics
+    # only consume `exceptions` (rrule expansion happens in the router layer).
+    from dateutil.rrule import MO, WEEKLY, rrule
+
+    expanded = [d.date() for d in rrule(WEEKLY, byweekday=MO, dtstart=tomorrow_dt, until=one_year)]
+
+    p_blocked = _person("p_blocked")
+    p_open = _person("p_open")
+    avail = Availability(person_id="p_blocked", exceptions=expanded)
+
+    ctx = _ctx_with(
+        people=[p_blocked, p_open],
+        events=[_event("evt-mon", monday + timedelta(days=7))],  # Next Monday
+        availability=[avail],
+        from_date=monday + timedelta(days=1),
+        to_date=monday + timedelta(days=14),
+    )
+    result = _solve(ctx)
+
+    assignments = [a for a in result.assignments if a.event_id == "evt-mon"]
+    assert assignments, "should have one assignment row for the event"
+    assignees = assignments[0].assignees
+    assert "p_blocked" not in assignees
+    assert "p_open" in assignees
+
+
+def test_single_exception_date_blocks_assignment():
+    """One-off AvailabilityException date blocks just that day."""
+    target = date(2026, 9, 12)
+    p_blocked = _person("p_blocked")
+    p_open = _person("p_open")
+    avail = Availability(person_id="p_blocked", exceptions=[target])
+
+    ctx = _ctx_with(
+        people=[p_blocked, p_open],
+        events=[_event("evt-target", target)],
+        availability=[avail],
+        from_date=target - timedelta(days=2),
+        to_date=target + timedelta(days=2),
+    )
+    result = _solve(ctx)
+
+    assignees = next(a.assignees for a in result.assignments if a.event_id == "evt-target")
+    assert "p_blocked" not in assignees
+    assert "p_open" in assignees
+
+
+def test_exception_does_not_affect_other_dates():
+    """An exception on one date doesn't block events on other dates."""
+    blocked_day = date(2026, 9, 12)
+    other_day = date(2026, 9, 13)
+    only_p = _person("p_only")
+    avail = Availability(person_id="p_only", exceptions=[blocked_day])
+
+    ctx = _ctx_with(
+        people=[only_p],
+        events=[_event("evt-other", other_day)],
+        availability=[avail],
+        from_date=blocked_day - timedelta(days=2),
+        to_date=blocked_day + timedelta(days=10),
+    )
+    result = _solve(ctx)
+
+    assignees = next(a.assignees for a in result.assignments if a.event_id == "evt-other")
+    # The only volunteer is available on the other day
+    assert "p_only" in assignees
+
+
+def test_empty_availability_means_assignable():
+    """No Availability row at all means no blocks."""
+    p = _person("p_free")
+    today = date(2026, 6, 1)
+
+    ctx = _ctx_with(
+        people=[p],
+        events=[_event("evt-free", today)],
+        availability=[],
+        from_date=today - timedelta(days=2),
+        to_date=today + timedelta(days=2),
+    )
+    result = _solve(ctx)
+
+    assignees = next(a.assignees for a in result.assignments if a.event_id == "evt-free")
+    assert "p_free" in assignees
+
+
+def test_multiple_rules_stack():
+    """Vacation + exception both apply; remaining open dates are still assignable."""
+    from api.core.models import VacationPeriod
+
+    busy_p = _person("p_busy")
+    spare_p = _person("p_spare")
+    vacation_start = date(2026, 7, 4)
+    vacation_end = date(2026, 7, 8)
+    one_off = date(2026, 7, 15)
+
+    avail = Availability(
+        person_id="p_busy",
+        vacations=[VacationPeriod(start=vacation_start, end=vacation_end)],
+        exceptions=[one_off],
+    )
+
+    # Three events: one in the vacation, one on the exception day, one free
+    events = [
+        _event("evt-vac", date(2026, 7, 5)),  # in vacation range
+        _event("evt-exc", one_off),
+        _event("evt-free", date(2026, 7, 20)),
+    ]
+
+    ctx = _ctx_with(
+        people=[busy_p, spare_p],
+        events=events,
+        availability=[avail],
+        from_date=date(2026, 7, 1),
+        to_date=date(2026, 7, 31),
+    )
+    result = _solve(ctx)
+
+    by_event = {a.event_id: a.assignees for a in result.assignments}
+    assert "p_busy" not in by_event["evt-vac"]
+    assert "p_busy" not in by_event["evt-exc"]
+    # On the free day busy_p IS assignable (spare_p may also be picked first
+    # by fairness; relax the assertion to "at least one of the two").
+    assert by_event["evt-free"], "free-day event must have at least one assignee"


### PR DESCRIPTION
## Summary

Sprint 3-E hooked up `VacationPeriod` ranges. This PR completes the availability story:

- **`Availability.rrule`** — recurring weekly availability via iCalendar RRULE strings (e.g. `FREQ=WEEKLY;BYDAY=MO`). Expanded over the `[from_date, to_date]` window using existing `parse_rrule` helper.
- **`AvailabilityException`** — one-off blocked dates stored in their own table.

Both feed the core `Availability.exceptions: list[date]` field; the solver consumes them via a new `_exception_dates_by_person` set built once in `solve()`, then checked alongside the existing `_vacation_by_person` map during candidate filtering.

Malformed rrule strings are logged and treated as no-op so one bad rule doesn't crash the entire solve.

## Changed files

- `api/routers/solver.py`: load `AvailabilityException` rows; expand rrule; pass into `AvailabilityModel`
- `api/core/solver/heuristics.py`: per-person exception set; reject candidate if `event_date` is in it
- `tests/unit/test_solver_rrule_honoring.py` (new): 5 unit tests

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/` — 532 passed, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- Sprint 5 PR 5.5 (solution compare + rollback) is next.