### PR TITLE
Sprint 7 PR 7.3: Volunteer Schedule against /people/me/assignments

### DIFF
--- a/mobile/lib/auth/auth_provider.dart
+++ b/mobile/lib/auth/auth_provider.dart
@@ -9,12 +9,38 @@ import 'package:signupflow_mobile/auth/secure_token_storage.dart';
 enum AuthRole { unauth, volunteer, admin }
 
 class AuthState {
-  const AuthState({this.role = AuthRole.unauth, this.token});
+  const AuthState({
+    this.role = AuthRole.unauth,
+    this.token,
+    this.personId,
+    this.email,
+    this.orgId,
+    this.name,
+  });
+
   final AuthRole role;
   final String? token;
+  final String? personId;
+  final String? email;
+  final String? orgId;
+  final String? name;
 
-  AuthState copyWith({AuthRole? role, String? token}) =>
-      AuthState(role: role ?? this.role, token: token ?? this.token);
+  AuthState copyWith({
+    AuthRole? role,
+    String? token,
+    String? personId,
+    String? email,
+    String? orgId,
+    String? name,
+  }) =>
+      AuthState(
+        role: role ?? this.role,
+        token: token ?? this.token,
+        personId: personId ?? this.personId,
+        email: email ?? this.email,
+        orgId: orgId ?? this.orgId,
+        name: name ?? this.name,
+      );
 }
 
 class AuthController extends Notifier<AuthState> {

--- a/mobile/lib/auth/login_repository.dart
+++ b/mobile/lib/auth/login_repository.dart
@@ -30,6 +30,10 @@ class LoginRepository {
       return AuthState(
         role: _resolveRole(body.roles.toList()),
         token: body.token,
+        personId: body.personId,
+        email: body.email,
+        orgId: body.orgId,
+        name: body.name,
       );
     } on DioException catch (e) {
       final code = e.response?.statusCode;

--- a/mobile/lib/features/volunteer/schedule_provider.dart
+++ b/mobile/lib/features/volunteer/schedule_provider.dart
@@ -1,0 +1,95 @@
+// Schedule provider — fetches the volunteer's upcoming assignments and
+// joins them with their events client-side. Returns a ScheduleData VM
+// grouped by date.
+//
+// API surface used:
+//   AssignmentsApi.listMyAssignments() — paginated assignments for the
+//                                         currently-authenticated person.
+//   EventsApi.listEvents(orgId: …)     — paginated events for the org;
+//                                         joined client-side by event_id.
+//
+// Why client-side join: the FastAPI shapes don't return event metadata
+// embedded in the assignment list. Doing the join here keeps the backend
+// thin. Two HTTP calls is fine for MVP scale (a typical volunteer has
+// <20 upcoming assignments + <100 events in a 90-day window).
+
+import 'package:dio/dio.dart' show Response;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+/// One row in the schedule — assignment + the event it points to.
+class ScheduleRow {
+  const ScheduleRow({required this.assignment, required this.event});
+  final api.AssignmentResponse assignment;
+  final api.EventResponse event;
+
+  DateTime get start => event.startTime.toLocal();
+  DateTime get end => event.endTime.toLocal();
+  DateTime get dateKey => DateTime(start.year, start.month, start.day);
+}
+
+/// Group of rows on a single calendar day.
+class ScheduleGroup {
+  const ScheduleGroup({required this.date, required this.rows});
+  final DateTime date;
+  final List<ScheduleRow> rows;
+}
+
+/// Top-level schedule VM consumed by ScheduleScreen.
+class ScheduleData {
+  const ScheduleData({required this.groups});
+  final List<ScheduleGroup> groups;
+  bool get isEmpty => groups.isEmpty;
+}
+
+final scheduleProvider = FutureProvider<ScheduleData>((ref) async {
+  final auth = ref.watch(authProvider);
+  final orgId = auth.orgId;
+  if (orgId == null) {
+    // Demo shortcuts skip the auth response, so we may not have an org_id.
+    // Empty data is the right behaviour — the screen renders an empty state.
+    return const ScheduleData(groups: []);
+  }
+
+  final apiClient = ref.watch(signupflowApiProvider);
+
+  // Fire both requests in parallel.
+  final futures = await Future.wait([
+    apiClient.getAssignmentsApi().listMyAssignments(),
+    apiClient.getEventsApi().listEvents(orgId: orgId),
+  ]);
+
+  final assignmentsBody = (futures[0] as Response<api.ListResponseAssignmentResponse>).data;
+  final eventsBody = (futures[1] as Response<api.ListResponseEventResponse>).data;
+
+  if (assignmentsBody == null || eventsBody == null) {
+    return const ScheduleData(groups: []);
+  }
+
+  final eventsById = <String, api.EventResponse>{
+    for (final e in eventsBody.items) e.id: e,
+  };
+
+  final rows = <ScheduleRow>[];
+  for (final a in assignmentsBody.items) {
+    final ev = eventsById[a.eventId];
+    if (ev == null) continue; // assignment for an event the user can't see; skip
+    rows.add(ScheduleRow(assignment: a, event: ev));
+  }
+
+  rows.sort((x, y) => x.start.compareTo(y.start));
+
+  // Group consecutive rows with the same dateKey.
+  final groups = <ScheduleGroup>[];
+  for (final r in rows) {
+    if (groups.isNotEmpty && groups.last.date == r.dateKey) {
+      groups.last.rows.add(r);
+    } else {
+      groups.add(ScheduleGroup(date: r.dateKey, rows: [r]));
+    }
+  }
+
+  return ScheduleData(groups: groups);
+});

--- a/mobile/lib/features/volunteer/schedule_screen.dart
+++ b/mobile/lib/features/volunteer/schedule_screen.dart
@@ -1,14 +1,264 @@
+// Volunteer Schedule — Sprint 7.3.
+// Visual target: mobile/prototype/screenshots/v2/03-v-schedule.png.
+// Data: scheduleProvider (FutureProvider) joins listMyAssignments +
+//        listEvents client-side.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/volunteer/schedule_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class VolunteerScheduleScreen extends StatelessWidget {
+class VolunteerScheduleScreen extends ConsumerWidget {
   const VolunteerScheduleScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Schedule',
-        endpoint: 'GET /people/me/assignments',
-        willLandIn: 'PR 7.3',
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(scheduleProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Top action — calendar export sheet (lands in PR 7.6).
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.accent,
+                      textStyle: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Calendar export lands in 7.6')),
+                    ),
+                    child: const Text('EXPORT'),
+                  ),
+                ],
+              ),
+            ),
+            const PageTitle('Schedule'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => _ErrorState(
+                  message: e.toString(),
+                  onRetry: () => ref.invalidate(scheduleProvider),
+                ),
+                data: (data) => data.isEmpty
+                    ? const _EmptyState()
+                    : _ScheduleList(data: data),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScheduleList extends StatelessWidget {
+  const _ScheduleList({required this.data});
+  final ScheduleData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final today = DateTime.now();
+    final thisMonday = today.subtract(Duration(days: today.weekday - 1));
+    final nextMonday = thisMonday.add(const Duration(days: 7));
+
+    // Pull-to-refresh comes in a follow-up; simple ListView is fine for now.
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+      itemCount: data.groups.length,
+      itemBuilder: (ctx, idx) {
+        final g = data.groups[idx];
+        // Tag the first group of "this week" / "next week" for context.
+        String? weekTag;
+        if (g.date.isAfter(thisMonday.subtract(const Duration(days: 1))) &&
+            g.date.isBefore(nextMonday)) {
+          final firstThisWeek = data.groups.indexWhere(
+            (x) => x.date.isAfter(thisMonday.subtract(const Duration(days: 1))),
+          );
+          if (idx == firstThisWeek) weekTag = 'THIS WEEK';
+        } else if (g.date.isAfter(nextMonday.subtract(const Duration(days: 1))) &&
+            g.date.isBefore(nextMonday.add(const Duration(days: 7)))) {
+          final firstNextWeek = data.groups.indexWhere(
+            (x) => x.date.isAfter(nextMonday.subtract(const Duration(days: 1))),
+          );
+          if (idx == firstNextWeek) weekTag = 'NEXT WEEK';
+        }
+        return _DateGroup(group: g, weekTag: weekTag);
+      },
+    );
+  }
+}
+
+class _DateGroup extends StatelessWidget {
+  const _DateGroup({required this.group, this.weekTag});
+  final ScheduleGroup group;
+  final String? weekTag;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateLabel = DateFormat('EEE d MMM').format(group.date).toUpperCase();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        MonoLabel(
+          dateLabel,
+          trailing: weekTag != null
+              ? Text(weekTag!, style: BlockType.monoLabel.copyWith(color: BlockColors.accent))
+              : null,
+        ),
+        ...group.rows.map((r) => _AssignmentRow(row: r)),
+      ],
+    );
+  }
+}
+
+class _AssignmentRow extends StatelessWidget {
+  const _AssignmentRow({required this.row});
+  final ScheduleRow row;
+
+  String _timeChipText() {
+    final f = DateFormat('HH:mm');
+    return '${f.format(row.start)}–${f.format(row.end)}';
+  }
+
+  StatusKind _status() => switch (row.assignment.status.toLowerCase()) {
+        'confirmed' || 'accepted' => StatusKind.confirmed,
+        'pending' => StatusKind.pending,
+        'declined' => StatusKind.declined,
+        _ => StatusKind.neutral,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: BlockColors.bgCard,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+          side: const BorderSide(color: BlockColors.line1),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: () => context.go('/v/assignment/${row.assignment.id}'),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Wrap(
+                        spacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          TimeChip(_timeChipText()),
+                          if (row.assignment.role != null)
+                            RoleChip(row.assignment.role!),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        row.event.type,
+                        style: BlockType.subhead,
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          // Location not present on EventResponse v1 — we
+                          // surface event id as a faint slug to keep the row
+                          // grounded; future schema can swap in a real
+                          // location field.
+                          Text(
+                            'Event ${row.event.id}',
+                            style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                          ),
+                          StatusText(kind: _status(), label: row.assignment.status),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 4),
+                const Icon(Icons.chevron_right, color: BlockColors.ink3, size: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('NO UPCOMING ASSIGNMENTS', style: BlockType.monoLabel),
+            const SizedBox(height: 8),
+            Text(
+              "When the next schedule is published you'll see your roster here.",
+              style: BlockType.bodySm,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('FAILED TO LOAD', style: BlockType.monoLabel.copyWith(color: BlockColors.danger)),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: BlockType.bodySm,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            BlockButton(
+              label: 'Retry',
+              kind: BlockButtonKind.secondary,
+              onPressed: onRetry,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/test/schedule_screen_test.dart
+++ b/mobile/test/schedule_screen_test.dart
@@ -1,0 +1,118 @@
+// Schedule screen widget test — overrides scheduleProvider with synthetic
+// data so we can assert the layout (date sections + time chips + status)
+// without hitting the network or the generated API.
+
+import 'package:built_value/built_value.dart' show BuiltValueNullFieldError;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/volunteer/schedule_provider.dart';
+import 'package:signupflow_mobile/features/volunteer/schedule_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.AssignmentResponse _assn({
+  required int id,
+  required String eventId,
+  required String role,
+  required String status,
+}) {
+  return (api.AssignmentResponseBuilder()
+        ..id = id
+        ..eventId = eventId
+        ..personId = 'me'
+        ..role = role
+        ..status = status
+        ..assignedAt = DateTime(2026, 5, 1).toUtc())
+      .build();
+}
+
+api.EventResponse _event({
+  required String id,
+  required String type,
+  required DateTime start,
+  required DateTime end,
+}) {
+  return (api.EventResponseBuilder()
+        ..id = id
+        ..orgId = 'hcc'
+        ..type = type
+        ..startTime = start.toUtc()
+        ..endTime = end.toUtc()
+        ..createdAt = DateTime(2026, 5, 1).toUtc()
+        ..updatedAt = DateTime(2026, 5, 1).toUtc())
+      .build();
+}
+
+void main() {
+  testWidgets('schedule renders date groups + time chips + status', (tester) async {
+    final group1 = ScheduleGroup(date: DateTime(2026, 5, 25), rows: [
+      ScheduleRow(
+        assignment: _assn(
+          id: 1,
+          eventId: 'e1',
+          role: 'usher',
+          status: 'confirmed',
+        ),
+        event: _event(
+          id: 'e1',
+          type: 'Sunday Service',
+          start: DateTime(2026, 5, 25, 10),
+          end: DateTime(2026, 5, 25, 11, 30),
+        ),
+      ),
+    ]);
+    final fakeData = ScheduleData(groups: [group1]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleProvider.overrideWith((ref) async => fakeData),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const VolunteerScheduleScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('SCHEDULE'), findsOneWidget);
+    // Date label format is `EEE d MMM` uppercased — e.g. "MON 25 MAY".
+    // Don't assert the day-of-week (calendar-dependent); just confirm the
+    // day-of-month + month appear.
+    expect(find.textContaining('25 MAY'), findsOneWidget);
+    expect(find.text('10:00–11:30'), findsOneWidget);
+    expect(find.text('USHER'), findsOneWidget);
+    expect(find.text('CONFIRMED'), findsOneWidget);
+    expect(find.text('Sunday Service'), findsOneWidget);
+  });
+
+  testWidgets('schedule shows empty state when no assignments', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleProvider.overrideWith((ref) async => const ScheduleData(groups: [])),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const VolunteerScheduleScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('NO UPCOMING ASSIGNMENTS'), findsOneWidget);
+  });
+
+  test('built_value model construction throws on missing fields', () {
+    // Smoke: confirms our test helpers populate enough fields. If we forget
+    // a required field the built_value builder throws — this test would fail.
+    expect(
+      () => api.AssignmentResponseBuilder().build(),
+      throwsA(isA<BuiltValueNullFieldError>()),
+    );
+  });
+}

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.14.0"
+  }
+}


