### PR TITLE
Sprint 6 PR 6.1: Compute stability metrics on every solve

### DIFF
--- a/api/routers/solver.py
+++ b/api/routers/solver.py
@@ -69,8 +69,10 @@ from api.schemas.solver import (
     SolutionMetrics,
     SolveRequest,
     SolveResponse,
+    StabilityMetrics,
     ViolationInfo,
 )
+from api.utils.solver_stability import compute_stability_metrics
 
 router = APIRouter(prefix="/solver", tags=["solver"])
 
@@ -271,6 +273,9 @@ def solve_schedule(
     solver.build_model(context)
     solution = solver.solve()
 
+    # Compute stability vs the org's currently-published solution.
+    stability = compute_stability_metrics(db, org_id=org.id, new_assignments=solution.assignments)
+
     # Save solution to database
     db_solution = DBSolution(
         org_id=org.id,
@@ -282,7 +287,11 @@ def solve_schedule(
             "fairness": {
                 "stdev": solution.metrics.fairness.stdev,
                 "per_person_counts": solution.metrics.fairness.per_person_counts,
-            }
+            },
+            "stability": {
+                "moves_from_published": stability.moves_from_published,
+                "affected_persons": stability.affected_persons,
+            },
         },
     )
     db.add(db_solution)
@@ -323,6 +332,10 @@ def solve_schedule(
         fairness=FairnessMetrics(
             stdev=solution.metrics.fairness.stdev,
             per_person_counts=solution.metrics.fairness.per_person_counts,
+        ),
+        stability=StabilityMetrics(
+            moves_from_published=stability.moves_from_published,
+            affected_persons=stability.affected_persons,
         ),
     )
 

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -32,6 +32,13 @@ class FairnessMetrics(BaseModel):
     per_person_counts: dict[str, int]
 
 
+class StabilityMetrics(BaseModel):
+    """Stability metrics relative to the org's currently-published solution."""
+
+    moves_from_published: int = 0
+    affected_persons: int = 0
+
+
 class SolutionMetrics(BaseModel):
     """Schema for solution metrics."""
 
@@ -40,6 +47,7 @@ class SolutionMetrics(BaseModel):
     health_score: float
     solve_ms: float
     fairness: FairnessMetrics
+    stability: StabilityMetrics = Field(default_factory=StabilityMetrics)
 
 
 class AssignmentInfo(BaseModel):

--- a/api/utils/solver_stability.py
+++ b/api/utils/solver_stability.py
@@ -1,0 +1,62 @@
+"""Compute stability metrics for a fresh solve against the org's published baseline.
+
+Sprint 6 PR 6.1 turns ``StabilityMetrics`` from a zero-stub into a real
+signal. The diff is computed using the same ``(event_id, person_id, role)``
+key shape as the ``GET /solutions/{a}/compare/{b}`` endpoint added in Sprint
+5 PR 5.5 (see ``api/routers/solutions.py::compare_solutions``).
+
+Note on role: the solver currently writes ``Assignment.role = NULL`` because
+the in-memory ``api.core.models.Assignment`` does not carry per-assignee
+roles. So a freshly-solved key always looks like ``(event_id, person_id,
+None)``. If a prior published solution has rows with non-null roles, those
+rows will compare as different from the new ``role=None`` rows — that is
+intentional: a role change is a real assignment change.
+"""
+
+from sqlalchemy.orm import Session
+
+from api.core.models import Assignment as CoreAssignment
+from api.core.models import StabilityMetrics
+from api.models import Assignment as DBAssignment
+from api.models import Solution
+
+
+def compute_stability_metrics(
+    db: Session,
+    *,
+    org_id: str,
+    new_assignments: list[CoreAssignment],
+) -> StabilityMetrics:
+    """Diff ``new_assignments`` against the org's currently-published solution.
+
+    Returns ``StabilityMetrics(0, 0)`` when no solution is published in the org.
+    """
+    published = (
+        db.query(Solution)
+        .filter(Solution.org_id == org_id, Solution.is_published.is_(True))
+        .first()
+    )
+    if published is None:
+        return StabilityMetrics()
+
+    prior_rows = db.query(DBAssignment).filter(DBAssignment.solution_id == published.id).all()
+    prior_keys: set[tuple[str, str, str | None]] = {
+        (
+            str(r.event_id),
+            str(r.person_id),
+            str(r.role) if r.role is not None else None,
+        )
+        for r in prior_rows
+    }
+
+    new_keys: set[tuple[str, str, str | None]] = {
+        (a.event_id, person_id, None) for a in new_assignments for person_id in a.assignees
+    }
+
+    sym_diff = prior_keys.symmetric_difference(new_keys)
+    affected = {person_id for (_, person_id, _) in sym_diff}
+
+    return StabilityMetrics(
+        moves_from_published=len(sym_diff),
+        affected_persons=len(affected),
+    )

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -3251,6 +3251,9 @@
           "solve_ms": {
             "title": "Solve Ms",
             "type": "number"
+          },
+          "stability": {
+            "$ref": "#/components/schemas/StabilityMetrics"
           }
         },
         "required": [
@@ -3419,6 +3422,23 @@
           "message"
         ],
         "title": "SolveResponse",
