### PR TITLE
Sprint 6 PR 6.5: Solution stats endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ make migrate              # Run Alembic migrations
 /api/v1/events         — CRUD for events + assignments
 /api/v1/constraints    — CRUD for scheduling constraints (DSL-based)
 /api/v1/solver         — POST /solve to generate schedules
-/api/v1/solutions      — list/view, compare, publish/unpublish/rollback
+/api/v1/solutions      — list/view/stats, compare, publish/unpublish/rollback
 /api/v1/availability   — time-off / blocked dates
 /api/v1/conflicts      — conflict checking between person+event
 /api/v1/invitations    — create/verify/accept invitation tokens

--- a/api/routers/solutions.py
+++ b/api/routers/solutions.py
@@ -21,9 +21,13 @@ from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.solver import (
     AssignmentChange,
     ExportFormat,
+    FairnessStats,
     SolutionDiffResponse,
     SolutionList,
     SolutionResponse,
+    SolutionStatsResponse,
+    StabilityMetrics,
+    WorkloadStats,
 )
 from api.timeutils import utcnow
 from api.utils.audit_logger import log_audit_event
@@ -576,6 +580,73 @@ def rollback_solution(
     response = SolutionResponse.model_validate(solution)
     response.assignment_count = assignment_count
     return response
+
+
+@router.get("/{solution_id}/stats", response_model=SolutionStatsResponse)
+def get_solution_stats(
+    solution_id: int,
+    current_admin: Person = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Stats endpoint (admin only): fairness histogram + stability + workload distribution."""
+    solution = db.query(Solution).filter(Solution.id == solution_id).first()
+    if not solution:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solution {solution_id} not found",
+        )
+    verify_org_member(current_admin, solution.org_id)
+
+    metrics = solution.metrics or {}
+    fairness_raw = metrics.get("fairness", {})
+    stability_raw = metrics.get("stability", {})
+
+    per_person_counts: dict[str, int] = fairness_raw.get("per_person_counts", {}) or {}
+
+    # Histogram: count_bucket → num_people_with_that_count.
+    histogram: dict[str, int] = {}
+    for c in per_person_counts.values():
+        key = str(c)
+        histogram[key] = histogram.get(key, 0) + 1
+
+    counts = list(per_person_counts.values())
+    if counts:
+        sorted_counts = sorted(counts)
+        n = len(sorted_counts)
+        if n % 2 == 1:
+            median = float(sorted_counts[n // 2])
+        else:
+            median = (sorted_counts[n // 2 - 1] + sorted_counts[n // 2]) / 2.0
+        max_v = max(counts)
+        min_v = min(counts)
+        total = sum(counts)
+        distinct = len(per_person_counts)
+    else:
+        median = 0.0
+        max_v = 0
+        min_v = 0
+        total = 0
+        distinct = 0
+
+    return SolutionStatsResponse(
+        solution_id=int(solution.id),
+        fairness=FairnessStats(
+            stdev=float(fairness_raw.get("stdev", 0.0)),
+            per_person_counts=per_person_counts,
+            histogram=histogram,
+        ),
+        stability=StabilityMetrics(
+            moves_from_published=int(stability_raw.get("moves_from_published", 0)),
+            affected_persons=int(stability_raw.get("affected_persons", 0)),
+        ),
+        workload=WorkloadStats(
+            max_events_per_person=max_v,
+            min_events_per_person=min_v,
+            median_events_per_person=median,
+            total_events_assigned=total,
+            distinct_persons_assigned=distinct,
+        ),
+    )
 
 
 @router.delete("/{solution_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -117,3 +117,30 @@ class SolutionDiffResponse(BaseModel):
     unchanged_count: int
     affected_persons: list[str]
     moves: int
+
+
+class FairnessStats(BaseModel):
+    """Fairness metrics + histogram of per-person assignment counts."""
+
+    stdev: float
+    per_person_counts: dict[str, int]
+    histogram: dict[str, int]  # str-keyed for JSON: "count" → num_people
+
+
+class WorkloadStats(BaseModel):
+    """Aggregate workload distribution stats."""
+
+    max_events_per_person: int
+    min_events_per_person: int
+    median_events_per_person: float
+    total_events_assigned: int
+    distinct_persons_assigned: int
+
+
+class SolutionStatsResponse(BaseModel):
+    """Stats response for ``GET /solutions/{id}/stats`` (admin only)."""
+
+    solution_id: int
+    fairness: FairnessStats
+    stability: StabilityMetrics
+    workload: WorkloadStats

--- a/tests/api/test_solution_stats.py
+++ b/tests/api/test_solution_stats.py
@@ -1,0 +1,195 @@
+"""Solution stats tests for /api/v1/solutions/{id}/stats.
+
+Sprint 6 PR 6.5 adds an admin-only stats endpoint that returns derived
+metrics for any solution in the caller's org:
+
+- ``fairness`` — stdev, per-person counts, and a histogram (count → num_people).
+- ``stability`` — moves_from_published and affected_persons (from 6.1).
+- ``workload`` — max/min/median events per person, totals.
+
+The values come from the persisted ``Solution.metrics`` dict (populated at
+solve time in ``api/routers/solver.py``) plus aggregations computed at
+request time from the same dict.
+"""
+
+import pytest
+
+from api.models import Solution
+from api.timeutils import utcnow
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@o.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _seed_solution_with_metrics(
+    db,
+    org_id: str,
+    *,
+    per_person_counts: dict[str, int],
+    moves_from_published: int = 0,
+    affected_persons: int = 0,
+) -> Solution:
+    sol = Solution(
+        org_id=org_id,
+        solve_ms=12.5,
+        hard_violations=0,
+        soft_score=2.0,
+        health_score=98.0,
+        metrics={
+            "fairness": {
+                "stdev": 0.5,
+                "per_person_counts": per_person_counts,
+            },
+            "stability": {
+                "moves_from_published": moves_from_published,
+                "affected_persons": affected_persons,
+            },
+        },
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    return sol
+
+
+@pytest.mark.no_mock_auth
+class TestSolutionStats:
+    def test_admin_can_get_stats(self, client, db):
+        org_id = "stats-ok"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "ok")
+        sol = _seed_solution_with_metrics(
+            db,
+            org_id,
+            per_person_counts={"p1": 3, "p2": 2, "p3": 2, "p4": 1},
+            moves_from_published=4,
+            affected_persons=2,
+        )
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/stats", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+
+        body = resp.json()
+        assert body["solution_id"] == sol.id
+
+        # Fairness — exposes stdev, per-person counts, and a histogram.
+        assert body["fairness"]["stdev"] == 0.5
+        assert body["fairness"]["per_person_counts"] == {
+            "p1": 3,
+            "p2": 2,
+            "p3": 2,
+            "p4": 1,
+        }
+        # Histogram: count → num_people_with_that_count.
+        assert body["fairness"]["histogram"] == {"1": 1, "2": 2, "3": 1}
+
+        # Stability — pass-through from the persisted metrics.
+        assert body["stability"]["moves_from_published"] == 4
+        assert body["stability"]["affected_persons"] == 2
+
+        # Workload — derived aggregations on per_person_counts.
+        assert body["workload"]["max_events_per_person"] == 3
+        assert body["workload"]["min_events_per_person"] == 1
+        assert body["workload"]["median_events_per_person"] == 2.0
+        assert body["workload"]["total_events_assigned"] == 8
+        assert body["workload"]["distinct_persons_assigned"] == 4
+
+    def test_volunteer_blocked(self, client, db):
+        org_id = "stats-vol"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "vol-admin")
+        seed_user(
+            client,
+            org_id,
+            email="vol@o.org",
+            name="Vol",
+            password="VolPass1!",
+            roles=["volunteer"],
+        )
+        vol_hdrs = auth_headers(client, email="vol@o.org", password="VolPass1!")
+        sol = _seed_solution_with_metrics(db, org_id, per_person_counts={"p1": 1})
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/stats", headers=vol_hdrs)
+        assert resp.status_code == 403
+
+    def test_cross_org_blocked(self, client, db):
+        seed_org(client, "stats-a")
+        seed_org(client, "stats-b")
+        a_hdrs = _admin_for(client, "stats-a", "a")
+        sol_b = _seed_solution_with_metrics(db, "stats-b", per_person_counts={"p1": 1})
+
+        resp = client.get(f"/api/v1/solutions/{sol_b.id}/stats", headers=a_hdrs)
+        assert resp.status_code == 403
+
+    def test_missing_solution_404(self, client, db):
+        org_id = "stats-missing"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "missing")
+
+        resp = client.get("/api/v1/solutions/9999999/stats", headers=hdrs)
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client, db):
+        org_id = "stats-noauth"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "noauth")
+        sol = _seed_solution_with_metrics(db, org_id, per_person_counts={"p1": 1})
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/stats")
+        assert resp.status_code in (401, 403)
+
+    def test_empty_per_person_counts(self, client, db):
+        """A solution with no assigned people returns sensible zero/empty values."""
+        org_id = "stats-empty"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "empty")
+        sol = _seed_solution_with_metrics(db, org_id, per_person_counts={})
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/stats", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["fairness"]["histogram"] == {}
+        assert body["workload"]["max_events_per_person"] == 0
+        assert body["workload"]["min_events_per_person"] == 0
+        assert body["workload"]["median_events_per_person"] == 0.0
+        assert body["workload"]["total_events_assigned"] == 0
+        assert body["workload"]["distinct_persons_assigned"] == 0
+
+    def test_missing_metrics_keys_treated_as_zero(self, client, db):
+        """A solution persisted before 6.1 has no stability metrics; default to 0."""
+        org_id = "stats-legacy"
+        seed_org(client, org_id)
+        hdrs = _admin_for(client, org_id, "legacy")
+
+        sol = Solution(
+            org_id=org_id,
+            solve_ms=10.0,
+            hard_violations=0,
+            soft_score=1.0,
+            health_score=99.0,
+            metrics={},  # no fairness or stability keys
+            is_published=False,
+            published_at=None,
+        )
+        sol.created_at = utcnow()
+        db.add(sol)
+        db.commit()
+        db.refresh(sol)
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/stats", headers=hdrs)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["stability"]["moves_from_published"] == 0
+        assert body["stability"]["affected_persons"] == 0
+        assert body["fairness"]["stdev"] == 0.0
+        assert body["fairness"]["per_person_counts"] == {}
+        assert body["fairness"]["histogram"] == {}

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1072,6 +1072,36 @@
         "title": "FairnessMetrics",
         "type": "object"
       },
+      "FairnessStats": {
+        "description": "Fairness metrics + histogram of per-person assignment counts.",
+        "properties": {
+          "histogram": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Histogram",
+            "type": "object"
+          },
+          "per_person_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Per Person Counts",
+            "type": "object"
+          },
+          "stdev": {
+            "title": "Stdev",
+            "type": "number"
+          }
+        },
+        "required": [
+          "stdev",
+          "per_person_counts",
+          "histogram"
+        ],
+        "title": "FairnessStats",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -3346,6 +3376,32 @@
         "title": "SolutionResponse",
         "type": "object"
       },
+      "SolutionStatsResponse": {
+        "description": "Stats response for ``GET /solutions/{id}/stats`` (admin only).",
+        "properties": {
+          "fairness": {
+            "$ref": "#/components/schemas/FairnessStats"
+          },
+          "solution_id": {
+            "title": "Solution Id",
+            "type": "integer"
+          },
+          "stability": {
+            "$ref": "#/components/schemas/StabilityMetrics"
+          },
+          "workload": {
+            "$ref": "#/components/schemas/WorkloadStats"
+          }
+        },
+        "required": [
+          "solution_id",
+          "fairness",
+          "stability",
+          "workload"
+        ],
+        "title": "SolutionStatsResponse",
+        "type": "object"
+      },
       "SolveRequest": {
         "description": "Schema for solve request.",
         "properties": {
@@ -3752,6 +3808,40 @@
           "severity"
         ],
         "title": "ViolationInfo",
+        "type": "object"
+      },
+      "WorkloadStats": {
+        "description": "Aggregate workload distribution stats.",
+        "properties": {
+          "distinct_persons_assigned": {
+            "title": "Distinct Persons Assigned",
+            "type": "integer"
+          },
+          "max_events_per_person": {
+            "title": "Max Events Per Person",
+            "type": "integer"
+          },
+          "median_events_per_person": {
+            "title": "Median Events Per Person",
+            "type": "number"
+          },
+          "min_events_per_person": {
+            "title": "Min Events Per Person",
+            "type": "integer"
+          },
+          "total_events_assigned": {
+            "title": "Total Events Assigned",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_events_per_person",
+          "min_events_per_person",
+          "median_events_per_person",
+          "total_events_assigned",
+          "distinct_persons_assigned"
+        ],
+        "title": "WorkloadStats",
         "type": "object"
       }
     },
@@ -8671,6 +8761,54 @@
           }
         ],
         "summary": "Rollback Solution",
+        "tags": [
+          "solutions"
+        ]
+      }
+    },
+    "/api/v1/solutions/{solution_id}/stats": {
+      "get": {
+        "description": "Stats endpoint (admin only): fairness histogram + stability + workload distribution.",
+        "operationId": "getSolutionStats",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "solution_id",
+            "required": true,
+            "schema": {
+              "title": "Solution Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionStatsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Solution Stats",
         "tags": [
           "solutions"
         ]


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/solutions/{id}/stats` — admin-only, scoped to the caller's org. Returns derived metrics from the persisted `Solution.metrics` dict:

- **fairness** — stdev, per-person counts, histogram (`count_bucket → num_people_with_that_count`).
- **stability** — `moves_from_published` + `affected_persons`, passthrough from 6.1.
- **workload** — max/min/median events per person, total assigned, distinct persons.

Aggregations (histogram, workload) are computed at request time from the same `per_person_counts` the solver writes at solve time.

## Compatibility with pre-6.1 solutions

Solutions persisted before 6.1 have no `stability` key in `metrics`. The handler uses defensive `.get()` with sensible defaults so they return zeros rather than crashing. Tested explicitly.

## Changed files

- `api/schemas/solver.py` — `FairnessStats`, `WorkloadStats`, `SolutionStatsResponse`.
- `api/routers/solutions.py` — handler after `rollback_solution`, mirrors admin-only verify_org_member pattern.
- `CLAUDE.md` — active-routers line updated.
- `tests/api/test_solution_stats.py` (new) — 7 cases: happy path with histogram + workload assertions, volunteer-blocked, cross-org-blocked, missing solution 404, requires auth, empty per_person_counts, legacy metrics missing keys.
- `tests/contract/openapi.snapshot.json` — refreshed for the new schemas.

## Test plan

- [x] `poetry run black --check api tests` clean
- [x] `poetry run ruff check` clean for touched files
- [x] All 5 tiers pass locally: 625 tests, 21 skipped
- [ ] CI green on the PR

## Closing Sprint 6

This is the final PR in Sprint 6:

- 6.0 — spec doc
- 6.1 — stability metrics on every solve
- 6.2 — change-min weight in candidate scoring
- 6.3 — workload-cap predicate (P{N}D rolling window)
- 6.4 — solver perf benchmark + SLO calibration
- 6.5 — solution stats endpoint (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)