### PR TITLE
Sprint 7 PR 7.7: Admin Dashboard with KPIs + recent solutions

### DIFF
--- a/mobile/lib/features/admin/dashboard_provider.dart
+++ b/mobile/lib/features/admin/dashboard_provider.dart
@@ -1,0 +1,98 @@
+// Admin dashboard data — Sprint 7.7.
+//
+// Combines:
+//   AnalyticsApi.getVolunteerStats(org_id) → JsonObject (active volunteers + …)
+//   AnalyticsApi.getScheduleHealth(org_id) → JsonObject (events, health, …)
+//   SolutionsApi.listSolutions(org_id)     → list[SolutionResponse]
+//
+// The two analytics endpoints return JsonObject because the backend
+// FastAPI handlers don't declare typed response models. We decode them
+// manually with optional fields — missing keys fall back to safe defaults.
+
+import 'dart:convert';
+
+import 'package:built_value/json_object.dart' show JsonObject;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+class DashboardData {
+  const DashboardData({
+    required this.activeVolunteers,
+    required this.eventsThisWeek,
+    required this.healthScore,
+    required this.publishedSolution,
+    required this.publishedAt,
+    required this.recentSolutions,
+  });
+
+  final int activeVolunteers;
+  final int eventsThisWeek;
+  final num healthScore;
+  final api.SolutionResponse? publishedSolution;
+  final DateTime? publishedAt;
+  final List<api.SolutionResponse> recentSolutions;
+}
+
+Map<String, dynamic>? _decodeJsonObject(JsonObject? obj) {
+  if (obj == null) return null;
+  final decoded = json.decode(obj.toString());
+  return decoded is Map<String, dynamic> ? decoded : null;
+}
+
+final dashboardProvider = FutureProvider<DashboardData>((ref) async {
+  final orgId = ref.watch(authProvider).orgId;
+  if (orgId == null) {
+    return const DashboardData(
+      activeVolunteers: 0,
+      eventsThisWeek: 0,
+      healthScore: 0,
+      publishedSolution: null,
+      publishedAt: null,
+      recentSolutions: [],
+    );
+  }
+
+  final apiClient = ref.watch(signupflowApiProvider);
+
+  final futures = await Future.wait([
+    apiClient.getAnalyticsApi().getVolunteerStats(orgId: orgId),
+    apiClient.getAnalyticsApi().getScheduleHealth(orgId: orgId),
+    apiClient.getSolutionsApi().listSolutions(orgId: orgId, limit: 10),
+  ]);
+
+  final volStats =
+      _decodeJsonObject((futures[0] as dynamic).data as JsonObject?) ?? {};
+  final health =
+      _decodeJsonObject((futures[1] as dynamic).data as JsonObject?) ?? {};
+  final solList =
+      ((futures[2] as dynamic).data as api.ListResponseSolutionResponse?)
+          ?.items
+          .toList() ??
+          const <api.SolutionResponse>[];
+
+  final activeVolunteers = (volStats['active_volunteers'] as num?)?.toInt() ??
+      (volStats['total'] as num?)?.toInt() ??
+      0;
+  final eventsThisWeek =
+      (health['events_this_week'] as num?)?.toInt() ?? 0;
+  final healthScore = (health['health_score'] as num?) ?? 0;
+
+  api.SolutionResponse? published;
+  for (final s in solList) {
+    if (s.isPublished ?? false) {
+      published = s;
+      break;
+    }
+  }
+
+  return DashboardData(
+    activeVolunteers: activeVolunteers,
+    eventsThisWeek: eventsThisWeek,
+    healthScore: healthScore,
+    publishedSolution: published,
+    publishedAt: published?.publishedAt,
+    recentSolutions: solList,
+  );
+});

