### PR TITLE
Sprint 7 PR 7.2: mobile-codegen target + auth flow (login, JWT, role)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,31 @@ test-contract: check-poetry
 update-openapi-snapshot: check-poetry
 	@echo "🔄 Refreshing OpenAPI contract snapshot..."
 	@poetry run python -m tests.contract.test_openapi_snapshot --update
-	@echo "✅ Snapshot updated. Review the diff, run 'make mobile-codegen' once mobile/ exists, then commit."
+	@echo "✅ Snapshot updated. Review the diff, run 'make mobile-codegen' to refresh the Flutter client, then commit."
+
+# ============================================================================
+# Mobile (Flutter) — see specs/022-flutter-mobile-app/spec.md
+# ============================================================================
+
+# Regenerate the Dart API client from the OpenAPI snapshot.
+# Requires: openjdk@17 (`brew install openjdk@17`) and node (already required).
+# Run after any backend API change that you want surfaced to the iOS app.
+mobile-codegen:
+	@echo "🔄 Generating Flutter API client from OpenAPI snapshot..."
+	@command -v java >/dev/null 2>&1 || { \
+		echo "❌ Java not found. Install with: brew install openjdk@17"; \
+		echo "   Then either re-link or set JAVA_HOME to /opt/homebrew/opt/openjdk@17."; \
+		exit 1; \
+	}
+	@npx -y @openapitools/openapi-generator-cli@2.20.2 generate \
+	  -i tests/contract/openapi.snapshot.json \
+	  -g dart-dio \
+	  -o mobile/lib/api \
+	  --additional-properties=pubName=signupflow_api,pubVersion=0.0.1,nullSafe=true,nullableFields=true \
+	  --skip-validate-spec
+	@cd mobile && PATH=/Users/tomwu/Projects/flutter/bin:$$PATH flutter pub get
+	@cd mobile && PATH=/Users/tomwu/Projects/flutter/bin:$$PATH dart run build_runner build --delete-conflicting-outputs
+	@echo "✅ Mobile API client regenerated at mobile/lib/api/."
 
 # ============================================================================
 # Docker Compose Commands (Development Environment)

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/mobile/lib/api/api_client.dart
+++ b/mobile/lib/api/api_client.dart
@@ -1,0 +1,52 @@
+// Hand-rolled dio client for the endpoints PR 7.2 needs (login + people/me).
+//
+// Note: this file lives at mobile/lib/api/ so it'll be REPLACED by generated
+// code once `make mobile-codegen` is run with Java available. Keep the public
+// surface (api_client provider, AuthApi, PeopleApi) compatible so the swap
+// is mechanical.
+//
+// Until then, any new endpoint added here must be done by hand and tracked
+// against tests/contract/openapi.snapshot.json so signatures stay in sync.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+const String defaultApiBaseUrl = String.fromEnvironment(
+  'API_BASE_URL',
+  defaultValue: 'http://localhost:8000/api/v1',
+);
+
+/// Provides a dio instance configured with the API base URL + a token
+/// interceptor that adds `Authorization: Bearer <jwt>` from secure storage.
+final dioProvider = Provider<Dio>((ref) {
+  final storage = ref.watch(secureTokenStorageProvider);
+  final dio = Dio(BaseOptions(
+    baseUrl: defaultApiBaseUrl,
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 30),
+    contentType: 'application/json',
+    headers: <String, dynamic>{'Accept': 'application/json'},
+  ));
+
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final token = await storage.readToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        handler.next(options);
+      },
+      onError: (e, handler) async {
+        // 401 → wipe token; router redirect handles the bounce to /login.
+        if (e.response?.statusCode == 401) {
+          await storage.clearToken();
+        }
+        handler.next(e);
+      },
+    ),
+  );
+
+  return dio;
+});

--- a/mobile/lib/api/auth_api.dart
+++ b/mobile/lib/api/auth_api.dart
@@ -1,0 +1,26 @@
+// POST /auth/login — returns JWT + role claim.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/api/models.dart';
+
+class AuthApi {
+  AuthApi(this._dio);
+  final Dio _dio;
+
+  Future<LoginResponse> login(LoginRequest req) async {
+    final res = await _dio.post<Map<String, dynamic>>(
+      '/auth/login',
+      data: req.toJson(),
+    );
+    if (res.data == null) {
+      throw const FormatException('empty /auth/login response');
+    }
+    return LoginResponse.fromJson(res.data!);
+  }
+}
+
+final authApiProvider = Provider<AuthApi>((ref) {
+  return AuthApi(ref.watch(dioProvider));
+});

