### PR TITLE
Sprint 7 PR 7.5: Volunteer Availability — TimeOff via AvailabilityApi

### DIFF
--- a/mobile/lib/features/volunteer/availability_provider.dart
+++ b/mobile/lib/features/volunteer/availability_provider.dart
@@ -1,0 +1,138 @@
+// Availability flow — Sprint 7.5.
+//
+// The OpenAPI snapshot only exposes TimeOff endpoints (multi-day vacation
+// periods). The Sprint 5 backend work that added single-date exceptions +
+// rrule rules is consumed by the solver but doesn't have CRUD routes yet —
+// so the recurring-rules section in mobile/prototype/screenshots/v2/05-…
+// stays in a "coming soon" state until the backend exposes those endpoints.
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+class TimeOffEntry {
+  const TimeOffEntry({
+    required this.id,
+    required this.startDate,
+    required this.endDate,
+    this.reason,
+  });
+  final int id;
+  final DateTime startDate; // local date (parsed from "YYYY-MM-DD")
+  final DateTime endDate;
+  final String? reason;
+
+  /// All days in the inclusive range — used to mark the calendar grid.
+  Iterable<DateTime> daysCovered() sync* {
+    var d = startDate;
+    while (!d.isAfter(endDate)) {
+      yield d;
+      d = d.add(const Duration(days: 1));
+    }
+  }
+}
+
+class AvailabilityData {
+  const AvailabilityData({required this.entries});
+  final List<TimeOffEntry> entries;
+
+  Set<DateTime> get blockedDays {
+    final s = <DateTime>{};
+    for (final e in entries) {
+      s.addAll(e.daysCovered());
+    }
+    return s;
+  }
+}
+
+DateTime _parseDate(String iso) {
+  // FastAPI returns "YYYY-MM-DD" (no timezone). Parse as a calendar date
+  // anchored at local midnight so calendar grid math is straightforward.
+  final parts = iso.split('-').map(int.parse).toList();
+  return DateTime(parts[0], parts[1], parts[2]);
+}
+
+final availabilityProvider = FutureProvider<AvailabilityData>((ref) async {
+  final personId = ref.watch(authProvider).personId;
+  if (personId == null) return const AvailabilityData(entries: []);
+
+  final apiClient = ref.watch(signupflowApiProvider);
+  final res = await apiClient.getAvailabilityApi().getTimeoff(personId: personId);
+  final body = res.data;
+  if (body == null) return const AvailabilityData(entries: []);
+
+  // body is JsonObject — re-encode + decode to plain Dart types.
+  final decoded = json.decode(body.toString());
+  if (decoded is! Map<String, dynamic>) {
+    return const AvailabilityData(entries: []);
+  }
+  final raw = decoded['timeoff'];
+  if (raw is! List) return const AvailabilityData(entries: []);
+
+  final entries = <TimeOffEntry>[];
+  for (final e in raw) {
+    if (e is! Map<String, dynamic>) continue;
+    entries.add(TimeOffEntry(
+      id: (e['id'] as num).toInt(),
+      startDate: _parseDate(e['start_date'] as String),
+      endDate: _parseDate(e['end_date'] as String),
+      reason: e['reason'] as String?,
+    ));
+  }
+  entries.sort((a, b) => a.startDate.compareTo(b.startDate));
+  return AvailabilityData(entries: entries);
+});
+
+class AvailabilityMutationsController extends Notifier<bool> {
+  @override
+  bool build() => false; // busy flag
+
+  Future<String?> addTimeoff(DateTime start, DateTime end, String? reason) async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      final body = (api.TimeOffCreateBuilder()
+            ..startDate = api.Date(start.year, start.month, start.day)
+            ..endDate = api.Date(end.year, end.month, end.day)
+            ..reason = reason)
+          .build();
+      await ref.read(signupflowApiProvider).getAvailabilityApi().addTimeoff(
+            personId: personId,
+            timeOffCreate: body,
+          );
+      ref.invalidate(availabilityProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+
+  Future<String?> deleteTimeoff(int timeoffId) async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      await ref.read(signupflowApiProvider).getAvailabilityApi().deleteTimeoff(
+            personId: personId,
+            timeoffId: timeoffId,
+          );
+      ref.invalidate(availabilityProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+}
+
+final availabilityMutationsProvider =
+    NotifierProvider<AvailabilityMutationsController, bool>(
+  AvailabilityMutationsController.new,
+);

--- a/mobile/lib/features/volunteer/availability_screen.dart
+++ b/mobile/lib/features/volunteer/availability_screen.dart
@@ -1,14 +1,468 @@
+// Volunteer Availability — Sprint 7.5.
+// Visual target: mobile/prototype/screenshots/v2/05-v-availability.png.
+//
+// Scope: ships TimeOff (multi-day vacation) management end-to-end against
+// AvailabilityApi. Recurring rules (rrule) + single-date exceptions are
+// in a "coming soon" panel — backend doesn't expose CRUD for them yet.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/volunteer/availability_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class AvailabilityScreen extends StatelessWidget {
+class AvailabilityScreen extends ConsumerWidget {
   const AvailabilityScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Availability',
-        endpoint: 'GET /availability · POST /availability/{exceptions,rrule}',
-        willLandIn: 'PR 7.5',
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(availabilityProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => _openAddSheet(context, ref),
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.accent,
+                    ),
+                    child: Text(
+                      'ADD',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const PageTitle('Availability'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'Failed to load: $e',
+                      style: BlockType.bodySm,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                data: (data) => _Body(data: data),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openAddSheet(BuildContext context, WidgetRef ref) async {
+    DateTime? start;
+    DateTime? end;
+    final reasonCtrl = TextEditingController();
+
+    final result = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: BlockColors.bgCard,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) {
+        return StatefulBuilder(
+          builder: (innerCtx, setState) => Padding(
+            padding: EdgeInsets.fromLTRB(
+              20,
+              16,
+              20,
+              MediaQuery.of(innerCtx).viewInsets.bottom + 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text('ADD TIME OFF', style: BlockType.monoLabel.copyWith(color: BlockColors.ink1)),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _DateField(
+                        label: 'From',
+                        value: start,
+                        onTap: () async {
+                          final picked = await _pickDate(innerCtx, initial: start);
+                          if (picked != null) setState(() => start = picked);
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _DateField(
+                        label: 'To',
+                        value: end,
+                        onTap: () async {
+                          final picked = await _pickDate(innerCtx, initial: end ?? start);
+                          if (picked != null) setState(() => end = picked);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                TextField(
+                  controller: reasonCtrl,
+                  style: BlockType.body,
+                  decoration: InputDecoration(
+                    hintText: 'Reason (optional)',
+                    hintStyle: BlockType.bodySm.copyWith(color: BlockColors.ink3),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(color: BlockColors.line1),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Row(
+                  children: [
+                    Expanded(
+                      child: BlockButton(
+                        label: 'Cancel',
+                        kind: BlockButtonKind.secondary,
+                        onPressed: () => Navigator.of(sheetCtx).pop(false),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: BlockButton(
+                        label: 'Save',
+                        onPressed: () async {
+                          if (start == null || end == null) return;
+                          if (end!.isBefore(start!)) {
+                            ScaffoldMessenger.of(innerCtx).showSnackBar(
+                              const SnackBar(content: Text('End date must be on or after start')),
+                            );
+                            return;
+                          }
+                          final err = await ref
+                              .read(availabilityMutationsProvider.notifier)
+                              .addTimeoff(
+                                start!,
+                                end!,
+                                reasonCtrl.text.trim().isEmpty
+                                    ? null
+                                    : reasonCtrl.text.trim(),
+                              );
+                          if (!innerCtx.mounted) return;
+                          if (err != null) {
+                            ScaffoldMessenger.of(innerCtx).showSnackBar(
+                              SnackBar(content: Text('Failed: $err')),
+                            );
+                            return;
+                          }
+                          Navigator.of(sheetCtx).pop(true);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    if ((result ?? false) && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Time off saved')),
       );
+    }
+  }
+
+  Future<DateTime?> _pickDate(BuildContext ctx, {DateTime? initial}) {
+    final now = DateTime.now();
+    return showDatePicker(
+      context: ctx,
+      initialDate: initial ?? now,
+      firstDate: DateTime(now.year, now.month - 1),
+      lastDate: DateTime(now.year + 2),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.data});
+  final AvailabilityData data;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final today = DateTime.now();
+    final monthStart = DateTime(today.year, today.month);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          BlockCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: [
+                    Text(
+                      DateFormat('MMMM y').format(monthStart),
+                      style: BlockType.subhead,
+                    ),
+                    Text(
+                      '${data.entries.length} BLOCKED',
+                      style: BlockType.monoData.copyWith(fontSize: 10),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                _MonthGrid(monthStart: monthStart, blockedDays: data.blockedDays),
+                const SizedBox(height: 12),
+                const Row(
+                  children: [
+                    _LegendDot(color: BlockColors.ink1, label: 'Blocked'),
+                    SizedBox(width: 14),
+                    _LegendDot(color: BlockColors.accentSoft, label: 'Today'),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const MonoLabel('Time off · vacation periods'),
+          if (data.entries.isEmpty)
+            BlockCard(
+              child: Text(
+                'No time off scheduled. Tap ADD above to block dates.',
+                style: BlockType.bodySm,
+                textAlign: TextAlign.center,
+              ),
+            )
+          else
+            for (final e in data.entries) _TimeOffRow(entry: e),
+          const MonoLabel('Recurring rules · weekly / biweekly'),
+          BlockCard(
+            color: const Color(0xFFFFF7ED),
+            borderColor: const Color(0xFFFED7AA),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'COMING SOON',
+                  style: BlockType.monoLabel.copyWith(color: BlockColors.warning),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Recurring availability rules (e.g. "Every Monday") are honoured by '
+                  'the solver but not yet exposed via the API. They land once the '
+                  'backend ships /availability/rrule endpoints.',
+                  style: BlockType.bodySm,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MonthGrid extends StatelessWidget {
+  const _MonthGrid({required this.monthStart, required this.blockedDays});
+  final DateTime monthStart;
+  final Set<DateTime> blockedDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final firstWeekday = monthStart.weekday; // Mon=1..Sun=7
+    final daysInMonth = DateTime(monthStart.year, monthStart.month + 1, 0).day;
+    final today = DateTime.now();
+    const dow = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+    final cells = <Widget>[];
+    for (final d in dow) {
+      cells.add(_GridCell(child: Text(d, style: BlockType.monoTiny.copyWith(fontSize: 9))));
+    }
+    for (var i = 1; i < firstWeekday; i++) {
+      cells.add(const _GridCell());
+    }
+    for (var d = 1; d <= daysInMonth; d++) {
+      final date = DateTime(monthStart.year, monthStart.month, d);
+      final blocked = blockedDays.contains(date);
+      final isToday = today.year == date.year && today.month == date.month && today.day == date.day;
+      cells.add(_DayCell(day: d, blocked: blocked, isToday: isToday));
+    }
+
+    return GridView.count(
+      crossAxisCount: 7,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      mainAxisSpacing: 4,
+      crossAxisSpacing: 4,
+      children: cells,
+    );
+  }
+}
+
+class _GridCell extends StatelessWidget {
+  const _GridCell({this.child});
+  final Widget? child;
+  @override
+  Widget build(BuildContext context) =>
+      Center(child: child ?? const SizedBox.shrink());
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({required this.day, required this.blocked, required this.isToday});
+  final int day;
+  final bool blocked;
+  final bool isToday;
+
+  @override
+  Widget build(BuildContext context) {
+    var bg = Colors.transparent;
+    var fg = BlockColors.ink1;
+    if (blocked) {
+      bg = BlockColors.ink1;
+      fg = Colors.white;
+    } else if (isToday) {
+      bg = BlockColors.accentSoft;
+      fg = BlockColors.accentInk;
+    }
+    return Container(
+      decoration: BoxDecoration(color: bg, borderRadius: BorderRadius.circular(8)),
+      alignment: Alignment.center,
+      child: Text(
+        '$day',
+        style: BlockType.body.copyWith(color: fg, fontSize: 14, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}
+
+class _LegendDot extends StatelessWidget {
+  const _LegendDot({required this.color, required this.label});
+  final Color color;
+  final String label;
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(3)),
+        ),
+        const SizedBox(width: 5),
+        Text(label, style: BlockType.bodySm),
+      ],
+    );
+  }
+}
+
+class _TimeOffRow extends ConsumerWidget {
+  const _TimeOffRow({required this.entry});
+  final TimeOffEntry entry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final f = DateFormat('d MMM');
+    final range = entry.startDate.isAtSameMomentAs(entry.endDate)
+        ? f.format(entry.startDate)
+        : '${f.format(entry.startDate)} – ${f.format(entry.endDate)}';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(range, style: BlockType.subhead),
+                  if (entry.reason != null && entry.reason!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(entry.reason!, style: BlockType.bodySm),
+                    ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: () async {
+                final err = await ref
+                    .read(availabilityMutationsProvider.notifier)
+                    .deleteTimeoff(entry.id);
+                if (!context.mounted) return;
+                if (err != null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Failed: $err')),
+                  );
+                }
+              },
+              icon: const Icon(Icons.close, color: BlockColors.danger, size: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({required this.label, required this.value, required this.onTap});
+  final String label;
+  final DateTime? value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          border: Border.all(color: BlockColors.line1),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label.toUpperCase(),
+              style: BlockType.monoLabel.copyWith(fontSize: 10),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              value == null ? 'Pick a date' : DateFormat('d MMM y').format(value!),
+              style: BlockType.body.copyWith(
+                color: value == null ? BlockColors.ink3 : BlockColors.ink1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/test/availability_screen_test.dart
+++ b/mobile/test/availability_screen_test.dart
@@ -1,0 +1,69 @@
+// Availability screen widget test — overrides availabilityProvider with
+// fake data, asserts the calendar grid + time-off list + the
+// "coming soon" recurring-rules panel render.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/features/volunteer/availability_provider.dart';
+import 'package:signupflow_mobile/features/volunteer/availability_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+AvailabilityData _data() => AvailabilityData(entries: [
+      TimeOffEntry(
+        id: 1,
+        startDate: DateTime(2026, 5, 12),
+        endDate: DateTime(2026, 5, 13),
+        reason: 'Family trip',
+      ),
+      TimeOffEntry(
+        id: 2,
+        startDate: DateTime(2026, 5, 27),
+        endDate: DateTime(2026, 5, 27),
+      ),
+    ]);
+
+void main() {
+  testWidgets('availability renders calendar + time-off list + rrule callout',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          availabilityProvider.overrideWith((ref) async => _data()),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const AvailabilityScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('AVAILABILITY'), findsOneWidget);
+    expect(find.text('2 BLOCKED'), findsOneWidget);
+    expect(find.text('Family trip'), findsOneWidget);
+    expect(find.text('COMING SOON'), findsOneWidget);
+  });
+
+  testWidgets('empty time-off shows the empty state copy', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          availabilityProvider.overrideWith(
+            (ref) async => const AvailabilityData(entries: []),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const AvailabilityScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No time off scheduled'), findsOneWidget);
+    expect(find.text('0 BLOCKED'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Real Volunteer Availability tab against the generated `AvailabilityApi`. Volunteer can see a month calendar with blocked days, list their time-off periods, add new ones, and delete existing ones.

## Scope deliberately narrowed

The OpenAPI snapshot only exposes `TimeOff` endpoints (multi-day vacation periods). Sprint 5 backend work added `rrule` + `AvailabilityException` to the SOLVER side, but those don't have CRUD routes yet. So this PR ships the **TimeOff** flow end-to-end, and the prototype's "Recurring rules" panel renders an honest **COMING SOON** callout instead of fake UI.

## What works

| | |
|---|---|
| **Month grid** | Today highlighted in teal-soft, blocked days filled ink-1 |
| **Time-off list** | Sorted by start date, range label (`12 May – 13 May` or single-day), optional reason |
| **ADD sheet** | from/to date pickers + optional reason → `POST /availability/{person_id}/timeoff` |
| **Per-row delete** | `DELETE /availability/{person_id}/timeoff/{id}` |
| **States** | Loading / error / empty all themed |
| **Refresh** | `ref.invalidate(availabilityProvider)` after every mutation |

## API plumbing

- `TimeOffEntry` / `AvailabilityData` view-models in `availability_provider.dart`.
- `getTimeoff` response is `JsonObject` (untyped — backend has no FastAPI response model on this route, so OpenAPI schema is empty `{}`). Manual JSON decode.
- `TimeOffCreate` built_value builder for `addTimeoff`.
- `AvailabilityMutationsController` exposes `addTimeoff` + `deleteTimeoff`, invalidates the provider, returns user-facing error or null.

## Tests (12 / 12 passing)

- `availability_screen_test.dart` (new):
  - Renders calendar + time-off list + COMING SOON callout
  - Empty state shows "No time off scheduled" copy
- All previous tests unchanged.

## Validation

- `flutter analyze` — **0 issues**.
- `flutter test` — **12 passed**.
- Backend Python tests untouched.

## Follow-ups

- **Backend gap**: expose `/availability/rrule` + `/availability/exceptions` CRUD so the recurring-rules + single-date sections can be implemented.
- **7.6** — Volunteer Profile (avatar + name + ICS export + log out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)