### PR TITLE
Sprint 7 PR 7.8: Admin People + Events lists with invite flow

### DIFF
--- a/mobile/lib/features/admin/events_provider.dart
+++ b/mobile/lib/features/admin/events_provider.dart
@@ -1,0 +1,37 @@
+// Events list + recurring series — Sprint 7.8.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+class EventsData {
+  const EventsData({required this.events, required this.series});
+  final List<api.EventResponse> events;
+  final List<api.RecurringSeriesResponse> series;
+}
+
+final eventsProvider = FutureProvider<EventsData>((ref) async {
+  final orgId = ref.watch(authProvider).orgId;
+  if (orgId == null) return const EventsData(events: [], series: []);
+
+  final apiClient = ref.watch(signupflowApiProvider);
+  final futures = await Future.wait([
+    apiClient.getEventsApi().listEvents(orgId: orgId, limit: 100),
+    apiClient.getRecurringEventsApi().listRecurringSeries(orgId: orgId),
+  ]);
+
+  final events = ((futures[0] as dynamic).data
+              as api.ListResponseEventResponse?)
+          ?.items
+          .toList() ??
+      const <api.EventResponse>[];
+  final series = ((futures[1] as dynamic).data
+              as api.ListResponseRecurringSeriesResponse?)
+          ?.items
+          .toList() ??
+      const <api.RecurringSeriesResponse>[];
+
+  events.sort((a, b) => a.startTime.compareTo(b.startTime));
+  return EventsData(events: events, series: series);
+});

