### PR TITLE
Sprint 7 PR 7.9: Solver flow + Solution Review

### DIFF
--- a/mobile/lib/features/admin/solution_review_screen.dart
+++ b/mobile/lib/features/admin/solution_review_screen.dart
@@ -1,15 +1,364 @@
+// Admin Solution Review — Sprint 7.9.
+// Visual target: mobile/prototype/screenshots/v2/12-a-solution.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/admin/solver_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class SolutionReviewScreen extends StatelessWidget {
+class SolutionReviewScreen extends ConsumerStatefulWidget {
   const SolutionReviewScreen({required this.solutionId, super.key});
   final String solutionId;
 
   @override
-  Widget build(BuildContext context) => StubScreen(
-        title: 'Solution #$solutionId',
-        endpoint: 'GET /solutions/$solutionId · /assignments · /stats',
-        willLandIn: 'PR 7.9',
+  ConsumerState<SolutionReviewScreen> createState() => _SolutionReviewScreenState();
+}
+
+class _SolutionReviewScreenState extends ConsumerState<SolutionReviewScreen> {
+  String _segment = 'assignments';
+
+  int? get _id => int.tryParse(widget.solutionId);
+
+  @override
+  Widget build(BuildContext context) {
+    final id = _id;
+    if (id == null) {
+      return _frame(
+        const Center(child: Text('Invalid solution id')),
       );
+    }
+    final asyncData = ref.watch(solutionDetailProvider(id));
+    return _frame(
+      asyncData.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('Failed to load solution: $e', style: BlockType.bodySm),
+          ),
+        ),
+        data: (data) => _Body(
+          data: data,
+          segment: _segment,
+          onSegmentChanged: (v) => setState(() => _segment = v),
+          onPublish: () => GoRouter.of(context).go('/a/publish'),
+          onCompare: () => GoRouter.of(context).go('/a/compare'),
+        ),
+      ),
+      id: id,
+    );
+  }
+
+  Widget _frame(Widget body, {int? id}) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: () => GoRouter.of(context).go('/a/solver'),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      '‹ SOLVER',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    id == null ? 'SOLUTION' : 'SOLUTION #$id',
+                    style: BlockType.monoLabel.copyWith(
+                      color: BlockColors.ink1,
+                      fontSize: 13,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: id == null ? null : () => GoRouter.of(context).go('/a/publish'),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      'PUBLISH',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(child: body),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({
+    required this.data,
+    required this.segment,
+    required this.onSegmentChanged,
+    required this.onPublish,
+    required this.onCompare,
+  });
+  final SolutionDetailData data;
+  final String segment;
+  final ValueChanged<String> onSegmentChanged;
+  final VoidCallback onPublish;
+  final VoidCallback onCompare;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _Segment(value: segment, onChanged: onSegmentChanged),
+          const SizedBox(height: 14),
+          if (segment == 'assignments') _AssignmentsView(data: data),
+          if (segment == 'stats') _StatsView(data: data),
+          if (segment == 'conflicts') _ConflictsView(data: data),
+          const SizedBox(height: 18),
+          BlockButton(
+            label: 'Compare with another solution',
+            kind: BlockButtonKind.secondary,
+            onPressed: onCompare,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Segment extends StatelessWidget {
+  const _Segment({required this.value, required this.onChanged});
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: BlockColors.line2,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Expanded(child: _seg('ASSIGNMENTS', 'assignments')),
+          Expanded(child: _seg('STATS', 'stats')),
+          Expanded(child: _seg('CONFLICTS', 'conflicts')),
+        ],
+      ),
+    );
+  }
+
+  Widget _seg(String label, String key) {
+    final active = value == key;
+    return GestureDetector(
+      onTap: () => onChanged(key),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 7),
+        decoration: BoxDecoration(
+          color: active ? Colors.white : Colors.transparent,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: BlockType.monoLabel.copyWith(
+            fontSize: 11,
+            color: active ? BlockColors.ink1 : BlockColors.ink2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AssignmentsView extends StatelessWidget {
+  const _AssignmentsView({required this.data});
+  final SolutionDetailData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final created = DateFormat('EEE d MMM y · h:mm a')
+        .format(data.solution.createdAt.toLocal())
+        .toUpperCase();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        BlockCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Solution #${data.solution.id}', style: BlockType.subhead),
+              const SizedBox(height: 4),
+              Text(created, style: BlockType.monoTiny.copyWith(fontSize: 10)),
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 14,
+                runSpacing: 6,
+                children: [
+                  StatusText(
+                    kind: data.solution.hardViolations == 0
+                        ? StatusKind.confirmed
+                        : StatusKind.declined,
+                    label: '${data.solution.hardViolations} hard',
+                  ),
+                  StatusText(
+                    kind: StatusKind.pending,
+                    label: '${data.solution.softScore.toStringAsFixed(1)} soft',
+                  ),
+                  Text(
+                    'HEALTH ${data.solution.healthScore.toInt()}',
+                    style: BlockType.monoData.copyWith(fontSize: 11),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const MonoLabel('Per-event breakdown — coming in 7.10'),
+        BlockCard(
+          color: const Color(0xFFFFF7ED),
+          borderColor: const Color(0xFFFED7AA),
+          child: Text(
+            'Listing assignments grouped by event needs an enriched API '
+            'response (event title + assignees in one call). The current '
+            'getSolutionAssignments returns a JsonObject; rendering it '
+            'cleanly will land alongside Compare in 7.10.',
+            style: BlockType.bodySm,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatsView extends StatelessWidget {
+  const _StatsView({required this.data});
+  final SolutionDetailData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = data.stats;
+    if (stats == null) {
+      return BlockCard(
+        child: Text('Stats unavailable for this solution.', style: BlockType.bodySm),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const MonoLabel('Stability vs published'),
+        Row(
+          children: [
+            Expanded(
+              child: KpiCell(
+                value: '${stats.stability.movesFromPublished}',
+                label: 'Moves',
+                accent: true,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: KpiCell(
+                value: '${stats.stability.affectedPersons}',
+                label: 'People affected',
+              ),
+            ),
+          ],
+        ),
+        const MonoLabel('Workload'),
+        Row(
+          children: [
+            Expanded(
+              child: KpiCell(
+                value: '${stats.workload.maxEventsPerPerson}',
+                label: 'Max / person',
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: KpiCell(
+                value: stats.workload.medianEventsPerPerson.toStringAsFixed(1),
+                label: 'Median / person',
+              ),
+            ),
+          ],
+        ),
+        const MonoLabel('Fairness'),
+        BlockCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Stdev', style: BlockType.monoLabel),
+              Text(
+                stats.fairness.stdev.toStringAsFixed(2),
+                style: BlockType.subhead.copyWith(fontSize: 22),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Lower stdev means assignments are more evenly distributed across people.',
+                style: BlockType.bodySm,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ConflictsView extends StatelessWidget {
+  const _ConflictsView({required this.data});
+  final SolutionDetailData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final hard = data.solution.hardViolations;
+    if (hard == 0) {
+      return BlockCard(
+        padding: const EdgeInsets.all(28),
+        child: Column(
+          children: [
+            const Icon(Icons.check_circle_outline, color: BlockColors.success, size: 28),
+            const SizedBox(height: 8),
+            Text('NO HARD CONFLICTS', style: BlockType.monoLabel.copyWith(color: BlockColors.success)),
+            const SizedBox(height: 4),
+            Text(
+              'Soft violations (if any) appear under STATS.',
+              style: BlockType.bodySm,
+            ),
+          ],
+        ),
+      );
+    }
+    return BlockCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          StatusText(kind: StatusKind.declined, label: '$hard hard violations'),
+          const SizedBox(height: 6),
+          Text(
+            'A breakdown of which constraint each violation traces to '
+            'comes alongside the Assignments view in 7.10.',
+            style: BlockType.bodySm,
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/mobile/lib/features/admin/solver_provider.dart
+++ b/mobile/lib/features/admin/solver_provider.dart
@@ -1,0 +1,98 @@
+// Solver mutation + last-solve memoization — Sprint 7.9.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/features/admin/dashboard_provider.dart';
+
+class SolverState {
+  const SolverState({
+    this.busy = false,
+    this.lastSolutionId,
+    this.lastError,
+  });
+  final bool busy;
+  final int? lastSolutionId;
+  final String? lastError;
+
+  SolverState copyWith({
+    bool? busy,
+    int? lastSolutionId,
+    String? lastError,
+  }) =>
+      SolverState(
+        busy: busy ?? this.busy,
+        lastSolutionId: lastSolutionId ?? this.lastSolutionId,
+        lastError: lastError ?? this.lastError,
+      );
+}
+
+class SolverController extends Notifier<SolverState> {
+  @override
+  SolverState build() => const SolverState();
+
+  Future<int?> run({
+    required DateTime fromDate,
+    required DateTime toDate,
+    required bool changeMin,
+    required String mode,
+  }) async {
+    final orgId = ref.read(authProvider).orgId;
+    if (orgId == null) {
+      state = state.copyWith(lastError: 'Not signed in');
+      return null;
+    }
+    state = const SolverState(busy: true);
+    try {
+      final body = (api.SolveRequestBuilder()
+            ..orgId = orgId
+            ..fromDate = api.Date(fromDate.year, fromDate.month, fromDate.day)
+            ..toDate = api.Date(toDate.year, toDate.month, toDate.day)
+            ..mode = mode
+            ..changeMin = changeMin)
+          .build();
+      final res = await ref
+          .read(signupflowApiProvider)
+          .getSolverApi()
+          .solveSchedule(solveRequest: body);
+      final solutionId = res.data?.solutionId;
+      ref.invalidate(dashboardProvider);
+      state = SolverState(busy: false, lastSolutionId: solutionId);
+      return solutionId;
+    } on Exception catch (e) {
+      state = SolverState(busy: false, lastError: e.toString());
+      return null;
+    }
+  }
+}
+
+final solverControllerProvider =
+    NotifierProvider<SolverController, SolverState>(SolverController.new);
+
+class SolutionDetailData {
+  const SolutionDetailData({
+    required this.solution,
+    required this.stats,
+  });
+  final api.SolutionResponse solution;
+  final api.SolutionStatsResponse? stats;
+}
+
+final solutionDetailProvider =
+    FutureProvider.family<SolutionDetailData, int>((ref, id) async {
+  final apiClient = ref.watch(signupflowApiProvider);
+  final futures = await Future.wait([
+    apiClient.getSolutionsApi().getSolution(solutionId: id),
+    apiClient.getSolutionsApi().getSolutionStats(solutionId: id).then(
+          (r) => r,
+          onError: (Object _) => null,
+        ),
+  ]);
+  final sol = (futures[0] as dynamic).data as api.SolutionResponse?;
+  if (sol == null) {
+    throw StateError('Empty /solutions/$id response');
+  }
+  final stats = (futures[1] as dynamic)?.data as api.SolutionStatsResponse?;
+  return SolutionDetailData(solution: sol, stats: stats);
+});

--- a/mobile/lib/features/admin/solver_screen.dart
+++ b/mobile/lib/features/admin/solver_screen.dart
@@ -1,14 +1,251 @@
+// Admin Solver — Sprint 7.9.
+// Visual target: mobile/prototype/screenshots/v2/11-a-solver.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/admin/solver_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class SolverScreen extends StatelessWidget {
+class SolverScreen extends ConsumerStatefulWidget {
   const SolverScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Run Solver',
-        endpoint: 'POST /solver/solve',
-        willLandIn: 'PR 7.9',
-      );
+  ConsumerState<SolverScreen> createState() => _SolverScreenState();
+}
+
+class _SolverScreenState extends ConsumerState<SolverScreen> {
+  late DateTime _from;
+  late DateTime _to;
+  bool _changeMin = true;
+  String _mode = 'strict';
+
+  @override
+  void initState() {
+    super.initState();
+    final today = DateTime.now();
+    _from = today;
+    _to = today.add(const Duration(days: 28));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(solverControllerProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 96),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const PageTitle('Run Solver'),
+              const MonoLabel('Date range'),
+              Row(
+                children: [
+                  Expanded(child: _DateField(label: 'From', value: _from, onTap: () => _pick(true))),
+                  const SizedBox(width: 8),
+                  Expanded(child: _DateField(label: 'To', value: _to, onTap: () => _pick(false))),
+                ],
+              ),
+              const MonoLabel('Mode'),
+              _ModeSegment(
+                value: _mode,
+                onChanged: (v) => setState(() => _mode = v),
+              ),
+              const MonoLabel('Options'),
+              _OptionRow(
+                title: 'Minimize moves from published',
+                subtitle: 'Bias the solver toward keeping current published assignments.',
+                value: _changeMin,
+                onChanged: (v) => setState(() => _changeMin = v),
+              ),
+              const SizedBox(height: 16),
+              BlockButton(
+                label: state.busy ? 'Solving…' : 'Run solver →',
+                kind: BlockButtonKind.go,
+                onPressed: state.busy
+                    ? null
+                    : () async {
+                        final id = await ref.read(solverControllerProvider.notifier).run(
+                              fromDate: _from,
+                              toDate: _to,
+                              changeMin: _changeMin,
+                              mode: _mode,
+                            );
+                        if (!context.mounted) return;
+                        if (id != null) {
+                          GoRouter.of(context).go('/a/solution/$id');
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Solve failed: ${state.lastError ?? "unknown"}')),
+                          );
+                        }
+                      },
+              ),
+              if (state.lastSolutionId != null) ...[
+                const MonoLabel('Last solve'),
+                BlockCard(
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Solution #${state.lastSolutionId}', style: BlockType.subhead),
+                            const SizedBox(height: 4),
+                            const StatusText(kind: StatusKind.pending, label: 'DRAFT'),
+                          ],
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () => GoRouter.of(context).go('/a/solution/${state.lastSolutionId}'),
+                        child: Text(
+                          'REVIEW →',
+                          style: BlockType.monoLabel.copyWith(
+                            color: BlockColors.accent,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pick(bool isFrom) async {
+    final init = isFrom ? _from : _to;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: init,
+      firstDate: DateTime(init.year, init.month - 1),
+      lastDate: DateTime(init.year + 2),
+    );
+    if (picked == null) return;
+    setState(() {
+      if (isFrom) {
+        _from = picked;
+        if (_to.isBefore(_from)) _to = _from.add(const Duration(days: 28));
+      } else {
+        _to = picked;
+      }
+    });
+  }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({required this.label, required this.value, required this.onTap});
+  final String label;
+  final DateTime value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: BlockCard(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label.toUpperCase(), style: BlockType.monoLabel.copyWith(fontSize: 10)),
+            const SizedBox(height: 2),
+            Text(DateFormat('d MMM y').format(value), style: BlockType.body),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ModeSegment extends StatelessWidget {
+  const _ModeSegment({required this.value, required this.onChanged});
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: BlockColors.line2,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Expanded(child: _seg('STRICT', 'strict')),
+          Expanded(child: _seg('RELAXED', 'relaxed')),
+        ],
+      ),
+    );
+  }
+
+  Widget _seg(String label, String key) {
+    final active = value == key;
+    return GestureDetector(
+      onTap: () => onChanged(key),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 7),
+        decoration: BoxDecoration(
+          color: active ? Colors.white : Colors.transparent,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: BlockType.monoLabel.copyWith(
+            fontSize: 11,
+            color: active ? BlockColors.ink1 : BlockColors.ink2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OptionRow extends StatelessWidget {
+  const _OptionRow({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: BlockType.body),
+                const SizedBox(height: 2),
+                Text(subtitle, style: BlockType.bodySm),
+              ],
+            ),
+          ),
+          Switch.adaptive(
+            value: value,
+            onChanged: onChanged,
+            activeThumbColor: BlockColors.accent,
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/mobile/test/solver_screen_test.dart
+++ b/mobile/test/solver_screen_test.dart
@@ -1,0 +1,137 @@
+// Solver + Solution Review widget tests.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/solution_review_screen.dart';
+import 'package:signupflow_mobile/features/admin/solver_provider.dart';
+import 'package:signupflow_mobile/features/admin/solver_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+void main() {
+  testWidgets('solver screen renders date range + mode + run button',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const SolverScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('RUN SOLVER'), findsOneWidget);
+    expect(find.text('DATE RANGE'), findsOneWidget);
+    expect(find.text('STRICT'), findsAtLeastNWidgets(1));
+    expect(find.text('Minimize moves from published'), findsOneWidget);
+    expect(find.text('RUN SOLVER →'), findsOneWidget);
+  });
+
+  testWidgets('solution review renders segmented control + assignments default',
+      (tester) async {
+    final solution = (api.SolutionResponseBuilder()
+          ..id = 142
+          ..orgId = 'hcc'
+          ..solveMs = 274
+          ..hardViolations = 0
+          ..softScore = 1.5
+          ..healthScore = 98
+          ..isPublished = false
+          ..assignmentCount = 24
+          ..createdAt = DateTime(2026, 5, 7, 14, 14).toUtc()
+          ..metrics = MapBuilder<String, JsonObject?>())
+        .build();
+    final stats = (api.SolutionStatsResponseBuilder()
+          ..solutionId = 142
+          ..fairness = (api.FairnessStatsBuilder()
+            ..stdev = 0.42
+            ..perPersonCounts = MapBuilder<String, int>({'p1': 1, 'p2': 2})
+            ..histogram = MapBuilder<String, int>({'1': 1, '2': 1}))
+          ..stability = (api.StabilityMetricsBuilder()
+            ..movesFromPublished = 4
+            ..affectedPersons = 2)
+          ..workload = (api.WorkloadStatsBuilder()
+            ..maxEventsPerPerson = 3
+            ..minEventsPerPerson = 1
+            ..medianEventsPerPerson = 2.0
+            ..totalEventsAssigned = 8
+            ..distinctPersonsAssigned = 4))
+        .build();
+    final data = SolutionDetailData(solution: solution, stats: stats);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          solutionDetailProvider(142).overrideWith((ref) async => data),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const SolutionReviewScreen(solutionId: '142'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('SOLUTION #142'), findsOneWidget);
+    expect(find.text('ASSIGNMENTS'), findsOneWidget);
+    expect(find.text('STATS'), findsOneWidget);
+    expect(find.text('CONFLICTS'), findsOneWidget);
+    expect(find.text('Solution #142'), findsOneWidget);
+    expect(find.text('PUBLISH'), findsOneWidget);
+    expect(find.text('COMPARE WITH ANOTHER SOLUTION'), findsOneWidget);
+  });
+
+  testWidgets('solution review STATS segment shows stability KPIs', (tester) async {
+    final solution = (api.SolutionResponseBuilder()
+          ..id = 142
+          ..orgId = 'hcc'
+          ..solveMs = 274
+          ..hardViolations = 0
+          ..softScore = 1.5
+          ..healthScore = 98
+          ..isPublished = false
+          ..assignmentCount = 24
+          ..createdAt = DateTime(2026, 5, 7, 14, 14).toUtc()
+          ..metrics = MapBuilder<String, JsonObject?>())
+        .build();
+    final stats = (api.SolutionStatsResponseBuilder()
+          ..solutionId = 142
+          ..fairness = (api.FairnessStatsBuilder()
+            ..stdev = 0.42
+            ..perPersonCounts = MapBuilder<String, int>()
+            ..histogram = MapBuilder<String, int>())
+          ..stability = (api.StabilityMetricsBuilder()
+            ..movesFromPublished = 4
+            ..affectedPersons = 2)
+          ..workload = (api.WorkloadStatsBuilder()
+            ..maxEventsPerPerson = 3
+            ..minEventsPerPerson = 1
+            ..medianEventsPerPerson = 2.0
+            ..totalEventsAssigned = 8
+            ..distinctPersonsAssigned = 4))
+        .build();
+    final data = SolutionDetailData(solution: solution, stats: stats);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          solutionDetailProvider(142).overrideWith((ref) async => data),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const SolutionReviewScreen(solutionId: '142'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap STATS segment
+    await tester.tap(find.text('STATS'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('4'), findsOneWidget);     // movesFromPublished KPI
+    expect(find.text('3'), findsOneWidget);     // max/person KPI
+    expect(find.text('0.42'), findsOneWidget);  // stdev
+  });
+}


### PR DESCRIPTION
## Summary

Real Solver tab + Solution Review pushed screen. Replaces both stubs with API-wired implementations matching `mobile/prototype/screenshots/v2/{11-a-solver,12-a-solution}.png`.

## Solver

- From / To date pickers (defaults: today → today+28d).
- Mode segmented control (STRICT / RELAXED).
- "Minimize moves from published" `Switch.adaptive` → `change_min` flag.
- **RUN SOLVER →** calls `SolverApi.solveSchedule` via `solverControllerProvider`. Busy state blocks the button. On success → `/a/solution/{id}`; on failure → snackbar with the error.
- "Last solve" card appears once a solve has run, with REVIEW → link.
- `ref.invalidate(dashboardProvider)` on success so the dashboard reflects the new solution.

## Solution Review

- `solutionDetailProvider.family(int)` parallel-fetches `getSolution` + `getSolutionStats`. Stats nullable — silently degrades if the endpoint errors.
- **Segmented control**: ASSIGNMENTS (default) / STATS / CONFLICTS.
- Header: `‹ SOLVER` back button + `SOLUTION #N` title + `PUBLISH` action.
- **ASSIGNMENTS view**: hero card with id, created_at, hard/soft badges, health KPI. Per-event breakdown deferred to 7.10 with an explicit "coming soon" callout (`getSolutionAssignments` returns `JsonObject`; rendering needs an enriched join, lands alongside Compare).
- **STATS view**: stability KPIs (moves_from_published, affected_persons), workload KPIs (max/median per person), fairness stdev card.
- **CONFLICTS view**: 0 hard → success illustration; >0 → counter + breakdown-coming-soon note.
- Bottom: COMPARE WITH ANOTHER SOLUTION → `/a/compare`.

## Tests (21 / 21 passing)

- `solver_screen_test.dart` (new):
  - Solver renders date range + mode + RUN SOLVER button
  - Solution review renders segmented control + assignments default
  - Solution review STATS segment shows stability KPIs (4 / 3 / 0.42)

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **21 passed**
- Backend Python tests untouched

## Follow-ups

- **7.10** — Compare diff + Publish/Rollback flows + per-event assignment list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)