--- a/mobile/lib/api/models.dart
+++ b/mobile/lib/api/models.dart
@@ -1,0 +1,63 @@
+// Minimal hand-rolled models for the endpoints PR 7.2 needs.
+// Will be replaced by generated dart-dio + built_value classes once
+// `make mobile-codegen` runs (Java required — see Makefile).
+
+class LoginRequest {
+  const LoginRequest({required this.email, required this.password});
+  final String email;
+  final String password;
+
+  Map<String, dynamic> toJson() => {'email': email, 'password': password};
+}
+
+class LoginResponse {
+  const LoginResponse({
+    required this.token,
+    required this.personId,
+    required this.email,
+    required this.roles,
+  });
+
+  final String token;
+  final String personId;
+  final String email;
+  final List<String> roles;
+
+  factory LoginResponse.fromJson(Map<String, dynamic> json) {
+    final person = (json['person'] as Map<String, dynamic>?) ?? json;
+    final roles = (person['roles'] as List<dynamic>?) ?? const <dynamic>[];
+    return LoginResponse(
+      token: json['token']?.toString() ?? json['access_token']?.toString() ?? '',
+      personId: person['id']?.toString() ?? '',
+      email: person['email']?.toString() ?? '',
+      roles: roles.map((r) => r.toString()).toList(),
+    );
+  }
+}
+
+class PersonMe {
+  const PersonMe({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.orgId,
+    required this.roles,
+  });
+
+  final String id;
+  final String name;
+  final String email;
+  final String orgId;
+  final List<String> roles;
+
+  factory PersonMe.fromJson(Map<String, dynamic> json) {
+    final roles = (json['roles'] as List<dynamic>?) ?? const <dynamic>[];
+    return PersonMe(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      email: json['email']?.toString() ?? '',
+      orgId: json['org_id']?.toString() ?? '',
+      roles: roles.map((r) => r.toString()).toList(),
+    );
+  }
+}

--- a/mobile/lib/api/people_api.dart
+++ b/mobile/lib/api/people_api.dart
@@ -1,0 +1,23 @@
+// GET /people/me — returns the authenticated person + role array.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/api/models.dart';
+
+class PeopleApi {
+  PeopleApi(this._dio);
+  final Dio _dio;
+
+  Future<PersonMe> me() async {
+    final res = await _dio.get<Map<String, dynamic>>('/people/me');
+    if (res.data == null) {
+      throw const FormatException('empty /people/me response');
+    }
+    return PersonMe.fromJson(res.data!);
+  }
+}
+
+final peopleApiProvider = Provider<PeopleApi>((ref) {
+  return PeopleApi(ref.watch(dioProvider));
+});

--- a/mobile/lib/auth/auth_provider.dart
+++ b/mobile/lib/auth/auth_provider.dart
@@ -1,7 +1,10 @@
-// Stub auth — Sprint 7.1 only. Real JWT/Keychain flow lands in 7.2.
-// Provides `role` (volunteer | admin | unauth) so GoRouter can branch.
+// AuthController — Riverpod state for token + role.
+// Real signIn lands in PR 7.2 (this file). Demo shortcuts retained for
+// offline dev and the widget smoke test.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/auth/login_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
 
 enum AuthRole { unauth, volunteer, admin }
 
