### PR TITLE
Sprint 7 PR 7.4: Assignment Detail with Accept / Decline / Swap

### DIFF
--- a/mobile/lib/features/volunteer/assignment_detail_provider.dart
+++ b/mobile/lib/features/volunteer/assignment_detail_provider.dart
@@ -1,0 +1,121 @@
+// AssignmentDetail flow — Sprint 7.4.
+//
+// `assignmentDetailProvider.family(int)` derives the row from
+// `scheduleProvider`'s already-loaded data instead of re-fetching. The
+// schedule is the canonical source — opening a detail page from a
+// notification (which we don't have a path for in MVP1) would require a
+// dedicated /assignments/{id} GET, which doesn't exist on the backend yet.
+//
+// Mutation actions (accept/decline/swap) live on
+// `AssignmentMutationsController` so callsites don't have to hold a Dio /
+// AuthState themselves. Successful mutations invalidate the schedule.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/features/volunteer/schedule_provider.dart';
+
+/// Returns the schedule row for the given assignment id if it's already present in
+/// the loaded schedule, otherwise null. Wraps the schedule's loading/error
+/// state so the screen can show the same spinners as the list.
+final assignmentDetailProvider =
+    Provider.family<AsyncValue<ScheduleRow?>, int>((ref, assignmentId) {
+  final schedule = ref.watch(scheduleProvider);
+  return schedule.whenData((data) {
+    for (final g in data.groups) {
+      for (final r in g.rows) {
+        if (r.assignment.id == assignmentId) return r;
+      }
+    }
+    return null;
+  });
+});
+
+enum MutationStatus { idle, busy, error }
+
+class MutationState {
+  const MutationState({this.status = MutationStatus.idle, this.error});
+  final MutationStatus status;
+  final String? error;
+
+  MutationState busy() => const MutationState(status: MutationStatus.busy);
+  MutationState fail(String msg) =>
+      MutationState(status: MutationStatus.error, error: msg);
+  MutationState idle() => const MutationState();
+}
+
+class AssignmentMutationsController extends Notifier<MutationState> {
+  @override
+  MutationState build() => const MutationState();
+
+  /// Accept. Returns null on success or error message on failure.
+  Future<String?> accept(int assignmentId) async {
+    state = state.busy();
+    try {
+      await ref
+          .read(signupflowApiProvider)
+          .getAssignmentsApi()
+          .acceptAssignment(assignmentId: assignmentId);
+      ref.invalidate(scheduleProvider);
+      state = state.idle();
+      return null;
+    } on Exception catch (e) {
+      final msg = _readableError(e);
+      state = state.fail(msg);
+      return msg;
+    }
+  }
+
+  /// Decline. `reason` is required on the backend even when blank-ish.
+  Future<String?> decline(int assignmentId, String reason) async {
+    state = state.busy();
+    try {
+      final body = (api.AssignmentDeclineRequestBuilder()
+            ..declineReason = reason.trim().isEmpty
+                ? 'No reason provided'
+                : reason.trim())
+          .build();
+      await ref.read(signupflowApiProvider).getAssignmentsApi().declineAssignment(
+            assignmentId: assignmentId,
+            assignmentDeclineRequest: body,
+          );
+      ref.invalidate(scheduleProvider);
+      state = state.idle();
+      return null;
+    } on Exception catch (e) {
+      final msg = _readableError(e);
+      state = state.fail(msg);
+      return msg;
+    }
+  }
+
+  /// Request a swap. `note` is optional.
+  Future<String?> requestSwap(int assignmentId, String? note) async {
+    state = state.busy();
+    try {
+      final builder = api.AssignmentSwapRequestBuilder();
+      if (note != null && note.trim().isNotEmpty) builder.note = note.trim();
+      await ref.read(signupflowApiProvider).getAssignmentsApi().requestSwap(
+            assignmentId: assignmentId,
+            assignmentSwapRequest: builder.build(),
+          );
+      ref.invalidate(scheduleProvider);
+      state = state.idle();
+      return null;
+    } on Exception catch (e) {
+      final msg = _readableError(e);
+      state = state.fail(msg);
+      return msg;
+    }
+  }
+
+  static String _readableError(Object e) {
+    final raw = e.toString();
+    return raw.length > 160 ? '${raw.substring(0, 160)}…' : raw;
+  }
+}
+
+final assignmentMutationsProvider =
+    NotifierProvider<AssignmentMutationsController, MutationState>(
+  AssignmentMutationsController.new,
+);

