### PR TITLE
Sprint 6 PR 6.3: Workload-cap predicate (P{N}D rolling window)

### DIFF
--- a/api/core/constraints/eval.py
+++ b/api/core/constraints/eval.py
@@ -1,5 +1,6 @@
 """Constraint evaluation engine."""
 
+from datetime import date
 
 from api.core.constraints.dsl import ConstraintResult, EvalContext
 from api.core.constraints.predicates import (
@@ -91,11 +92,27 @@ def evaluate_constraint(binding: ConstraintBinding, ctx: EvalContext) -> Constra
         period = action.enforce_cap.get("period", "P1M")
         max_count = action.enforce_cap.get("max_count", 999)
 
-        # Simple monthly cap
-        if period == "P1M" and ctx.date:
-            month_start = ctx.date.replace(day=1)
-            month_end = (month_start + timedelta(days=32)).replace(day=1) - timedelta(days=1)
-            count = count_assignments_in_period(ctx, ctx.person.id, month_start, month_end)
+        # Resolve [win_start, win_end] for the configured period.
+        win_start: date | None = None
+        win_end: date | None = None
+        if ctx.date:
+            if period == "P1M":
+                win_start = ctx.date.replace(day=1)
+                win_end = (win_start + timedelta(days=32)).replace(day=1) - timedelta(days=1)
+            elif period.startswith("P") and period.endswith("D"):
+                # Rolling N-day window centered on the candidate event date.
+                # For N=7, half=3, win=[date-3, date+3] (7 days inclusive).
+                try:
+                    window_days = int(period[1:-1])
+                except ValueError:
+                    window_days = 0
+                if window_days > 0:
+                    half = window_days // 2
+                    win_start = ctx.date - timedelta(days=half)
+                    win_end = ctx.date + timedelta(days=window_days - half - 1)
+
+        if win_start is not None and win_end is not None:
+            count = count_assignments_in_period(ctx, ctx.person.id, win_start, win_end)
             if count >= max_count:
                 return ConstraintResult(
                     satisfied=False,

--- a/specs/020-solver-quality-changemin/spec.md
+++ b/specs/020-solver-quality-changemin/spec.md
@@ -75,14 +75,20 @@ A new constraint DSL predicate `workload_cap`:
 ```yaml
 constraints:
   - key: weekly_volunteer_cap
-    predicate: workload_cap
+    scope: person
+    applies_to: ["service"]
     severity: hard
-    params:
-      max_per_window_days: 7
-      max_count: 2
+    then:
+      enforce_cap:
+        period: P7D
+        max_count: 2
 ```
 
 Evaluates per `Person` over a rolling N-day window centered on each candidate event. Rejects (or penalizes, per `severity`) candidates that would exceed `max_count`. Reuses the existing constraint DSL evaluator (`api/core/constraints/eval.py`).
+
+**Implementation note**: Sprint 6 PR 6.3 reuses the existing `enforce_cap` action shape rather than introducing a new top-level `predicate` node. The `period` field accepts ISO-8601 abbreviated durations: `P1M` (existing — calendar month) or `P{N}D` (new — rolling N-day window centered on the candidate event date). For `P7D` and a candidate on Jun 7, the window is `[Jun 4, Jun 10]`.
+
+**Out of scope for 6.3**: wiring DB `Constraint` rows into `SolveContext.constraints`. The router currently passes `constraints = []` (`api/routers/solver.py:189`). Once that wiring exists, admins can author workload-cap constraints via the constraint API and the solver will honor them. Until then, the predicate is unit-tested via `evaluate_constraint` directly.
 
 ### Performance SLO target
 

--- a/tests/unit/test_workload_cap.py
+++ b/tests/unit/test_workload_cap.py
@@ -1,0 +1,198 @@
+"""Unit tests: enforce_cap with P{N}D rolling windows.
+
+Sprint 6 PR 6.3 extends the existing ``enforce_cap`` constraint action to
+support rolling N-day windows in addition to the prior ``P1M`` (monthly)
+window. Period strings follow ISO-8601 abbreviated form: ``P7D`` = 7 days,
+``P14D`` = 14 days, etc. Window is **centered** on the candidate event
+date — for ``P7D`` and event on Jun 7, the window is [Jun 4, Jun 10].
+
+This is a unit test on ``evaluate_constraint`` directly — no solver, no
+router, no DB. The downstream wiring of DB constraints into solver context
+is a separate follow-up.
+"""
+
+from datetime import date, datetime, timedelta
+
+from api.core.constraints.dsl import EvalContext
+from api.core.constraints.eval import evaluate_constraint
+from api.core.models import (
+    ConstraintAction,
+    ConstraintBinding,
+    Event,
+    Person,
+)
+
+
+def _person(pid: str) -> Person:
+    return Person(id=pid, name=pid, roles=["volunteer"], skills=[], teams=[])
+
+
+def _event(eid: str, on: date) -> Event:
+    return Event(
+        id=eid,
+        type="service",
+        start=datetime.combine(on, datetime.min.time().replace(hour=10)),
+        end=datetime.combine(on, datetime.min.time().replace(hour=11)),
+    )
+
+
+def _binding(period: str, max_count: int, severity: str = "hard") -> ConstraintBinding:
+    return ConstraintBinding(
+        key="weekly_cap",
+        scope="person",
+        applies_to=["service"],
+        severity=severity,
+        weight=10 if severity == "soft" else None,
+        then=ConstraintAction(enforce_cap={"period": period, "max_count": max_count}),
+    )
+
+
+def _ctx(
+    *,
+    candidate_event: Event,
+    person: Person,
+    person_assignments: dict[str, list[Event]],
+) -> EvalContext:
+    return EvalContext(
+        event=candidate_event,
+        date=candidate_event.start.date(),
+        person=person,
+        person_assignments=person_assignments,
+    )
+
+
+def test_p7d_rejects_when_at_max_count():
+    """Person with 2 prior events inside 7d window, hard cap=2 → rejected."""
+    target_date = date(2026, 6, 7)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+    # 2 prior events in [Jun 4, Jun 10] window
+    prior = [_event("e1", target_date - timedelta(days=2)), _event("e2", target_date)]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    binding = _binding("P7D", max_count=2)
+
+    result = evaluate_constraint(binding, ctx)
+    assert result.satisfied is False
+    assert result.penalty == 1000.0
+    assert "max" in result.reason.lower() or "cap" in result.reason.lower()
+
+
+def test_p7d_allows_when_under_max():
+    """Person with 1 prior event inside window, cap=2 → satisfied."""
+    target_date = date(2026, 6, 7)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+    prior = [_event("e1", target_date - timedelta(days=1))]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    binding = _binding("P7D", max_count=2)
+
+    result = evaluate_constraint(binding, ctx)
+    assert result.satisfied is True
+
+
+def test_p7d_excludes_events_outside_window():
+    """Events more than half-window days away are not counted."""
+    target_date = date(2026, 6, 15)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+    # P7D centered on Jun 15 = [Jun 12, Jun 18]
+    # Jun 5 and Jun 25 are both outside.
+    prior = [
+        _event("e_far_back", date(2026, 6, 5)),
+        _event("e_far_forward", date(2026, 6, 25)),
+    ]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    binding = _binding("P7D", max_count=1)
+
+    result = evaluate_constraint(binding, ctx)
+    assert result.satisfied is True
+
+
+def test_p14d_window_extends_further():
+    """A 14-day window catches events a 7-day window misses."""
+    target_date = date(2026, 6, 15)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+    # 6 days before: outside P7D ([Jun 12, Jun 18]) but inside P14D ([Jun 8, Jun 21])
+    prior = [_event("e_back", date(2026, 6, 9))]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+
+    # P7D with cap=1 → satisfied (event on Jun 9 is outside window)
+    assert evaluate_constraint(_binding("P7D", max_count=1), ctx).satisfied is True
+    # P14D with cap=1 → rejected (Jun 9 is inside window, count=1 already at cap)
+    assert evaluate_constraint(_binding("P14D", max_count=1), ctx).satisfied is False
+
+
+def test_p7d_soft_severity_returns_weight_penalty():
+    """severity=soft hits the soft penalty branch with the binding's weight."""
+    target_date = date(2026, 6, 7)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+    prior = [_event("e1", target_date), _event("e2", target_date)]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    binding = _binding("P7D", max_count=2, severity="soft")
+
+    result = evaluate_constraint(binding, ctx)
+    assert result.satisfied is False
+    assert result.penalty == 10.0
+
+
+def test_p1m_period_still_works():
+    """Backwards compat: existing P1M monthly cap behavior is unchanged."""
+    p = _person("p1")
+    candidate = _event("e_target", date(2026, 6, 30))  # June
+    # 5 events in June already
+    prior = [_event(f"e{i}", date(2026, 6, i + 1)) for i in range(5)]
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    binding = _binding("P1M", max_count=5)
+
+    result = evaluate_constraint(binding, ctx)
+    assert result.satisfied is False
+
+
+def test_no_prior_assignments_satisfies():
+    """A person with no prior events is always under cap."""
+    p = _person("p1")
+    candidate = _event("e_target", date(2026, 6, 7))
+
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={})
+    binding = _binding("P7D", max_count=1)
+
+    assert evaluate_constraint(binding, ctx).satisfied is True
+
+
+def test_p7d_window_centering_math():
+    """Verify the exact window bounds for P7D centered on a target date.
+
+    For N=7, half=3, win=[date-3, date+3] inclusive, total 7 days.
+    """
+    target_date = date(2026, 6, 10)
+    p = _person("p1")
+    candidate = _event("e_target", target_date)
+
+    # Boundary cases:
+    # date-3 = Jun 7 (in window)
+    # date-4 = Jun 6 (out)
+    # date+3 = Jun 13 (in)
+    # date+4 = Jun 14 (out)
+    prior = [
+        _event("e_in_back", date(2026, 6, 7)),
+        _event("e_in_fwd", date(2026, 6, 13)),
+    ]
+    ctx = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior})
+    # cap=2, 2 already in window → reject
+    assert evaluate_constraint(_binding("P7D", max_count=2), ctx).satisfied is False
+
+    # Boundary - just outside:
+    prior_out = [
+        _event("e_out_back", date(2026, 6, 6)),
+        _event("e_out_fwd", date(2026, 6, 14)),
+    ]
+    ctx_out = _ctx(candidate_event=candidate, person=p, person_assignments={"p1": prior_out})
+    assert evaluate_constraint(_binding("P7D", max_count=2), ctx_out).satisfied is True


