### PR TITLE
Sprint 7 PR 7.6: Volunteer Profile + ICS export

### DIFF
--- a/mobile/lib/features/volunteer/profile_provider.dart
+++ b/mobile/lib/features/volunteer/profile_provider.dart
@@ -1,0 +1,68 @@
+// Profile flow — Sprint 7.6.
+//
+// Loads PersonMe (PeopleApi.getCurrentPerson) + CalendarSubscriptionResponse
+// (CalendarApi.getSubscriptionUrl) in parallel. Reset-token mutation calls
+// CalendarApi.resetCalendarToken (self-reset; admin-reset is a separate
+// endpoint we don't surface in the volunteer profile).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+class ProfileData {
+  const ProfileData({required this.person, this.subscription});
+  final api.PersonResponse person;
+  final api.CalendarSubscriptionResponse? subscription;
+}
+
+final profileProvider = FutureProvider<ProfileData>((ref) async {
+  final personId = ref.watch(authProvider).personId;
+  final apiClient = ref.watch(signupflowApiProvider);
+
+  final personFuture = apiClient.getPeopleApi().getCurrentPerson();
+  // Subscription URL is per-person; only fetchable if we know our id.
+  final subFuture = personId == null
+      ? Future<api.CalendarSubscriptionResponse?>.value(null)
+      : apiClient
+          .getCalendarApi()
+          .getSubscriptionUrl(personId: personId)
+          .then((r) => r.data);
+
+  final results = await Future.wait([personFuture, subFuture]);
+  final person = (results[0] as dynamic).data as api.PersonResponse?;
+  if (person == null) {
+    throw StateError('Empty /people/me response');
+  }
+  final sub = results[1] as api.CalendarSubscriptionResponse?;
+  return ProfileData(person: person, subscription: sub);
+});
+
+class ProfileMutationsController extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  /// Reset calendar token. Returns null on success or an error message.
+  Future<String?> resetToken() async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      await ref
+          .read(signupflowApiProvider)
+          .getCalendarApi()
+          .resetCalendarToken(personId: personId);
+      ref.invalidate(profileProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+}
+
+final profileMutationsProvider =
+    NotifierProvider<ProfileMutationsController, bool>(
+  ProfileMutationsController.new,
+);