--- a/mobile/lib/features/volunteer/assignment_detail_screen.dart
+++ b/mobile/lib/features/volunteer/assignment_detail_screen.dart
@@ -1,15 +1,345 @@
+// Volunteer Assignment Detail — Sprint 7.4.
+// Visual target: mobile/prototype/screenshots/v2/04-v-assignment.png.
+//
+// Reads the schedule row from `assignmentDetailProvider`. Mutations route
+// through `assignmentMutationsProvider`, which invalidates the schedule
+// on success and pops back. Decline opens a bottom sheet for an optional
+// reason.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/volunteer/assignment_detail_provider.dart';
+import 'package:signupflow_mobile/features/volunteer/schedule_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class AssignmentDetailScreen extends StatelessWidget {
+class AssignmentDetailScreen extends ConsumerWidget {
   const AssignmentDetailScreen({required this.assignmentId, super.key});
   final String assignmentId;
 
+  int? get _id => int.tryParse(assignmentId);
+
   @override
-  Widget build(BuildContext context) => StubScreen(
-        title: 'Assignment',
-        endpoint: 'GET /assignments/$assignmentId · POST /assignments/$assignmentId/{accept,decline}',
-        willLandIn: 'PR 7.4',
+  Widget build(BuildContext context, WidgetRef ref) {
+    final id = _id;
+    if (id == null) {
+      return const _DetailFrame(
+        body: Center(
+          child: Text('Invalid assignment id'),
+        ),
       );
+    }
+
+    final asyncRow = ref.watch(assignmentDetailProvider(id));
+    final mutation = ref.watch(assignmentMutationsProvider);
+
+    return _DetailFrame(
+      onBack: () => context.go('/v/schedule'),
+      body: asyncRow.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Padding(
+          padding: const EdgeInsets.all(24),
+          child: Center(
+            child: Text(
+              'Failed to load assignment: $e',
+              style: BlockType.bodySm,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        data: (row) => row == null
+            ? const _NotFound()
+            : _Body(row: row, busy: mutation.status == MutationStatus.busy, error: mutation.error),
+      ),
+    );
+  }
+}
+
+class _DetailFrame extends StatelessWidget {
+  const _DetailFrame({required this.body, this.onBack});
+  final Widget body;
+  final VoidCallback? onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  if (onBack != null)
+                    TextButton(
+                      onPressed: onBack,
+                      style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                      child: Text(
+                        '‹ SCHEDULE',
+                        style: BlockType.monoLabel.copyWith(
+                          color: BlockColors.accent,
+                          fontSize: 13,
+                        ),
+                      ),
+                    )
+                  else
+                    const SizedBox(width: 80),
+                  Text(
+                    'ASSIGNMENT',
+                    style: BlockType.monoLabel.copyWith(
+                      color: BlockColors.ink1,
+                      fontSize: 13,
+                    ),
+                  ),
+                  const SizedBox(width: 80),
+                ],
+              ),
+            ),
+            Expanded(child: body),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NotFound extends StatelessWidget {
+  const _NotFound();
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('NOT FOUND', style: BlockType.monoLabel),
+            const SizedBox(height: 8),
+            Text(
+              "This assignment isn't in your current schedule. It may have been "
+              'reassigned or the schedule republished.',
+              style: BlockType.bodySm,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.row, required this.busy, this.error});
+  final ScheduleRow row;
+  final bool busy;
+  final String? error;
+
+  StatusKind _status() => switch (row.assignment.status.toLowerCase()) {
+        'confirmed' || 'accepted' => StatusKind.confirmed,
+        'pending' => StatusKind.pending,
+        'declined' => StatusKind.declined,
+        _ => StatusKind.neutral,
+      };
+
+  String _timeRange() {
+    final f = DateFormat('HH:mm');
+    return '${f.format(row.start)}–${f.format(row.end)}';
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          BlockCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    TimeChip(_timeRange()),
+                    if (row.assignment.role != null) RoleChip(row.assignment.role!),
+                    StatusText(kind: _status(), label: row.assignment.status),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  row.event.type,
+                  style: BlockType.displayUpper(22).copyWith(
+                    fontSize: 22,
+                    height: 1.15,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  DateFormat('EEE d MMM y · h:mm a').format(row.start).toUpperCase(),
+                  style: BlockType.monoData.copyWith(fontSize: 11),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Tap a button below to update your response. The schedule '
+                  'will refresh once the change reaches the server.',
+                  style: BlockType.bodySm,
+                ),
+              ],
+            ),
+          ),
+          if (error != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              error!,
+              style: BlockType.bodySm.copyWith(color: BlockColors.danger),
+              textAlign: TextAlign.center,
+            ),
+          ],
+          const MonoLabel('Your response'),
+          Row(
+            children: [
+              Expanded(
+                child: BlockButton(
+                  label: busy ? 'Working…' : 'Accept',
+                  kind: BlockButtonKind.go,
+                  onPressed: busy ? null : () => _doAccept(context, ref),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: BlockButton(
+                  label: 'Swap',
+                  kind: BlockButtonKind.secondary,
+                  onPressed: busy ? null : () => _doSwap(context, ref),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          BlockButton(
+            label: 'Decline',
+            kind: BlockButtonKind.destructive,
+            onPressed: busy ? null : () => _doDecline(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _doAccept(BuildContext context, WidgetRef ref) async {
+    final err = await ref
+        .read(assignmentMutationsProvider.notifier)
+        .accept(row.assignment.id);
+    if (!context.mounted) return;
+    if (err == null) context.go('/v/schedule');
+  }
+
+  Future<void> _doSwap(BuildContext context, WidgetRef ref) async {
+    final note = await _promptForText(
+      context,
+      title: 'REQUEST SWAP',
+      hint: 'Optional note to your team lead',
+      submitLabel: 'Send swap request',
+    );
+    if (note == null || !context.mounted) return; // user cancelled
+    final err = await ref
+        .read(assignmentMutationsProvider.notifier)
+        .requestSwap(row.assignment.id, note);
+    if (!context.mounted) return;
+    if (err == null) context.go('/v/schedule');
+  }
+
+  Future<void> _doDecline(BuildContext context, WidgetRef ref) async {
+    final reason = await _promptForText(
+      context,
+      title: 'DECLINE',
+      hint: 'Reason (visible to your admin)',
+      submitLabel: 'Decline',
+      requireNonEmpty: true,
+    );
+    if (reason == null || !context.mounted) return;
+    final err = await ref
+        .read(assignmentMutationsProvider.notifier)
+        .decline(row.assignment.id, reason);
+    if (!context.mounted) return;
+    if (err == null) context.go('/v/schedule');
+  }
+
+  Future<String?> _promptForText(
+    BuildContext context, {
+    required String title,
+    required String hint,
+    required String submitLabel,
+    bool requireNonEmpty = false,
+  }) {
+    final ctrl = TextEditingController();
+    return showModalBottomSheet<String?>(
+      context: context,
+      backgroundColor: BlockColors.bgCard,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) {
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+            20,
+            16,
+            20,
+            MediaQuery.of(sheetCtx).viewInsets.bottom + 20,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(title, style: BlockType.monoLabel.copyWith(color: BlockColors.ink1)),
+              const SizedBox(height: 8),
+              TextField(
+                controller: ctrl,
+                autofocus: true,
+                maxLines: 3,
+                style: BlockType.body,
+                decoration: InputDecoration(
+                  hintText: hint,
+                  hintStyle: BlockType.bodySm.copyWith(color: BlockColors.ink3),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: BlockColors.line1),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              Row(
+                children: [
+                  Expanded(
+                    child: BlockButton(
+                      label: 'Cancel',
+                      kind: BlockButtonKind.secondary,
+                      onPressed: () => Navigator.of(sheetCtx).pop(null),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: BlockButton(
+                      label: submitLabel,
+                      onPressed: () {
+                        final value = ctrl.text.trim();
+                        if (requireNonEmpty && value.isEmpty) return;
+                        Navigator.of(sheetCtx).pop(value);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
 }

--- a/mobile/test/assignment_detail_test.dart
+++ b/mobile/test/assignment_detail_test.dart
@@ -1,0 +1,118 @@
+// Assignment detail screen widget test — overrides scheduleProvider with
+// fake data and confirms the detail screen finds the row by id and shows
+// the action buttons.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/volunteer/assignment_detail_screen.dart';
+import 'package:signupflow_mobile/features/volunteer/schedule_provider.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.AssignmentResponse _assn({
+  required int id,
+  required String eventId,
+  required String role,
+  required String status,
+}) {
+  return (api.AssignmentResponseBuilder()
+        ..id = id
+        ..eventId = eventId
+        ..personId = 'me'
+        ..role = role
+        ..status = status
+        ..assignedAt = DateTime(2026, 5, 1).toUtc())
+      .build();
+}
+
+api.EventResponse _event({
+  required String id,
+  required String type,
+  required DateTime start,
+  required DateTime end,
+}) {
+  return (api.EventResponseBuilder()
+        ..id = id
+        ..orgId = 'hcc'
+        ..type = type
+        ..startTime = start.toUtc()
+        ..endTime = end.toUtc()
+        ..createdAt = DateTime(2026, 5, 1).toUtc()
+        ..updatedAt = DateTime(2026, 5, 1).toUtc())
+      .build();
+}
+
+ScheduleData _scheduleWithOneRow() {
+  final row = ScheduleRow(
+    assignment: _assn(id: 142, eventId: 'e1', role: 'usher', status: 'pending'),
+    event: _event(
+      id: 'e1',
+      type: 'Sunday Service',
+      start: DateTime(2026, 5, 25, 10),
+      end: DateTime(2026, 5, 25, 11, 30),
+    ),
+  );
+  return ScheduleData(
+    groups: [ScheduleGroup(date: DateTime(2026, 5, 25), rows: [row])],
+  );
+}
+
+void main() {
+  testWidgets('detail finds row by id and renders actions', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleProvider.overrideWith((ref) async => _scheduleWithOneRow()),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const AssignmentDetailScreen(assignmentId: '142'),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('ASSIGNMENT'), findsOneWidget);
+    expect(find.text('Sunday Service'), findsOneWidget);
+    expect(find.text('USHER'), findsOneWidget);
+    expect(find.text('PENDING'), findsOneWidget);
+    expect(find.text('ACCEPT'), findsOneWidget);
+    expect(find.text('SWAP'), findsOneWidget);
+    expect(find.text('DECLINE'), findsOneWidget);
+  });
+
+  testWidgets('detail shows not-found when id is unknown', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleProvider.overrideWith((ref) async => _scheduleWithOneRow()),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const AssignmentDetailScreen(assignmentId: '999'),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('NOT FOUND'), findsOneWidget);
+  });
+
+  testWidgets('detail rejects non-numeric id', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const AssignmentDetailScreen(assignmentId: 'banana'),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid assignment id'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the stub `AssignmentDetailScreen` with a real one matching `mobile/prototype/screenshots/v2/04-v-assignment.png`. Wires Accept / Decline / Swap to the generated `AssignmentsApi` and refreshes the schedule on success.

## Data flow

- `assignmentDetailProvider.family(int)` derives the row from already-loaded `scheduleProvider` data — no second roundtrip.
- Backend has no `/assignments/{id}` GET, so the schedule list is the canonical source. If we ever ship deep-links from notifications (no `/notifications` endpoint yet either), we'd need a single-assignment fetch — out of MVP1 scope.

## Mutations — `AssignmentMutationsController`

| Action | Generated method | Body |
|---|---|---|
| Accept | `acceptAssignment(assignmentId:)` | none |
| Decline | `declineAssignment(assignmentId:, assignmentDeclineRequest:)` | `decline_reason` (required; substitutes "No reason provided" if blank) |
| Swap | `requestSwap(assignmentId:, assignmentSwapRequest:)` | `note` (optional) |

On success, `ref.invalidate(scheduleProvider)` so the schedule reloads. `MutationState.busy()` blocks all three buttons during the request. Errors surface as inline copy + return value to the caller.

## UI

- `BlockCard` hero — time chip + role chip + status, then event title (Inter 700 22px) + full date in JetBrains Mono.
- Action row: **ACCEPT** (go-teal) · **SWAP** (secondary) · **DECLINE** (destructive). Decline + Swap open a bottom sheet for the note.
- After successful mutation: `context.go('/v/schedule')` pops back.

## Tests (10 / 10 passing)

- `assignment_detail_test.dart` (new):
  - detail finds row by id + renders actions
  - detail shows NOT FOUND when id is unknown
  - detail rejects non-numeric id with "Invalid assignment id"
- existing `auth_test.dart`, `schedule_screen_test.dart`, `widget_test.dart` — unchanged, still passing.

## Validation

- `flutter analyze` — **0 issues**.
- `flutter test` — **10 passed**.
- Backend Python tests untouched.

## Follow-ups

- **7.5** — Volunteer Availability (calendar grid + recurring rrule editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)