+        "type": "object"
+      },
+      "StabilityMetrics": {
+        "description": "Stability metrics relative to the org's currently-published solution.",
+        "properties": {
+          "affected_persons": {
+            "default": 0,
+            "title": "Affected Persons",
+            "type": "integer"
+          },
+          "moves_from_published": {
+            "default": 0,
+            "title": "Moves From Published",
+            "type": "integer"
+          }
+        },
+        "title": "StabilityMetrics",
         "type": "object"
       },
       "TeamCreate": {

--- a/tests/unit/test_solver_stability.py
+++ b/tests/unit/test_solver_stability.py
@@ -1,0 +1,192 @@
+"""Unit tests: compute_stability_metrics against a published solution.
+
+Sprint 6 PR 6.1 turns the dormant StabilityMetrics zero-stub into a real
+signal: how many ``(event_id, person_id, role)`` tuples differ between a
+fresh solve's assignments and the org's currently-published solution, and
+how many distinct people are affected.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from api.core.models import Assignment as CoreAssignment
+from api.models import Assignment as DBAssignment
+from api.models import Event, Person, Solution
+from api.timeutils import utcnow
+from api.utils.solver_stability import compute_stability_metrics
+
+
+@pytest.fixture
+def org_id():
+    return "test_org"  # auto-seeded by tests/conftest.py reset
+
+
+def _seed_event(db, org_id: str, event_id: str) -> Event:
+    start = datetime(2026, 6, 1, 10, 0, 0)
+    e = Event(
+        id=event_id,
+        org_id=org_id,
+        type="Service",
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+    )
+    db.add(e)
+    db.commit()
+    return e
+
+
+def _seed_person(db, org_id: str, person_id: str) -> Person:
+    p = Person(id=person_id, org_id=org_id, name=person_id.title(), roles=[])
+    db.add(p)
+    db.commit()
+    return p
+
+
+def _seed_published_solution(
+    db, org_id: str, *, assignments: list[tuple[str, str, str | None]]
+) -> Solution:
+    """Create a published Solution with the given (event_id, person_id, role) rows."""
+    sol = Solution(
+        org_id=org_id,
+        solve_ms=10.0,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=1.0,
+        metrics={},
+        is_published=True,
+        published_at=utcnow(),
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+
+    for event_id, person_id, role in assignments:
+        db.add(
+            DBAssignment(
+                solution_id=sol.id,
+                event_id=event_id,
+                person_id=person_id,
+                role=role,
+            )
+        )
+    db.commit()
+    return sol
+
+
+def test_no_prior_published_returns_zeros(db, org_id):
+    """When no solution is published in the org, both metrics are 0."""
+    new_assignments = [CoreAssignment(event_id="e1", assignees=["p1"])]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    assert metrics.moves_from_published == 0
+    assert metrics.affected_persons == 0
+
+
+def test_byte_equal_solve_returns_zeros(db, org_id):
+    """When the new solve matches the published solution exactly, metrics are 0."""
+    _seed_event(db, org_id, "e1")
+    _seed_event(db, org_id, "e2")
+    _seed_person(db, org_id, "p1")
+    _seed_person(db, org_id, "p2")
+    _seed_published_solution(db, org_id, assignments=[("e1", "p1", None), ("e2", "p2", None)])
+
+    new_assignments = [
+        CoreAssignment(event_id="e1", assignees=["p1"]),
+        CoreAssignment(event_id="e2", assignees=["p2"]),
+    ]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    assert metrics.moves_from_published == 0
+    assert metrics.affected_persons == 0
+
+
+def test_one_swap_counts_as_two_moves(db, org_id):
+    """Replacing p1 with p3 on e1 = 2 moves (1 removed + 1 added), 2 affected."""
+    for pid in ("p1", "p2", "p3"):
+        _seed_person(db, org_id, pid)
+    _seed_event(db, org_id, "e1")
+    _seed_event(db, org_id, "e2")
+    _seed_published_solution(db, org_id, assignments=[("e1", "p1", None), ("e2", "p2", None)])
+
+    new_assignments = [
+        CoreAssignment(event_id="e1", assignees=["p3"]),  # changed: p1 → p3
+        CoreAssignment(event_id="e2", assignees=["p2"]),  # unchanged
+    ]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    assert metrics.moves_from_published == 2
+    assert metrics.affected_persons == 2  # p1 (removed) + p3 (added)
+
+
+def test_completely_different_solve(db, org_id):
+    """Disjoint assignment sets produce |a| + |b| moves."""
+    for pid in ("p1", "p2", "p3", "p4"):
+        _seed_person(db, org_id, pid)
+    for eid in ("e1", "e2"):
+        _seed_event(db, org_id, eid)
+    _seed_published_solution(db, org_id, assignments=[("e1", "p1", None), ("e2", "p2", None)])
+
+    new_assignments = [
+        CoreAssignment(event_id="e1", assignees=["p3"]),
+        CoreAssignment(event_id="e2", assignees=["p4"]),
+    ]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    assert metrics.moves_from_published == 4
+    assert metrics.affected_persons == 4
+
+
+def test_role_differences_in_prior_count_as_moves(db, org_id):
+    """Solver writes role=None; if prior used a role string, both rows differ."""
+    _seed_person(db, org_id, "p1")
+    _seed_event(db, org_id, "e1")
+    _seed_published_solution(db, org_id, assignments=[("e1", "p1", "usher")])
+
+    new_assignments = [CoreAssignment(event_id="e1", assignees=["p1"])]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    # Prior key = (e1, p1, "usher"); new key = (e1, p1, None) — different tuples.
+    assert metrics.moves_from_published == 2
+    assert metrics.affected_persons == 1
+
+
+def test_multi_assignee_event_counted_per_person(db, org_id):
+    """An Event with multiple assignees expands into one key per person."""
+    for pid in ("p1", "p2"):
+        _seed_person(db, org_id, pid)
+    _seed_event(db, org_id, "e1")
+    _seed_published_solution(db, org_id, assignments=[("e1", "p1", None), ("e1", "p2", None)])
+
+    new_assignments = [CoreAssignment(event_id="e1", assignees=["p1", "p2"])]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    assert metrics.moves_from_published == 0
+    assert metrics.affected_persons == 0
+
+
+def test_other_org_published_solution_ignored(db, org_id):
+    """Stability is scoped per-org; another org's published solution is irrelevant."""
+    from api.models import Organization
+
+    other = Organization(id="other_org", name="Other", region="US", config={})
+    db.add(other)
+    db.commit()
+
+    _seed_person(db, "other_org", "px")
+    _seed_event(db, "other_org", "ex")
+    _seed_published_solution(db, "other_org", assignments=[("ex", "px", None)])
+
+    new_assignments = [CoreAssignment(event_id="e1", assignees=["p1"])]
+
+    metrics = compute_stability_metrics(db, org_id=org_id, new_assignments=new_assignments)
+
+    # No published solution for org_id="test_org" — zero baseline.
+    assert metrics.moves_from_published == 0
+    assert metrics.affected_persons == 0


### PR DESCRIPTION
## Summary

Replaces the dormant `StabilityMetrics()` zero-stub at `api/core/solver/heuristics.py:284` with a real signal computed on every solve:

- **`moves_from_published`** — symmetric-difference size of `(event_id, person_id, role)` tuples between the new solve's assignments and the org's currently-published solution.
- **`affected_persons`** — distinct `person_id`s appearing in that diff.

When no solution is published in the org, both are 0. Reuses the same key shape as the compare endpoint (Sprint 5 PR 5.5).

## Changed files

- `api/utils/solver_stability.py` (new) — `compute_stability_metrics(db, org_id, new_assignments)`. Strict mypy clean.
- `api/routers/solver.py` — call helper between `solve()` and DB write; persist into `db_solution.metrics["stability"]`; include in `SolveResponse`.
- `api/schemas/solver.py` — new `StabilityMetrics` schema; `SolutionMetrics.stability` field with zero default.
- `tests/unit/test_solver_stability.py` (new) — 7 unit cases covering no-prior, byte-equal, single swap, fully disjoint, role-only diff, multi-assignee event, other-org isolation.
- `tests/contract/openapi.snapshot.json` — refreshed for the new schema.

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api tests` clean
- [x] `poetry run mypy api/utils` strict clean (new module is fully typed)
- [x] `poetry run pytest tests/unit/ tests/api/ tests/cli/ tests/contract/ tests/integration/` — 604 passed locally
- [ ] CI green on the PR

## Follow-ups

- **6.2** wires `change_min` through to candidate scoring — uses the same key shape to nudge the solver toward keeping the published baseline. 6.1 only computes the metric; it does not yet feed back into solver decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)