### PR TITLE
Sprint 5 PR 5.5: Solution compare + rollback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ make migrate              # Run Alembic migrations
 /api/v1/events         — CRUD for events + assignments
 /api/v1/constraints    — CRUD for scheduling constraints (DSL-based)
 /api/v1/solver         — POST /solve to generate schedules
-/api/v1/solutions      — list/view generated solutions
+/api/v1/solutions      — list/view, compare, publish/unpublish/rollback
 /api/v1/availability   — time-off / blocked dates
 /api/v1/conflicts      — conflict checking between person+event
 /api/v1/invitations    — create/verify/accept invitation tokens

--- a/api/models.py
+++ b/api/models.py
@@ -905,6 +905,7 @@ class AuditAction:
     # Solution lifecycle
     SOLUTION_PUBLISHED = "solution.published"
     SOLUTION_UNPUBLISHED = "solution.unpublished"
+    SOLUTION_ROLLED_BACK = "solution.rolled_back"
 
     # Bulk operations
     BULK_IMPORT = "data.bulk_import"

--- a/api/routers/solutions.py
+++ b/api/routers/solutions.py
@@ -16,9 +16,15 @@ from api.core.models import (
 )
 from api.database import get_db
 from api.dependencies import get_current_admin_user, verify_org_member
-from api.models import Assignment, AuditAction, Event, Organization, Person, Solution
+from api.models import Assignment, AuditAction, AuditLog, Event, Organization, Person, Solution
 from api.schemas.common import PaginationParams, get_pagination_params
-from api.schemas.solver import ExportFormat, SolutionList, SolutionResponse
+from api.schemas.solver import (
+    AssignmentChange,
+    ExportFormat,
+    SolutionDiffResponse,
+    SolutionList,
+    SolutionResponse,
+)
 from api.timeutils import utcnow
 from api.utils.audit_logger import log_audit_event
 from api.utils.pdf_export import generate_schedule_pdf
@@ -440,6 +446,128 @@ def unpublish_solution(
         organization_id=solution.org_id,
         resource_type="solution",
         resource_id=str(solution.id),
+        ip_address=http_request.client.host if http_request.client else None,
+        user_agent=http_request.headers.get("user-agent"),
+    )
+
+    assignment_count = db.query(Assignment).filter(Assignment.solution_id == solution.id).count()
+    response = SolutionResponse.model_validate(solution)
+    response.assignment_count = assignment_count
+    return response
+
+
+@router.get("/{solution_a_id}/compare/{solution_b_id}", response_model=SolutionDiffResponse)
+def compare_solutions(
+    solution_a_id: int,
+    solution_b_id: int,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Diff two solutions (admin only). Both must belong to the same org as the caller."""
+    sol_a = db.query(Solution).filter(Solution.id == solution_a_id).first()
+    if not sol_a:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_a_id} not found",
+        )
+    sol_b = db.query(Solution).filter(Solution.id == solution_b_id).first()
+    if not sol_b:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_b_id} not found",
+        )
+    verify_org_member(current_admin, sol_a.org_id)
+    verify_org_member(current_admin, sol_b.org_id)
+
+    a_rows = db.query(Assignment).filter(Assignment.solution_id == sol_a.id).all()
+    b_rows = db.query(Assignment).filter(Assignment.solution_id == sol_b.id).all()
+
+    a_keys = {(r.event_id, r.person_id, r.role) for r in a_rows}
+    b_keys = {(r.event_id, r.person_id, r.role) for r in b_rows}
+
+    removed = a_keys - b_keys
+    added = b_keys - a_keys
+    unchanged_count = len(a_keys & b_keys)
+
+    affected_persons = sorted({pid for (_, pid, _) in removed | added})
+
+    return SolutionDiffResponse(
+        solution_a_id=sol_a.id,
+        solution_b_id=sol_b.id,
+        added=[AssignmentChange(event_id=e, person_id=p, role=r) for (e, p, r) in added],
+        removed=[AssignmentChange(event_id=e, person_id=p, role=r) for (e, p, r) in removed],
+        unchanged_count=unchanged_count,
+        affected_persons=affected_persons,
+        moves=len(added) + len(removed),
+    )
+
+
+@router.post("/{solution_id}/rollback", response_model=SolutionResponse)
+def rollback_solution(
+    solution_id: int,
+    http_request: Request,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Rollback to a previously-published solution (admin only).
+
+    Republishes the target and unpublishes whatever is currently published in
+    the same org. The target must have been published at some point before
+    (i.e. an audit row recording its publish/rollback exists); otherwise 400.
+    """
+    solution = db.query(Solution).filter(Solution.id == solution_id).first()
+    if not solution:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_id} not found",
+        )
+    verify_org_member(current_admin, solution.org_id)
+
+    # Eligibility: existing publish_solution nulls published_at on the prior
+    # when it replaces, so published_at is unreliable. Use the audit trail.
+    was_ever_published = (
+        db.query(AuditLog)
+        .filter(
+            AuditLog.action.in_([AuditAction.SOLUTION_PUBLISHED, AuditAction.SOLUTION_ROLLED_BACK]),
+            AuditLog.resource_id == str(solution.id),
+        )
+        .count()
+        > 0
+    )
+    if not was_ever_published:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot roll back to a solution that has never been published",
+        )
+
+    prior = (
+        db.query(Solution)
+        .filter(
+            Solution.org_id == solution.org_id,
+            Solution.is_published.is_(True),
+            Solution.id != solution.id,
+        )
+        .all()
+    )
+    for s in prior:
+        s.is_published = False
+        s.published_at = None
+
+    now = utcnow()
+    solution.is_published = True
+    solution.published_at = now
+    db.commit()
+    db.refresh(solution)
+
+    log_audit_event(
+        db,
+        action=AuditAction.SOLUTION_ROLLED_BACK,
+        user_id=current_admin.id,
+        user_email=current_admin.email,
+        organization_id=solution.org_id,
+        resource_type="solution",
+        resource_id=str(solution.id),
+        details={"unpublished_prior_ids": [s.id for s in prior]},
         ip_address=http_request.client.host if http_request.client else None,
         user_agent=http_request.headers.get("user-agent"),
     )

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -89,3 +89,23 @@ class ExportFormat(BaseModel):
 
     format: str = Field(..., description="Export format: json, csv, pdf, or ics")
     scope: str = Field("org", description="Export scope: org, person:{id}, or team:{id}")