### PR DESCRIPTION
## Summary

Volunteer Schedule tab is now real. Fetches the user's assignments via the generated `AssignmentsApi.listMyAssignments()`, joins them client-side with `EventsApi.listEvents(orgId)`, groups by date, and renders the Block-Mono layout from `mobile/prototype/screenshots/v2/03-v-schedule.png`.

## What works

- **Date sections** with mono uppercase labels (e.g. `MON 25 MAY`).
- **Time chips** (teal-soft) and **role chips** (bordered mono) per row.
- **Event title** as the row hero (Inter 600).
- **Status dot + label** (`● CONFIRMED` / `● PENDING` / `● DECLINED`).
- **THIS WEEK** / **NEXT WEEK** callouts on the first group in each window.
- **Loading** spinner, **error** state with Retry, **empty** state — all themed.
- Tap a row → `/v/assignment/<id>` (detail still stubbed; lands in 7.4).

## Why client-side join

`AssignmentResponse` doesn't embed event metadata. Joining in the client keeps the backend thin. Two HTTP calls in parallel via `Future.wait` — fine for MVP scale (typical volunteer has <20 upcoming assignments + <100 events in 90 days).

## `AuthState` extension

Added `personId`, `email`, `orgId`, `name` fields, populated from `AuthResponse` on login. `ScheduleProvider` reads `orgId` to scope `listEvents`. Demo shortcuts leave `orgId` null on purpose — provider returns empty data, screen renders empty state, smoke test passes without network mocks.

## Tests (7 passed)

- `schedule_screen_test.dart` (new):
  - Overrides `scheduleProvider` with synthetic `ScheduleData`; asserts page title, date label, time chip, role chip, status text, event title all render.
  - Empty-state test.
  - `built_value` sanity test.
- `auth_test.dart` unchanged (3/3 still pass; new AuthState fields default to null).
- `widget_test.dart` unchanged (1/1 — smoke routes through Volunteer demo shortcut → empty state).

## Validation

- `flutter analyze` — **0 issues**.
- `flutter test` — **7 passed**.
- Backend Python tests untouched.

## Follow-ups

- **7.4** — Assignment Detail screen with Accept / Decline / Swap.
- Pull-to-refresh on Schedule (deferred — basic ListView is fine for first cut).
- `openapitools.json` committed as a side-effect of `make mobile-codegen` (pins the underlying Java codegen tool to 7.14.0 for reproducibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)