### PR DESCRIPTION
## Summary

Extends the existing `enforce_cap` constraint action with ISO-8601 abbreviated period strings `P{N}D` for rolling N-day windows centered on the candidate event date. The previous monthly `P1M` behavior is unchanged.

## Window math

- `P7D` and event on Jun 7: half=3, window=`[Jun 4, Jun 10]` (7 days inclusive).
- `P14D` and event on Jun 15: half=7, window=`[Jun 8, Jun 21]` (14 days inclusive).

Reuses the existing `count_assignments_in_period` helper. Hard violations return `penalty=1000`; soft return `binding.weight`.

## YAML shape (per spec)

```yaml
constraints:
  - key: weekly_volunteer_cap
    scope: person
    applies_to: ["service"]
    severity: hard
    then:
      enforce_cap:
        period: P7D
        max_count: 2
```

The spec previously sketched a top-level `predicate: workload_cap` node; this PR reuses the existing `enforce_cap` action shape instead. spec.md updated with the rationale.

## Out of scope

Wiring DB `Constraint` rows into `SolveContext.constraints`. The solver router currently passes `constraints = []` (`api/routers/solver.py:189`). When that wiring lands as a separate PR, admins can author workload-cap constraints via the constraint API and the solver will honor them. Until then, this predicate is unit-tested via `evaluate_constraint` directly.

## Changed files

- `api/core/constraints/eval.py` — `enforce_cap` resolves `[win_start, win_end]` for P1M or P{N}D, then applies the same count-vs-max check.
- `specs/020-solver-quality-changemin/spec.md` — YAML example updated; implementation note added.
- `tests/unit/test_workload_cap.py` (new) — 8 cases:
  - hard reject at cap (P7D)
  - allow under cap (P7D)
  - events outside window not counted
  - P14D catches events P7D misses
  - soft severity returns binding.weight
  - P1M backwards compat
  - no prior assignments → satisfied
  - boundary-day inclusivity (date±half = in, ±half+1 = out)

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check api/core/constraints/eval.py tests/unit/test_workload_cap.py` clean
- [x] `poetry run mypy api/utils` strict clean (touched files outside this scope)
- [x] All 5 tiers pass locally: 617 tests, 21 skipped
- [ ] CI green on the PR

## Follow-ups

- **6.4** — synthetic perf bench (1000 events × 500 people).
- **DB→solver constraint wiring** — separate PR; not gated to Sprint 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)