+
+
+class AssignmentChange(BaseModel):
+    """One added/removed assignment in a diff."""
+
+    event_id: str
+    person_id: str
+    role: str | None = None
+
+
+class SolutionDiffResponse(BaseModel):
+    """Diff between two solutions in the same org."""
+
+    solution_a_id: int
+    solution_b_id: int
+    added: list[AssignmentChange]
+    removed: list[AssignmentChange]
+    unchanged_count: int
+    affected_persons: list[str]
+    moves: int

--- a/tests/api/test_solution_compare_rollback.py
+++ b/tests/api/test_solution_compare_rollback.py
@@ -1,0 +1,301 @@
+"""Solution compare + rollback tests for /api/v1/solutions/.
+
+Sprint 5 PR 5.5 adds two admin-only endpoints on top of the existing
+publish/unpublish flow (Sprint 4 PR 4.2):
+
+- ``GET /solutions/{a}/compare/{b}`` — diff two solutions in the same org;
+  returns added/removed assignment changes keyed by ``(event_id, person_id, role)``.
+- ``POST /solutions/{id}/rollback`` — republish a previously-published
+  solution. The target must have ``published_at IS NOT NULL``. Whatever is
+  currently published in the org is unpublished. Audited as
+  ``solution.rolled_back``.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from api.models import Assignment, AuditAction, AuditLog, Event, Person, Solution
+from api.timeutils import utcnow
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@o.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _seed_solution(db, org_id: str, *, published: bool = False) -> Solution:
+    sol = Solution(
+        org_id=org_id,
+        solve_ms=10.0,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=1.0,
+        metrics={},
+    )
+    if published:
+        sol.is_published = True
+        sol.published_at = utcnow()
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    return sol
+
+
+def _seed_person(db, org_id: str, person_id: str) -> Person:
+    p = Person(id=person_id, org_id=org_id, name=person_id.title(), roles=[])
+    db.add(p)
+    db.commit()
+    return p
+
+
+def _seed_event(db, org_id: str, event_id: str) -> Event:
+    start = datetime(2026, 6, 1, 10, 0, 0)
+    e = Event(
+        id=event_id,
+        org_id=org_id,
+        type="Service",
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+    )
+    db.add(e)
+    db.commit()
+    return e
+
+
+def _seed_assignment(
+    db, *, solution_id: int, event_id: str, person_id: str, role: str | None
+) -> Assignment:
+    a = Assignment(
+        solution_id=solution_id,
+        event_id=event_id,
+        person_id=person_id,
+        role=role,
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Compare
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestCompareSolutions:
+    def test_admin_can_compare_returns_correct_diff(self, client, db):
+        org_id = "cmp-ok"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "cmp-ok")
+
+        for pid in ("p1", "p2", "p3"):
+            _seed_person(db, org_id, pid)
+        for eid in ("e1", "e2"):
+            _seed_event(db, org_id, eid)
+
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        # A: (e1,p1,usher), (e1,p2,greeter)
+        _seed_assignment(db, solution_id=sol_a.id, event_id="e1", person_id="p1", role="usher")
+        _seed_assignment(db, solution_id=sol_a.id, event_id="e1", person_id="p2", role="greeter")
+
+        # B: (e1,p1,usher), (e2,p3,sound)
+        _seed_assignment(db, solution_id=sol_b.id, event_id="e1", person_id="p1", role="usher")
+        _seed_assignment(db, solution_id=sol_b.id, event_id="e2", person_id="p3", role="sound")
+
+        resp = client.get(f"/api/v1/solutions/{sol_a.id}/compare/{sol_b.id}", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["solution_a_id"] == sol_a.id
+        assert body["solution_b_id"] == sol_b.id
+        assert body["unchanged_count"] == 1
+        assert body["moves"] == 2
+
+        removed = {(c["event_id"], c["person_id"], c["role"]) for c in body["removed"]}
+        added = {(c["event_id"], c["person_id"], c["role"]) for c in body["added"]}
+        assert removed == {("e1", "p2", "greeter")}
+        assert added == {("e2", "p3", "sound")}
+        assert set(body["affected_persons"]) == {"p2", "p3"}
+
+    def test_compare_role_difference_counts_as_remove_add(self, client, db):
+        org_id = "cmp-role"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "cmp-role")
+        _seed_person(db, org_id, "p1")
+        _seed_event(db, org_id, "e1")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        _seed_assignment(db, solution_id=sol_a.id, event_id="e1", person_id="p1", role="usher")
+        _seed_assignment(db, solution_id=sol_b.id, event_id="e1", person_id="p1", role="greeter")
+
+        resp = client.get(f"/api/v1/solutions/{sol_a.id}/compare/{sol_b.id}", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["moves"] == 2
+        assert body["unchanged_count"] == 0
+        assert {c["role"] for c in body["removed"]} == {"usher"}
+        assert {c["role"] for c in body["added"]} == {"greeter"}
+
+    def test_compare_volunteer_blocked(self, client, db):
+        org_id = "cmp-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "cmp-vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        resp = client.get(f"/api/v1/solutions/{sol_a.id}/compare/{sol_b.id}", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+    def test_compare_cross_org_blocked(self, client, db):
+        seed_org(client, "cmp-a")
+        seed_org(client, "cmp-b")
+        a_hdrs = _admin_for(client, "cmp-a", "cmp-a")
+        sol_a = _seed_solution(db, "cmp-a")
+        sol_b = _seed_solution(db, "cmp-b")
+
+        resp = client.get(f"/api/v1/solutions/{sol_a.id}/compare/{sol_b.id}", headers=a_hdrs)
+        assert resp.status_code == 403
+
+    def test_compare_missing_solution_404(self, client, db):
+        org_id = "cmp-missing"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "cmp-missing")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/compare/9999999", headers=hdrs)
+        assert resp.status_code == 404
+
+    def test_compare_requires_auth(self, client, db):
+        org_id = "cmp-noauth"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "cmp-noauth")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        resp = client.get(f"/api/v1/solutions/{sol_a.id}/compare/{sol_b.id}")
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_auth
+class TestRollbackSolution:
+    def test_admin_can_rollback_to_prior_published(self, client, db):
+        org_id = "rb-ok"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "rb-ok")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+
+        # Publish a, then b (which unpublishes a). a now has published_at != None
+        # but is_published = False — eligible for rollback.
+        client.post(f"/api/v1/solutions/{sol_a.id}/publish", headers=hdrs)
+        client.post(f"/api/v1/solutions/{sol_b.id}/publish", headers=hdrs)
+
+        resp = client.post(f"/api/v1/solutions/{sol_a.id}/rollback", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_published"] is True
+        assert body["published_at"] is not None
+
+        a_after = client.get(f"/api/v1/solutions/{sol_a.id}", headers=hdrs).json()
+        b_after = client.get(f"/api/v1/solutions/{sol_b.id}", headers=hdrs).json()
+        assert a_after["is_published"] is True
+        assert b_after["is_published"] is False
+
+    def test_rollback_to_never_published_400(self, client, db):
+        org_id = "rb-never"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "rb-never")
+        sol = _seed_solution(db, org_id)  # published_at IS NULL
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/rollback", headers=hdrs)
+        assert resp.status_code == 400
+
+    def test_rollback_volunteer_blocked(self, client, db):
+        org_id = "rb-vol"
+        seed_org(client, org_id)
+        admin_hdrs = _admin_for(client, org_id, "rb-vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+        sol = _seed_solution(db, org_id)
+        client.post(f"/api/v1/solutions/{sol.id}/publish", headers=admin_hdrs)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/rollback", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+    def test_rollback_cross_org_blocked(self, client, db):
+        seed_org(client, "rb-a")
+        seed_org(client, "rb-b")
+        a_hdrs = _admin_for(client, "rb-a", "rb-a")
+        b_hdrs = _admin_for(client, "rb-b", "rb-b")
+        sol_b = _seed_solution(db, "rb-b")
+        client.post(f"/api/v1/solutions/{sol_b.id}/publish", headers=b_hdrs)
+
+        resp = client.post(f"/api/v1/solutions/{sol_b.id}/rollback", headers=a_hdrs)
+        assert resp.status_code == 403
+
+    def test_rollback_emits_audit_row(self, client, db):
+        org_id = "rb-audit"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "rb-audit")
+        sol_a = _seed_solution(db, org_id)
+        sol_b = _seed_solution(db, org_id)
+        client.post(f"/api/v1/solutions/{sol_a.id}/publish", headers=hdrs)
+        client.post(f"/api/v1/solutions/{sol_b.id}/publish", headers=hdrs)
+
+        before = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_ROLLED_BACK).count()
+        )
+        client.post(f"/api/v1/solutions/{sol_a.id}/rollback", headers=hdrs)
+        after = (
+            db.query(AuditLog).filter(AuditLog.action == AuditAction.SOLUTION_ROLLED_BACK).count()
+        )
+        assert after == before + 1
+
+    def test_rollback_missing_solution_404(self, client, db):
+        org_id = "rb-missing"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "rb-missing")
+
+        resp = client.post("/api/v1/solutions/9999999/rollback", headers=hdrs)
+        assert resp.status_code == 404
+
+    def test_rollback_requires_auth(self, client, db):
+        org_id = "rb-noauth"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "rb-noauth")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.post(f"/api/v1/solutions/{sol.id}/rollback")
+        assert resp.status_code in (401, 403)

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1,6 +1,36 @@
 {
   "components": {
     "schemas": {
+      "AssignmentChange": {
+        "description": "One added/removed assignment in a diff.",
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "person_id": {
+            "title": "Person Id",
+            "type": "string"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          }
+        },
+        "required": [
+          "event_id",
+          "person_id"
+        ],
+        "title": "AssignmentChange",
+        "type": "object"
+      },
       "AssignmentDeclineRequest": {
         "description": "Body for POST /assignments/{id}/decline.",
         "properties": {
@@ -3145,6 +3175,59 @@
           "password"
         ],
         "title": "SignupRequest",
+        "type": "object"
+      },
+      "SolutionDiffResponse": {
+        "description": "Diff between two solutions in the same org.",
+        "properties": {
+          "added": {
+            "items": {
+              "$ref": "#/components/schemas/AssignmentChange"
+            },
+            "title": "Added",
+            "type": "array"
+          },
+          "affected_persons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Affected Persons",
+            "type": "array"
+          },
+          "moves": {
+            "title": "Moves",
+            "type": "integer"
+          },
+          "removed": {
+            "items": {
+              "$ref": "#/components/schemas/AssignmentChange"
+            },
+            "title": "Removed",
+            "type": "array"
+          },
+          "solution_a_id": {
+            "title": "Solution A Id",
+            "type": "integer"
+          },
+          "solution_b_id": {
+            "title": "Solution B Id",
+            "type": "integer"
+          },
+          "unchanged_count": {
+            "title": "Unchanged Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "solution_a_id",
+          "solution_b_id",
+          "added",
+          "removed",
+          "unchanged_count",
+          "affected_persons",
+          "moves"
+        ],
+        "title": "SolutionDiffResponse",
         "type": "object"
       },
       "SolutionMetrics": {
@@ -8251,6 +8334,63 @@
         ]
       }
     },
+    "/api/v1/solutions/{solution_a_id}/compare/{solution_b_id}": {
+      "get": {
+        "description": "Diff two solutions (admin only). Both must belong to the same org as the caller.",
+        "operationId": "compareSolutions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "solution_a_id",
+            "required": true,
+            "schema": {
+              "title": "Solution A Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "solution_b_id",
+            "required": true,
+            "schema": {
+              "title": "Solution B Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionDiffResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Compare Solutions",
+        "tags": [
+          "solutions"
+        ]
+      }
+    },
     "/api/v1/solutions/{solution_id}": {
       "delete": {
         "description": "Delete solution and all assignments.",
@@ -8463,6 +8603,54 @@
           }
         ],
         "summary": "Publish Solution",
+        "tags": [
+          "solutions"
+        ]
+      }
+    },
+    "/api/v1/solutions/{solution_id}/rollback": {
+      "post": {
+        "description": "Rollback to a previously-published solution (admin only).\n\nRepublishes the target and unpublishes whatever is currently published in\nthe same org. The target must have been published at some point before\n(i.e. an audit row recording its publish/rollback exists); otherwise 400.",
+        "operationId": "rollbackSolution",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "solution_id",
+            "required": true,
+            "schema": {
+              "title": "Solution Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Rollback Solution",
         "tags": [
           "solutions"
         ]


### PR DESCRIPTION
## Summary

Caps the solution-management capability that Sprint 4 PR 4.2 began (publish/unpublish). Two admin-only endpoints:

- **`GET /solutions/{a}/compare/{b}`** — diff two solutions in the same org, keying assignments by `(event_id, person_id, role)`. Returns `added`/`removed`, `unchanged_count`, `affected_persons`, and total `moves`.
- **`POST /solutions/{id}/rollback`** — republish a previously-published solution and unpublish whatever is currently published in the org. Audited as `solution.rolled_back`.

Eligibility for rollback is checked via the audit trail (`SOLUTION_PUBLISHED` / `SOLUTION_ROLLED_BACK` rows for that `solution_id`) because the existing publish flow nulls `published_at` on the prior when it replaces — the column alone isn't a reliable "ever-published" signal. No schema changes; reuses `Solution.is_published` / `published_at`.

## Changed files

- `api/models.py` — add `AuditAction.SOLUTION_ROLLED_BACK` constant.
- `api/schemas/solver.py` — add `AssignmentChange` and `SolutionDiffResponse`.
- `api/routers/solutions.py` — `compare_solutions` and `rollback_solution` handlers; mirrors publish flow at lines 359–411.
- `tests/api/test_solution_compare_rollback.py` (new) — 13 test cases.
- `tests/contract/openapi.snapshot.json` — refreshed for two new endpoints + two new schemas.
- `CLAUDE.md` — active-routers line updated to mention compare/rollback.

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api/routers/solutions.py api/schemas/solver.py api/models.py tests/api/test_solution_compare_rollback.py` clean
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/ tests/integration/` — all pass locally (each tier separately, mirroring CI)
- [ ] CI green on the PR

## Follow-ups

None queued — Sprint 5 closes here unless further work is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)