--- a/mobile/lib/features/admin/events_screen.dart
+++ b/mobile/lib/features/admin/events_screen.dart
@@ -1,14 +1,158 @@
+// Admin Events — Sprint 7.8.
+// Visual target: mobile/prototype/screenshots/v2/10-a-events.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/events_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class EventsScreen extends StatelessWidget {
+class EventsScreen extends ConsumerWidget {
   const EventsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Events',
-        endpoint: 'GET /events · GET /recurring_events',
-        willLandIn: 'PR 7.8',
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(eventsProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Create event lands in 7.10+')),
+                    ),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      '+ NEW',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const PageTitle('Events'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text('Failed to load: $e', style: BlockType.bodySm),
+                  ),
+                ),
+                data: (data) => _Body(data: data),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.data});
+  final EventsData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final upcoming = data.events
+        .where((e) => e.startTime.toLocal().isAfter(DateTime.now().subtract(const Duration(hours: 1))))
+        .take(20)
+        .toList();
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          MonoLabel('Upcoming · ${upcoming.length}'),
+          if (upcoming.isEmpty)
+            BlockCard(
+              child: Text(
+                'No upcoming events. Add one with + NEW above.',
+                style: BlockType.bodySm,
+              ),
+            )
+          else
+            for (final e in upcoming) _EventRow(event: e),
+          MonoLabel('Recurring series · ${data.series.length}'),
+          if (data.series.isEmpty)
+            BlockCard(
+              child: Text(
+                'No recurring series defined yet.',
+                style: BlockType.bodySm,
+              ),
+            )
+          else
+            for (final s in data.series) _SeriesRow(series: s),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventRow extends StatelessWidget {
+  const _EventRow({required this.event});
+  final api.EventResponse event;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = event.startTime.toLocal();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              DateFormat('EEE d MMM · HH:mm').format(start).toUpperCase(),
+              style: BlockType.monoTiny.copyWith(fontSize: 10),
+            ),
+            const SizedBox(height: 4),
+            Text(event.type, style: BlockType.subhead),
+            const SizedBox(height: 4),
+            Text('Event ${event.id}', style: BlockType.bodySm),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SeriesRow extends StatelessWidget {
+  const _SeriesRow({required this.series});
+  final api.RecurringSeriesResponse series;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(series.title, style: BlockType.subhead),
+            const SizedBox(height: 4),
+            Text(
+              '${series.patternType.toUpperCase()} · '
+              'EVERY ${series.frequencyInterval} ${series.weekdayName ?? ""}',
+              style: BlockType.monoTiny.copyWith(fontSize: 10),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/lib/features/admin/people_provider.dart
+++ b/mobile/lib/features/admin/people_provider.dart
@@ -1,0 +1,52 @@
+// People list + invite — Sprint 7.8.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+final peopleProvider = FutureProvider<List<api.PersonResponse>>((ref) async {
+  final orgId = ref.watch(authProvider).orgId;
+  if (orgId == null) return const [];
+  final res = await ref
+      .watch(signupflowApiProvider)
+      .getPeopleApi()
+      .listPeople(orgId: orgId, limit: 200);
+  return res.data?.items.toList() ?? const [];
+});
+
+class InviteController extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  Future<String?> invite({
+    required String name,
+    required String email,
+    required List<String> roles,
+  }) async {
+    final orgId = ref.read(authProvider).orgId;
+    if (orgId == null) return 'Not signed in';
+    state = true;
+    try {
+      final body = (api.InvitationCreateBuilder()
+            ..name = name
+            ..email = email
+            ..roles = ListBuilder<String>(roles))
+          .build();
+      await ref
+          .read(signupflowApiProvider)
+          .getInvitationsApi()
+          .createInvitation(orgId: orgId, invitationCreate: body);
+      ref.invalidate(peopleProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+}
+
+final inviteControllerProvider =
+    NotifierProvider<InviteController, bool>(InviteController.new);

--- a/mobile/lib/features/admin/people_screen.dart
+++ b/mobile/lib/features/admin/people_screen.dart
@@ -1,14 +1,294 @@
+// Admin People — Sprint 7.8.
+// Visual target: mobile/prototype/screenshots/v2/09-a-people.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/people_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class PeopleScreen extends StatelessWidget {
+class PeopleScreen extends ConsumerStatefulWidget {
   const PeopleScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'People',
-        endpoint: 'GET /people · POST /invitations',
-        willLandIn: 'PR 7.8',
+  ConsumerState<PeopleScreen> createState() => _PeopleScreenState();
+}
+
+class _PeopleScreenState extends ConsumerState<PeopleScreen> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncData = ref.watch(peopleProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => _openInviteSheet(context),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      'INVITE',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            asyncData.when(
+              loading: () => const SizedBox.shrink(),
+              error: (_, __) => const SizedBox.shrink(),
+              data: (people) => PageTitle(
+                'People',
+                trailingCount: '${people.length}',
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: _SearchField(onChanged: (v) => setState(() => _query = v.trim().toLowerCase())),
+            ),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text('Failed to load: $e', style: BlockType.bodySm),
+                  ),
+                ),
+                data: (people) {
+                  final filtered = _query.isEmpty
+                      ? people
+                      : people.where((p) {
+                          final hay = '${p.name} ${p.email ?? ''}'.toLowerCase();
+                          return hay.contains(_query);
+                        }).toList();
+                  if (filtered.isEmpty) {
+                    return Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Text(
+                          _query.isEmpty
+                              ? 'No people yet. Tap INVITE to add one.'
+                              : 'No matches for "$_query".',
+                          style: BlockType.bodySm,
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    );
+                  }
+                  return ListView.builder(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+                    itemCount: filtered.length,
+                    itemBuilder: (ctx, i) => _PersonRow(person: filtered[i]),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openInviteSheet(BuildContext context) async {
+    final nameCtrl = TextEditingController();
+    final emailCtrl = TextEditingController();
+    final roles = {'volunteer'};
+
+    final ok = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: BlockColors.bgCard,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) => StatefulBuilder(
+        builder: (innerCtx, setLocal) {
+          return Padding(
+            padding: EdgeInsets.fromLTRB(
+              20,
+              16,
+              20,
+              MediaQuery.of(innerCtx).viewInsets.bottom + 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text('INVITE PERSON', style: BlockType.monoLabel.copyWith(color: BlockColors.ink1)),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: nameCtrl,
+                  autofocus: true,
+                  style: BlockType.body,
+                  decoration: const InputDecoration(
+                    labelText: 'Full name',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: emailCtrl,
+                  keyboardType: TextInputType.emailAddress,
+                  style: BlockType.body,
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  children: ['volunteer', 'admin']
+                      .map(
+                        (r) => FilterChip(
+                          selected: roles.contains(r),
+                          label: Text(r.toUpperCase()),
+                          onSelected: (sel) => setLocal(() {
+                            if (sel) {
+                              roles.add(r);
+                            } else {
+                              roles.remove(r);
+                            }
+                          }),
+                        ),
+                      )
+                      .toList(),
+                ),
+                const SizedBox(height: 14),
+                Row(
+                  children: [
+                    Expanded(
+                      child: BlockButton(
+                        label: 'Cancel',
+                        kind: BlockButtonKind.secondary,
+                        onPressed: () => Navigator.of(sheetCtx).pop(false),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: BlockButton(
+                        label: 'Send invite',
+                        onPressed: () async {
+                          if (nameCtrl.text.trim().isEmpty || emailCtrl.text.trim().isEmpty) {
+                            ScaffoldMessenger.of(innerCtx).showSnackBar(
+                              const SnackBar(content: Text('Name and email required')),
+                            );
+                            return;
+                          }
+                          if (roles.isEmpty) roles.add('volunteer');
+                          final err = await ref
+                              .read(inviteControllerProvider.notifier)
+                              .invite(
+                                name: nameCtrl.text.trim(),
+                                email: emailCtrl.text.trim(),
+                                roles: roles.toList(),
+                              );
+                          if (!innerCtx.mounted) return;
+                          if (err != null) {
+                            ScaffoldMessenger.of(innerCtx).showSnackBar(
+                              SnackBar(content: Text('Failed: $err')),
+                            );
+                            return;
+                          }
+                          Navigator.of(sheetCtx).pop(true);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
+    if ((ok ?? false) && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invitation sent')),
       );
+    }
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  const _SearchField({required this.onChanged});
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Row(
+        children: [
+          const Icon(Icons.search, color: BlockColors.ink3, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              onChanged: onChanged,
+              style: BlockType.body,
+              decoration: InputDecoration(
+                hintText: 'Search by name or email…',
+                hintStyle: BlockType.body.copyWith(color: BlockColors.ink3),
+                border: InputBorder.none,
+                isDense: true,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PersonRow extends StatelessWidget {
+  const _PersonRow({required this.person});
+  final api.PersonResponse person;
+
+  @override
+  Widget build(BuildContext context) {
+    final email = person.email ?? '—';
+    final roles = person.roles?.toList() ?? const <String>[];
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            AvatarBadge(name: person.name),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(person.name, style: BlockType.subhead),
+                  const SizedBox(height: 2),
+                  Text(email, style: BlockType.bodySm),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 4,
+                    children: [for (final r in roles) RoleChip(r)],
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: BlockColors.ink3, size: 20),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/test/people_screen_test.dart
+++ b/mobile/test/people_screen_test.dart
@@ -1,0 +1,93 @@
+// People + Events screen widget tests.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/events_provider.dart';
+import 'package:signupflow_mobile/features/admin/events_screen.dart';
+import 'package:signupflow_mobile/features/admin/people_provider.dart';
+import 'package:signupflow_mobile/features/admin/people_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.PersonResponse _person({
+  required String id,
+  required String name,
+  required String email,
+  required List<String> roles,
+}) =>
+    (api.PersonResponseBuilder()
+          ..id = id
+          ..name = name
+          ..email = email
+          ..orgId = 'hcc'
+          ..language = 'en'
+          ..timezone = 'UTC'
+          ..roles = ListBuilder<String>(roles)
+          ..createdAt = DateTime(2026, 5, 1).toUtc()
+          ..updatedAt = DateTime(2026, 5, 1).toUtc()
+          ..extraData = MapBuilder<String, JsonObject?>())
+        .build();
+
+api.EventResponse _event({
+  required String id,
+  required String type,
+  required DateTime start,
+}) =>
+    (api.EventResponseBuilder()
+          ..id = id
+          ..orgId = 'hcc'
+          ..type = type
+          ..startTime = start.toUtc()
+          ..endTime = start.add(const Duration(hours: 1)).toUtc()
+          ..createdAt = DateTime(2026, 5, 1).toUtc()
+          ..updatedAt = DateTime(2026, 5, 1).toUtc()
+          ..extraData = MapBuilder<String, JsonObject?>())
+        .build();
+
+void main() {
+  testWidgets('people screen renders search + person rows', (tester) async {
+    final people = [
+      _person(id: 'p1', name: 'Sarah Kowalski', email: 's@hcc.org', roles: ['volunteer']),
+      _person(id: 'p2', name: 'James Park', email: 'j@hcc.org', roles: ['volunteer', 'admin']),
+    ];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [peopleProvider.overrideWith((ref) async => people)],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const PeopleScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('PEOPLE'), findsOneWidget);
+    expect(find.textContaining('Search by name'), findsOneWidget);
+    expect(find.text('Sarah Kowalski'), findsOneWidget);
+    expect(find.text('James Park'), findsOneWidget);
+    expect(find.text('VOLUNTEER'), findsAtLeastNWidgets(2));
+    expect(find.text('ADMIN'), findsOneWidget);
+  });
+
+  testWidgets('events screen renders upcoming + recurring sections', (tester) async {
+    final tomorrow = DateTime.now().add(const Duration(days: 1));
+    final data = EventsData(
+      events: [_event(id: 'e1', type: 'Sunday Service', start: tomorrow)],
+      series: const [],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [eventsProvider.overrideWith((ref) async => data)],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const EventsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('EVENTS'), findsOneWidget);
+    // MonoLabel uppercases whatever is passed in, so the rendered text
+    // is "UPCOMING · 1" / "RECURRING SERIES · 0".
+    expect(find.textContaining('UPCOMING · 1'), findsOneWidget);
+    expect(find.text('Sunday Service'), findsOneWidget);
+    expect(find.textContaining('RECURRING SERIES · 0'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Real Admin People + Events tabs. Replaces both StubScreens with API-wired lists matching `mobile/prototype/screenshots/v2/{09-a-people,10-a-events}.png`.

## People

- `peopleProvider` → `PeopleApi.listPeople(orgId, limit=200)`.
- Search field (case-insensitive name + email match).
- Person rows: avatar, name, email, role chips, chevron.
- **INVITE bottom sheet** — name + email + role chip selector (volunteer/admin) → `InvitationsApi.createInvitation` via `inviteControllerProvider`. Invalidates `peopleProvider` on success so newly-invited entries surface.
- Empty state + filter-no-match copy.

## Events

- `eventsProvider` parallel-fetches `EventsApi.listEvents` + `RecurringEventsApi.listRecurringSeries`.
- Sorted by `startTime` ascending; filtered to `startTime >= 1h ago`.
- Two sections: **UPCOMING · n** (event cards with date+time mono label, type, id) and **RECURRING SERIES · n** (title + pattern type + frequency/weekday).
- Empty fallbacks per section.

## Tests (18 / 18 passing)

- `people_screen_test.dart` (new):
  - People screen renders search + person rows + role chips
  - Events screen renders upcoming + recurring sections

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **18 passed**
- Backend Python tests untouched

## Follow-ups

- **7.9** — Solver flow + Solution Review with assignments/stats/conflicts segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)