@@ -18,14 +21,35 @@ class AuthController extends Notifier<AuthState> {
   @override
   AuthState build() => const AuthState();
 
-  // Demo shortcuts that the prototype uses too. Real /auth/login lands in 7.2.
+  /// Real /auth/login + secure storage. Returns null on success;
+  /// returns a user-facing error message on failure.
+  Future<String?> signIn(String email, String password) async {
+    try {
+      final next = await ref
+          .read(loginRepositoryProvider)
+          .signIn(email.trim(), password);
+      state = next;
+      return null;
+    } on LoginFailure catch (e) {
+      return e.message;
+    } on Exception catch (e) {
+      return 'Unexpected error: $e';
+    }
+  }
+
+  // Demo shortcuts — bypass /auth/login. Useful for design review and the
+  // smoke widget test (no network). NOT included in production builds via
+  // a const guard once we add release flavours; for now they're always on.
   void demoSignInVolunteer() =>
       state = state.copyWith(role: AuthRole.volunteer, token: 'demo-volunteer');
 
   void demoSignInAdmin() =>
       state = state.copyWith(role: AuthRole.admin, token: 'demo-admin');
 
-  void signOut() => state = const AuthState();
+  Future<void> signOut() async {
+    await ref.read(secureTokenStorageProvider).clearToken();
+    state = const AuthState();
+  }
 }
 
 final authProvider = NotifierProvider<AuthController, AuthState>(

--- a/mobile/lib/auth/login_repository.dart
+++ b/mobile/lib/auth/login_repository.dart
@@ -1,0 +1,59 @@
+// LoginRepository — wraps AuthApi + secure storage. Returns the resolved
+// AuthState (or throws) so AuthController stays declarative.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/api/auth_api.dart';
+import 'package:signupflow_mobile/api/models.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+class LoginRepository {
+  LoginRepository(this._authApi, this._storage);
+  final AuthApi _authApi;
+  final SecureTokenStorage _storage;
+
+  /// Sign in. On success, persists the token in secure storage and returns
+  /// the auth state to apply. Throws [LoginFailure] on bad creds / network.
+  Future<AuthState> signIn(String email, String password) async {
+    try {
+      final res = await _authApi.login(
+        LoginRequest(email: email, password: password),
+      );
+      if (res.token.isEmpty) {
+        throw const LoginFailure('Server returned an empty token');
+      }
+      await _storage.writeToken(res.token);
+      return AuthState(role: _resolveRole(res.roles), token: res.token);
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 401 || code == 403) {
+        throw const LoginFailure('Wrong email or password');
+      }
+      throw LoginFailure('Network error: ${e.message ?? code}');
+    }
+  }
+
+  Future<void> signOut() => _storage.clearToken();
+
+  static AuthRole _resolveRole(List<String> roles) {
+    final lower = roles.map((r) => r.toLowerCase()).toSet();
+    if (lower.contains('admin')) return AuthRole.admin;
+    if (lower.contains('volunteer')) return AuthRole.volunteer;
+    return AuthRole.unauth;
+  }
+}
+
+class LoginFailure implements Exception {
+  const LoginFailure(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+final loginRepositoryProvider = Provider<LoginRepository>((ref) {
+  return LoginRepository(
+    ref.watch(authApiProvider),
+    ref.watch(secureTokenStorageProvider),
+  );
+});

--- a/mobile/lib/auth/secure_token_storage.dart
+++ b/mobile/lib/auth/secure_token_storage.dart
@@ -1,0 +1,46 @@
+// Wraps flutter_secure_storage so the rest of the app can swap to an
+// in-memory mock for tests without depending on native plugin channels.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+abstract class SecureTokenStorage {
+  Future<String?> readToken();
+  Future<void> writeToken(String token);
+  Future<void> clearToken();
+}
+
+class _RealStorage implements SecureTokenStorage {
+  static const _key = 'signupflow.jwt';
+  final _impl = const FlutterSecureStorage(
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
+
+  @override
+  Future<String?> readToken() => _impl.read(key: _key);
+
+  @override
+  Future<void> writeToken(String token) =>
+      _impl.write(key: _key, value: token);
+
+  @override
+  Future<void> clearToken() => _impl.delete(key: _key);
+}
+
+/// In-memory implementation used by tests via Riverpod overrides.
+class InMemoryTokenStorage implements SecureTokenStorage {
+  String? _token;
+
+  @override
+  Future<String?> readToken() async => _token;
+
+  @override
+  Future<void> writeToken(String token) async => _token = token;
+
+  @override
+  Future<void> clearToken() async => _token = null;
+}
+
+final secureTokenStorageProvider = Provider<SecureTokenStorage>((ref) {
+  return _RealStorage();
+});

--- a/mobile/lib/features/auth/login_screen.dart
+++ b/mobile/lib/features/auth/login_screen.dart
@@ -1,21 +1,67 @@
-// Login screen — Sprint 7.1 stub. Real /auth/login wiring lands in 7.2.
-// Visual: matches mobile/prototype/screenshots/v2/01-login.png.
+// Login screen — wired to /auth/login + flutter_secure_storage in PR 7.2.
+// Visual matches mobile/prototype/screenshots/v2/01-login.png.
+// Demo shortcuts retained — they bypass the network for offline dev.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-
 import 'package:signupflow_mobile/auth/auth_provider.dart';
 import 'package:signupflow_mobile/shared/widgets/brand.dart';
 import 'package:signupflow_mobile/theme/colors.dart';
 import 'package:signupflow_mobile/theme/components.dart';
 import 'package:signupflow_mobile/theme/typography.dart';
 
-class LoginScreen extends ConsumerWidget {
+class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signIn() async {
+    if (_busy) return;
+    final email = _email.text.trim();
+    final pw = _password.text;
+    if (email.isEmpty || pw.isEmpty) {
+      setState(() => _error = 'Email and password required');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final err = await ref.read(authProvider.notifier).signIn(email, pw);
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (err != null) {
+      setState(() => _error = err);
+      return;
+    }
+    final role = ref.read(authProvider).role;
+    if (role == AuthRole.admin) {
+      context.go('/a/dashboard');
+    } else if (role == AuthRole.volunteer) {
+      context.go('/v/schedule');
+    } else {
+      setState(() => _error = 'No role assigned. Contact your admin.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final auth = ref.read(authProvider.notifier);
 
     return Scaffold(
@@ -36,21 +82,33 @@ class LoginScreen extends ConsumerWidget {
                 ),
                 const SizedBox(height: 44),
 
-                const _Field(label: 'Email', placeholder: 'you@church.org'),
+                _Field(
+                  label: 'Email',
+                  controller: _email,
+                  hint: 'you@church.org',
+                  keyboard: TextInputType.emailAddress,
+                ),
                 const SizedBox(height: 10),
-                const _Field(
+                _Field(
                   label: 'Password',
-                  placeholder: '•••••••',
+                  controller: _password,
+                  hint: '•••••••',
                   obscure: true,
                 ),
 
+                if (_error != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    _error!,
+                    style: BlockType.bodySm.copyWith(color: BlockColors.danger),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+
                 const SizedBox(height: 18),
                 BlockButton(
-                  label: 'Sign in',
-                  onPressed: () =>
-                      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-                    content: Text('Real /auth/login lands in PR 7.2'),
-                  )),
+                  label: _busy ? 'Signing in…' : 'Sign in',
+                  onPressed: _busy ? null : _signIn,
                 ),
                 const SizedBox(height: 20),
                 Text(
@@ -109,28 +167,42 @@ class LoginScreen extends ConsumerWidget {
 class _Field extends StatelessWidget {
   const _Field({
     required this.label,
-    required this.placeholder,
+    required this.controller,
+    required this.hint,
     this.obscure = false,
+    this.keyboard,
   });
 
   final String label;
-  final String placeholder;
+  final TextEditingController controller;
+  final String hint;
   final bool obscure;
+  final TextInputType? keyboard;
 
   @override
   Widget build(BuildContext context) {
     return BlockCard(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(label.toUpperCase(), style: BlockType.monoLabel.copyWith(fontSize: 10)),
-          const SizedBox(height: 4),
           Text(
-            placeholder,
-            style: BlockType.body.copyWith(
-              color: BlockColors.ink3,
-              letterSpacing: obscure ? 6 : 0,
+            label.toUpperCase(),
+            style: BlockType.monoLabel.copyWith(fontSize: 10),
+          ),
+          TextField(
+            controller: controller,
+            obscureText: obscure,
+            keyboardType: keyboard,
+            autocorrect: false,
+            enableSuggestions: !obscure,
+            style: BlockType.body,
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: BlockType.body.copyWith(color: BlockColors.ink3),
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: EdgeInsets.zero,
             ),
           ),
         ],

--- a/mobile/test/auth_test.dart
+++ b/mobile/test/auth_test.dart
@@ -1,0 +1,89 @@
+// Auth controller test — exercises signIn / signOut without hitting the
+// network. Uses Riverpod overrides to swap in a fake LoginRepository +
+// in-memory secure storage.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/login_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+class _FakeLoginRepo implements LoginRepository {
+  _FakeLoginRepo({this.shouldSucceed = true, this.role = AuthRole.volunteer});
+  bool shouldSucceed;
+  AuthRole role;
+  bool signedOut = false;
+
+  @override
+  Future<AuthState> signIn(String email, String password) async {
+    if (!shouldSucceed) throw const LoginFailure('Wrong email or password');
+    return AuthState(role: role, token: 'fake-jwt-$email');
+  }
+
+  @override
+  Future<void> signOut() async {
+    signedOut = true;
+  }
+}
+
+void main() {
+  test('signIn success → role + token applied', () async {
+    final repo = _FakeLoginRepo(role: AuthRole.admin);
+    final storage = InMemoryTokenStorage();
+    final container = ProviderContainer(
+      overrides: [
+        loginRepositoryProvider.overrideWithValue(repo),
+        secureTokenStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(authProvider).role, AuthRole.unauth);
+
+    final err = await container.read(authProvider.notifier).signIn(
+          'admin@hcc.org',
+          'pw',
+        );
+    expect(err, isNull);
+    final state = container.read(authProvider);
+    expect(state.role, AuthRole.admin);
+    expect(state.token, 'fake-jwt-admin@hcc.org');
+  });
+
+  test('signIn failure surfaces user-facing message', () async {
+    final repo = _FakeLoginRepo(shouldSucceed: false);
+    final container = ProviderContainer(
+      overrides: [
+        loginRepositoryProvider.overrideWithValue(repo),
+        secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final err = await container
+        .read(authProvider.notifier)
+        .signIn('a@b.org', 'wrong');
+    expect(err, 'Wrong email or password');
+    expect(container.read(authProvider).role, AuthRole.unauth);
+  });
+
+  test('signOut wipes state and storage', () async {
+    final repo = _FakeLoginRepo();
+    final storage = InMemoryTokenStorage();
+    await storage.writeToken('tok');
+    final container = ProviderContainer(
+      overrides: [
+        loginRepositoryProvider.overrideWithValue(repo),
+        secureTokenStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(authProvider.notifier).demoSignInVolunteer();
+    expect(container.read(authProvider).role, AuthRole.volunteer);
+
+    await container.read(authProvider.notifier).signOut();
+    expect(container.read(authProvider).role, AuthRole.unauth);
+    expect(await storage.readToken(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Wires real authentication end-to-end: `POST /auth/login` → JWT in iOS Keychain via `flutter_secure_storage` → role detection → role-based GoRouter routing.

Adds `make mobile-codegen` target for full Dart-Dio openapi codegen, but **doesn't run codegen here** — Java isn't installed on this machine. Ships a hand-rolled minimal client (`mobile/lib/api/`) with the same public surface so the swap to generated code is mechanical when `brew install openjdk@17` happens.

## What works after this PR

- Type real credentials on `/login` → app calls `POST /auth/login` → token stored in iOS Keychain.
- Role detected from response: `admin` → `/a/dashboard`; `volunteer` → `/v/schedule`; otherwise stays on login with an error.
- Sign-out from Profile wipes both Riverpod state and the stored token.
- Any 401 from a future API call clears the token automatically; GoRouter redirect bounces the user to `/login` on next navigation.
- Demo shortcuts retained for offline dev and the smoke widget test.

## `make mobile-codegen`

```makefile
mobile-codegen:
    @command -v java >/dev/null 2>&1 || { echo "Install: brew install openjdk@17"; exit 1; }
    @npx -y @openapitools/openapi-generator-cli@2.20.2 generate \
      -i tests/contract/openapi.snapshot.json \
      -g dart-dio \
      -o mobile/lib/api \
      --additional-properties=pubName=signupflow_api,nullSafe=true,nullableFields=true \
      --skip-validate-spec
    @cd mobile && flutter pub get
    @cd mobile && dart run build_runner build --delete-conflicting-outputs
```

Errors cleanly with a `brew install` hint if Java is missing — never silently produces stale code.

## Hand-rolled API client (deliberately thin)

| File | Purpose |
|---|---|
| `mobile/lib/api/api_client.dart` | dio factory with `Authorization: Bearer` interceptor + 401 → token wipe |
| `mobile/lib/api/models.dart` | `LoginRequest`, `LoginResponse`, `PersonMe` — minimal hand-rolled types matching FastAPI shapes |
| `mobile/lib/api/auth_api.dart` | `AuthApi.login()` |
| `mobile/lib/api/people_api.dart` | `PeopleApi.me()` |

## Auth layer

| File | Purpose |
|---|---|
| `mobile/lib/auth/secure_token_storage.dart` | `SecureTokenStorage` interface · real Keychain impl · `InMemoryTokenStorage` for tests |
| `mobile/lib/auth/login_repository.dart` | Wraps API + storage, returns `AuthState` or throws `LoginFailure` |
| `mobile/lib/auth/auth_provider.dart` | `AuthController.signIn()` / `signOut()` — real flow; `demoSignIn*` retained |
| `mobile/lib/features/auth/login_screen.dart` | Real `TextField`s, error display, busy state on Sign In |

## Tests (4 / 4 passing)

- `auth_test.dart` — signIn success, signIn failure, signOut, all via Riverpod overrides (no network, no native plugins).
- `widget_test.dart` — smoke test from 7.1 still passes.

## Cocoapods

`mobile/ios/Podfile` created (required by `flutter_secure_storage`). Debug/Release `.xcconfig` updated with the conditional `#include?` for `Pods-Runner.{debug,release}.xcconfig`.

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **4 passed**
- Backend Python tests untouched.

## Follow-ups

- **7.3** — Volunteer Schedule against `GET /people/me/assignments`. Will need 1 more file in `lib/api/` (`assignments_api.dart`) until openapi-codegen runs.
- **Java install on dev machine** — `brew install openjdk@17`, then `make mobile-codegen` regenerates the full client. Hand-rolled `lib/api/` files become the codegen output and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)