--- a/mobile/lib/features/admin/dashboard_screen.dart
+++ b/mobile/lib/features/admin/dashboard_screen.dart
@@ -1,14 +1,256 @@
+// Admin Dashboard — Sprint 7.7.
+// Visual target: mobile/prototype/screenshots/v2/08-a-dashboard.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/dashboard_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class DashboardScreen extends StatelessWidget {
+class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Dashboard',
-        endpoint: 'GET /analytics/org · GET /solutions',
-        willLandIn: 'PR 7.7',
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(dashboardProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Org settings drawer comes in 7.10+'),
+                      ),
+                    ),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      'SETTINGS',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const PageTitle('Dashboard'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'Failed to load dashboard: $e',
+                      style: BlockType.bodySm,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                data: (data) => _Body(data: data),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.data});
+  final DashboardData data;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          GridView.count(
+            crossAxisCount: 2,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+            childAspectRatio: 1.7,
+            children: [
+              KpiCell(
+                value: '${data.activeVolunteers}',
+                label: 'Active volunteers',
+              ),
+              KpiCell(
+                value: '${data.eventsThisWeek}',
+                label: 'Events this week',
+              ),
+              KpiCell(
+                value: '${data.healthScore.toInt()}',
+                unit: '/100',
+                label: 'Health score',
+                accent: true,
+              ),
+              _PublishedKpi(
+                published: data.publishedSolution,
+                publishedAt: data.publishedAt,
+              ),
+            ],
+          ),
+          const MonoLabel('Recent solutions'),
+          if (data.recentSolutions.isEmpty)
+            BlockCard(
+              child: Text(
+                'No solutions yet. Run the solver to generate the first one.',
+                style: BlockType.bodySm,
+              ),
+            )
+          else
+            for (final s in data.recentSolutions.take(5))
+              _SolutionRow(solution: s),
+          const MonoLabel('Quick actions'),
+          Row(
+            children: [
+              Expanded(
+                child: BlockButton(
+                  label: 'Run solver',
+                  kind: BlockButtonKind.go,
+                  onPressed: () => GoRouter.of(context).go('/a/solver'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: BlockButton(
+                  label: 'Invite people',
+                  kind: BlockButtonKind.secondary,
+                  onPressed: () => GoRouter.of(context).go('/a/people'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PublishedKpi extends StatelessWidget {
+  const _PublishedKpi({required this.published, required this.publishedAt});
+  final api.SolutionResponse? published;
+  final DateTime? publishedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    if (published == null) {
+      return BlockCard(
+        padding: const EdgeInsets.fromLTRB(14, 16, 14, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const StatusText(kind: StatusKind.neutral, label: 'NONE LIVE'),
+            const SizedBox(height: 6),
+            Text('Publish a solution to start.', style: BlockType.bodySm),
+            const Spacer(),
+            Text('No published solution', style: BlockType.monoTiny),
+          ],
+        ),
       );
+    }
+    final ago = publishedAt != null
+        ? _relativeAgo(publishedAt!)
+        : '—';
+    return BlockCard(
+      padding: const EdgeInsets.fromLTRB(14, 16, 14, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const StatusText(kind: StatusKind.confirmed, label: 'PUBLISHED'),
+          const SizedBox(height: 4),
+          Text(
+            ago,
+            style: BlockType.body.copyWith(fontSize: 13, fontWeight: FontWeight.w500),
+          ),
+          const Spacer(),
+          Text(
+            'Solution #${published!.id}',
+            style: BlockType.monoTiny.copyWith(color: BlockColors.ink2),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _relativeAgo(DateTime when) {
+    final delta = DateTime.now().difference(when);
+    if (delta.inMinutes < 60) return '${delta.inMinutes}m ago';
+    if (delta.inHours < 24) return '${delta.inHours}h ago';
+    if (delta.inDays < 30) return '${delta.inDays}d ago';
+    return DateFormat('d MMM').format(when);
+  }
+}
+
+class _SolutionRow extends StatelessWidget {
+  const _SolutionRow({required this.solution});
+  final api.SolutionResponse solution;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLive = solution.isPublished ?? false;
+    final created = DateFormat('d MMM · h:mm a').format(solution.createdAt.toLocal());
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: BlockColors.bgCard,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+          side: const BorderSide(color: BlockColors.line1),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: () => GoRouter.of(context).go('/a/solution/${solution.id}'),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text('Solution #${solution.id}', style: BlockType.subhead),
+                          const SizedBox(width: 8),
+                          if (isLive)
+                            const StatusText(kind: StatusKind.confirmed, label: 'LIVE')
+                          else
+                            const StatusText(kind: StatusKind.pending, label: 'DRAFT'),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'HEALTH ${solution.healthScore.toInt()} · ${created.toUpperCase()}',
+                        style: BlockType.monoTiny.copyWith(fontSize: 10),
+                      ),
+                    ],
+                  ),
+                ),
+                const Icon(Icons.chevron_right, color: BlockColors.ink3, size: 20),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/lib/theme/components.dart
+++ b/mobile/lib/theme/components.dart
@@ -273,29 +273,30 @@ class KpiCell extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          RichText(
-            text: TextSpan(
-              style: GoogleFonts.inter(
-                fontSize: 26,
-                fontWeight: FontWeight.w700,
-                letterSpacing: -0.65,
-                color: color,
-                height: 1.05,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                value,
+                style: GoogleFonts.inter(
+                  fontSize: 26,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: -0.65,
+                  color: color,
+                  height: 1.05,
+                ),
               ),
-              children: [
-                TextSpan(text: value),
-                if (unit != null)
-                  TextSpan(
-                    text: unit,
-                    style: GoogleFonts.inter(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
-                      color: BlockColors.ink2,
-                      letterSpacing: 0,
-                    ),
+              if (unit != null)
+                Text(
+                  unit!,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: BlockColors.ink2,
                   ),
-              ],
-            ),
+                ),
+            ],
           ),
           const SizedBox(height: 4),
           Text(label.toUpperCase(), style: BlockType.monoTiny),

--- a/mobile/test/dashboard_screen_test.dart
+++ b/mobile/test/dashboard_screen_test.dart
@@ -1,0 +1,99 @@
+// Admin dashboard widget test — overrides dashboardProvider with synthetic
+// data and asserts KPI grid + recent solutions list + quick action row.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/dashboard_provider.dart';
+import 'package:signupflow_mobile/features/admin/dashboard_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.SolutionResponse _solution({
+  required int id,
+  required bool isPublished,
+  required int health,
+}) {
+  return (api.SolutionResponseBuilder()
+        ..id = id
+        ..orgId = 'hcc'
+        ..solveMs = 274
+        ..hardViolations = 0
+        ..softScore = 1
+        ..healthScore = health
+        ..createdAt = DateTime(2026, 5, 7, 14, 14).toUtc()
+        ..isPublished = isPublished
+        ..publishedAt = isPublished ? DateTime(2026, 5, 4).toUtc() : null
+        ..assignmentCount = 24
+        ..metrics = MapBuilder<String, JsonObject?>())
+      .build();
+}
+
+void main() {
+  testWidgets('dashboard renders KPI grid + recent solutions', (tester) async {
+    final data = DashboardData(
+      activeVolunteers: 47,
+      eventsThisWeek: 12,
+      healthScore: 98,
+      publishedSolution: _solution(id: 141, isPublished: true, health: 96),
+      publishedAt: DateTime(2026, 5, 4),
+      recentSolutions: [
+        _solution(id: 142, isPublished: false, health: 98),
+        _solution(id: 141, isPublished: true, health: 96),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dashboardProvider.overrideWith((ref) async => data),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const DashboardScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('DASHBOARD'), findsOneWidget);
+    expect(find.text('47'), findsOneWidget);
+    expect(find.text('12'), findsOneWidget);
+    expect(find.text('98'), findsOneWidget);
+    expect(find.text('Solution #142'), findsOneWidget);
+    expect(find.text('DRAFT'), findsOneWidget);
+    // Solution #141 appears twice: in the KPI card subtitle + in the
+    // recent solutions list row.
+    expect(find.text('Solution #141'), findsNWidgets(2));
+    expect(find.text('LIVE'), findsAtLeastNWidgets(1));
+    expect(find.text('RUN SOLVER'), findsOneWidget);
+  });
+
+  testWidgets('dashboard with no solutions shows empty copy', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dashboardProvider.overrideWith((ref) async => const DashboardData(
+                activeVolunteers: 0,
+                eventsThisWeek: 0,
+                healthScore: 0,
+                publishedSolution: null,
+                publishedAt: null,
+                recentSolutions: [],
+              )),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const DashboardScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('NONE LIVE'), findsOneWidget);
+    expect(find.textContaining('No solutions yet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Real Admin Dashboard tab. Opens the admin journey for Sprint 7 (volunteer journey shipped in 7.1–7.6).

## What works

- **2×2 KPI grid**: active volunteers · events this week · health score (teal accent) · published solution status with "Xd ago" timestamp.
- **Recent solutions list** (top 5) with LIVE / DRAFT status indicators. Tap a row → `/a/solution/{id}`.
- **Quick actions**: RUN SOLVER (go-teal) → `/a/solver`; INVITE PEOPLE (secondary) → `/a/people`.
- Loading / error / empty states all themed.

## Data flow

`dashboardProvider` parallel-fetches three endpoints:

| Endpoint | Returns |
|---|---|
| `AnalyticsApi.getVolunteerStats(orgId)` | `JsonObject` — active volunteer count |
| `AnalyticsApi.getScheduleHealth(orgId)` | `JsonObject` — events this week, health score |
| `SolutionsApi.listSolutions(orgId, 10)` | typed `ListResponseSolutionResponse` |

The analytics endpoints return `JsonObject` because the backend FastAPI handlers don't declare typed response models. Manual JSON decode with safe defaults (missing keys → 0). Currently-published solution detected by the `isPublished` flag on the list response — no separate fetch.

## `KpiCell` refactor

Switched from `RichText` with `TextSpan`s to a `Row` of plain `Text` widgets for value+unit. Same visual output, but `find.text("47")` now works in widget tests. Used by both the volunteer Profile (assignments YTD) and admin Dashboard.

## Tests (16 / 16 passing)

- `dashboard_screen_test.dart` (new):
  - Renders KPI grid + recent solutions list with LIVE/DRAFT badges
  - Empty solutions case shows "NONE LIVE" + "No solutions yet" copy

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **16 passed**
- Backend Python tests untouched

## Follow-ups

- **7.8** — Admin People + Events lists with invite flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)