--- a/mobile/lib/features/volunteer/profile_screen.dart
+++ b/mobile/lib/features/volunteer/profile_screen.dart
@@ -1,38 +1,257 @@
+// Volunteer Profile — Sprint 7.6.
+// Visual target: mobile/prototype/screenshots/v2/07-v-profile.png.
+//
+// Loads PersonResponse + CalendarSubscriptionResponse from profileProvider.
+// Reset-token mutation invalidates the provider so the new ICS URL renders
+// without a manual refresh. Log out wipes Riverpod state + secure storage
+// then routes to /login.
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-
+import 'package:signupflow_api/signupflow_api.dart' as api;
 import 'package:signupflow_mobile/auth/auth_provider.dart';
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
+import 'package:signupflow_mobile/features/volunteer/profile_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
 import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
 class VolunteerProfileScreen extends ConsumerWidget {
   const VolunteerProfileScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(profileProvider);
     return Scaffold(
       body: SafeArea(
-        child: Stack(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const StubScreen(
-              title: 'Profile',
-              endpoint: 'GET /people/me · POST /calendar/reset',
-              willLandIn: 'PR 7.6',
-            ),
-            Positioned(
-              left: 16,
-              right: 16,
-              bottom: 16,
-              child: BlockButton(
-                label: 'Log out',
-                kind: BlockButtonKind.destructive,
-                onPressed: () {
-                  ref.read(authProvider.notifier).signOut();
-                  context.go('/login');
-                },
+            const PageTitle('Profile'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'Failed to load profile: $e',
+                      style: BlockType.bodySm,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                data: (data) => _Body(data: data),
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.data});
+  final ProfileData data;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final person = data.person;
+    final email = person.email ?? '—';
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          BlockCard(
+            child: Row(
+              children: [
+                AvatarBadge(name: person.name, size: 64),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        person.name,
+                        style: BlockType.subhead.copyWith(fontSize: 18),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        email.toUpperCase(),
+                        style: BlockType.monoTiny.copyWith(fontSize: 10),
+                      ),
+                      Text(
+                        person.orgId.toUpperCase(),
+                        style: BlockType.monoTiny.copyWith(
+                          fontSize: 10,
+                          color: BlockColors.accent,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const MonoLabel('Calendar export'),
+          if (data.subscription case final api.CalendarSubscriptionResponse sub)
+            _CalendarCard(subscription: sub)
+          else
+            BlockCard(
+              child: Text(
+                'Calendar export unavailable — subscription URL is unset.',
+                style: BlockType.bodySm,
+              ),
+            ),
+          const MonoLabel('Settings'),
+          _SettingRow(
+            label: 'Language',
+            value: _resolveLanguage(person.language ?? 'en'),
+          ),
+          _SettingRow(
+            label: 'Time zone',
+            value: person.timezone ?? 'UTC',
+          ),
+          _SettingRow(
+            label: 'Roles',
+            value: (person.roles?.toList() ?? const <String>[]).join(' · ').toUpperCase(),
+          ),
+          const SizedBox(height: 16),
+          BlockButton(
+            label: 'Log out',
+            kind: BlockButtonKind.destructive,
+            onPressed: () async {
+              await ref.read(authProvider.notifier).signOut();
+              if (!context.mounted) return;
+              context.go('/login');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _resolveLanguage(String code) {
+    return switch (code.toLowerCase()) {
+      'en' => 'English',
+      'es' => 'Español',
+      'fr' => 'Français',
+      'de' => 'Deutsch',
+      'pt' => 'Português',
+      'zh' => '中文',
+      _ => code.toUpperCase(),
+    };
+  }
+}
+
+class _CalendarCard extends ConsumerWidget {
+  const _CalendarCard({required this.subscription});
+  final api.CalendarSubscriptionResponse subscription;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final url = subscription.httpsUrl;
+    final busy = ref.watch(profileMutationsProvider);
+    return BlockCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            decoration: BoxDecoration(
+              color: BlockColors.accentSoft,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              url.toUpperCase(),
+              style: BlockType.monoData.copyWith(
+                color: BlockColors.accentInk,
+                fontSize: 11,
+              ),
+              softWrap: true,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: BlockButton(
+                  label: 'Copy URL',
+                  kind: BlockButtonKind.secondary,
+                  onPressed: () async {
+                    await Clipboard.setData(ClipboardData(text: url));
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Copied to clipboard')),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: BlockButton(
+                  label: busy ? 'Resetting…' : 'Reset token',
+                  kind: BlockButtonKind.secondary,
+                  onPressed: busy
+                      ? null
+                      : () async {
+                          final err = await ref
+                              .read(profileMutationsProvider.notifier)
+                              .resetToken();
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                err == null
+                                    ? 'Calendar token reset — old subscriptions stop working'
+                                    : 'Failed: $err',
+                              ),
+                            ),
+                          );
+                        },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'Subscribe in Apple Calendar, Google Calendar, or Outlook. Updates within 1 hour of publish.',
+            style: BlockType.bodySm,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingRow extends StatelessWidget {
+  const _SettingRow({required this.label, required this.value});
+  final String label;
+  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label.toUpperCase(),
+                    style: BlockType.monoLabel.copyWith(fontSize: 10),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(value, style: BlockType.body),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: BlockColors.ink3, size: 20),
           ],
         ),
       ),

--- a/mobile/test/profile_screen_test.dart
+++ b/mobile/test/profile_screen_test.dart
@@ -1,0 +1,81 @@
+// Profile screen widget test — overrides profileProvider with synthetic
+// PersonResponse + CalendarSubscriptionResponse and asserts the avatar,
+// settings rows, ICS card, and log-out button render.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/volunteer/profile_provider.dart';
+import 'package:signupflow_mobile/features/volunteer/profile_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.PersonResponse _person() => (api.PersonResponseBuilder()
+      ..id = 'p-sk'
+      ..name = 'Sarah Kowalski'
+      ..email = 'sarah.k@gmail.com'
+      ..orgId = 'hcc'
+      ..language = 'en'
+      ..timezone = 'America/Los_Angeles'
+      ..roles = ListBuilder<String>(['volunteer'])
+      ..createdAt = DateTime(2026, 5, 1).toUtc()
+      ..updatedAt = DateTime(2026, 5, 1).toUtc())
+    .build();
+
+api.CalendarSubscriptionResponse _sub() => (api.CalendarSubscriptionResponseBuilder()
+      ..httpsUrl = 'https://api.signupflow.app/calendar/abc-123/ics'
+      ..webcalUrl = 'webcal://api.signupflow.app/calendar/abc-123/ics'
+      ..token = 'abc-123'
+      ..message = 'OK')
+    .build();
+
+void main() {
+  testWidgets('profile renders person + ICS card + settings', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          profileProvider.overrideWith(
+            (ref) async => ProfileData(person: _person(), subscription: _sub()),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const VolunteerProfileScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('PROFILE'), findsOneWidget);
+    expect(find.text('Sarah Kowalski'), findsOneWidget);
+    expect(find.text('SARAH.K@GMAIL.COM'), findsOneWidget);
+    expect(find.text('HCC'), findsOneWidget);
+    expect(find.text('Copy URL'.toUpperCase()), findsOneWidget);
+    expect(find.text('Reset token'.toUpperCase()), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('LOG OUT'), findsOneWidget);
+  });
+
+  testWidgets('profile without subscription falls back gracefully', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          profileProvider.overrideWith(
+            (ref) async => ProfileData(person: _person()),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const VolunteerProfileScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Calendar export unavailable'), findsOneWidget);
+    expect(find.text('LOG OUT'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Real Volunteer Profile tab. Avatar, name + email + org badge, ICS calendar export with copy/reset, settings, and the working log-out button.

## Closes Volunteer MVP

This is the **last volunteer-side PR** in Sprint 7. The volunteer journey end-to-end is:

`/login → demo or real auth → /v/schedule → /v/assignment/{id} (Accept/Decline/Swap) → /v/availability (TimeOff add/delete) → /v/profile (ICS + log out)`

Admin journey is the remaining 7.7–7.10 work.

## What works

- **Avatar** (initials in deterministic teal-tone) + name + email + org id chip.
- **Calendar export card**: ICS URL on accent-soft pill, COPY URL via `Clipboard.setData`, RESET TOKEN via `CalendarApi.resetCalendarToken` (self-reset, not the admin override path).
- **Settings rows**: language (resolved `en` → "English" etc.), time zone, roles list.
- **Log out**: wipes Riverpod state + Keychain JWT, routes to `/login`.

## Data flow

- `profileProvider` parallel-fetches `PeopleApi.getCurrentPerson` + `CalendarApi.getSubscriptionUrl`.
- Subscription is optional — fallback copy reads "Calendar export unavailable".
- `ProfileMutationsController.resetToken()` invalidates `profileProvider` on success so the new ICS URL re-renders without manual refresh.

## Tests (14 / 14 passing)

- `profile_screen_test.dart` (new):
  - Renders person + ICS card + settings rows
  - Falls back gracefully when subscription is null

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **14 passed**
- Backend Python tests untouched

## Follow-ups

- **7.7** — Admin Dashboard with KPI fetch (analytics + recent solutions list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)