### PR TITLE
Sprint 7 PR 7.10: Compare diff + Publish/Unpublish/Rollback

### DIFF
--- a/mobile/lib/features/admin/compare_provider.dart
+++ b/mobile/lib/features/admin/compare_provider.dart
@@ -1,0 +1,33 @@
+// Compare diff provider — Sprint 7.10.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+
+@immutable
+class CompareIds {
+  const CompareIds({required this.a, required this.b});
+  final int a;
+  final int b;
+
+  @override
+  bool operator ==(Object other) =>
+      other is CompareIds && other.a == a && other.b == b;
+  @override
+  int get hashCode => Object.hash(a, b);
+}
+
+final compareDiffProvider =
+    FutureProvider.family<api.SolutionDiffResponse, CompareIds>((ref, ids) async {
+  final apiClient = ref.watch(signupflowApiProvider);
+  final res = await apiClient.getSolutionsApi().compareSolutions(
+        solutionAId: ids.a,
+        solutionBId: ids.b,
+      );
+  final body = res.data;
+  if (body == null) {
+    throw StateError('Empty compare response for ${ids.a} vs ${ids.b}');
+  }
+  return body;
+});

--- a/mobile/lib/features/admin/compare_screen.dart
+++ b/mobile/lib/features/admin/compare_screen.dart
@@ -1,14 +1,281 @@
+// Admin Compare — Sprint 7.10.
+// Visual target: mobile/prototype/screenshots/v2/13-a-compare.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/compare_provider.dart';
+import 'package:signupflow_mobile/features/admin/publish_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class CompareScreen extends StatelessWidget {
+class CompareScreen extends ConsumerStatefulWidget {
   const CompareScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Compare',
-        endpoint: 'GET /solutions/{a}/compare/{b}',
-        willLandIn: 'PR 7.10',
-      );
+  ConsumerState<CompareScreen> createState() => _CompareScreenState();
+}
+
+class _CompareScreenState extends ConsumerState<CompareScreen> {
+  int? _aId;
+  int? _bId;
+
+  @override
+  Widget build(BuildContext context) {
+    final recent = ref.watch(recentSolutionsProvider);
+    final canCompare = _aId != null && _bId != null && _aId != _bId;
+    final diffAsync = canCompare
+        ? ref.watch(compareDiffProvider(CompareIds(a: _aId!, b: _bId!)))
+        : null;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: () => GoRouter.of(context).pop(),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      '‹ BACK',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    'COMPARE',
+                    style: BlockType.monoLabel.copyWith(
+                      color: BlockColors.ink1,
+                      fontSize: 13,
+                    ),
+                  ),
+                  const SizedBox(width: 60),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    recent.when(
+                      loading: () => const Padding(
+                        padding: EdgeInsets.all(24),
+                        child: Center(child: CircularProgressIndicator()),
+                      ),
+                      error: (e, _) => Text('Failed to load solutions: $e', style: BlockType.bodySm),
+                      data: (solutions) {
+                        if (solutions.length < 2) {
+                          return BlockCard(
+                            child: Text(
+                              'You need at least 2 solutions to compare.',
+                              style: BlockType.bodySm,
+                            ),
+                          );
+                        }
+                        return Row(
+                          children: [
+                            Expanded(
+                              child: _SolutionDropdown(
+                                label: 'Solution A',
+                                solutions: solutions,
+                                value: _aId,
+                                onChanged: (v) => setState(() => _aId = v),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: _SolutionDropdown(
+                                label: 'Solution B',
+                                solutions: solutions,
+                                value: _bId,
+                                onChanged: (v) => setState(() => _bId = v),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                    if (diffAsync != null) ...[
+                      const MonoLabel('Diff summary'),
+                      diffAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.all(24),
+                          child: Center(child: CircularProgressIndicator()),
+                        ),
+                        error: (e, _) => BlockCard(
+                          child: Text('Failed: $e', style: BlockType.bodySm),
+                        ),
+                        data: _DiffView.new,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SolutionDropdown extends StatelessWidget {
+  const _SolutionDropdown({
+    required this.label,
+    required this.solutions,
+    required this.value,
+    required this.onChanged,
+  });
+  final String label;
+  final List<api.SolutionResponse> solutions;
+  final int? value;
+  final ValueChanged<int?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label.toUpperCase(), style: BlockType.monoLabel.copyWith(fontSize: 10)),
+          const SizedBox(height: 2),
+          DropdownButtonHideUnderline(
+            child: DropdownButton<int>(
+              value: value,
+              hint: Text('Pick…', style: BlockType.body.copyWith(color: BlockColors.ink3)),
+              isExpanded: true,
+              items: [
+                for (final s in solutions)
+                  DropdownMenuItem(
+                    value: s.id,
+                    child: Text(
+                      '#${s.id} · ${(s.isPublished ?? false) ? "live" : "draft"}',
+                      style: BlockType.body,
+                    ),
+                  ),
+              ],
+              onChanged: onChanged,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiffView extends StatelessWidget {
+  const _DiffView(this.diff);
+  final api.SolutionDiffResponse diff;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        BlockCard(
+          child: Row(
+            children: [
+              _DiffStat(label: 'ADDED', value: '+${diff.added.length}', color: BlockColors.success),
+              _DiffStat(label: 'REMOVED', value: '−${diff.removed.length}', color: BlockColors.danger),
+              _DiffStat(label: 'UNCHANGED', value: '${diff.unchangedCount}', color: BlockColors.ink1),
+              _DiffStat(label: 'AFFECTED', value: '${diff.affectedPersons.length}', color: BlockColors.accent),
+            ],
+          ),
+        ),
+        if (diff.removed.isNotEmpty) ...[
+          MonoLabel('Removed · ${diff.removed.length}'),
+          for (final c in diff.removed) _ChangeRow(change: c, sign: '−', color: BlockColors.danger),
+        ],
+        if (diff.added.isNotEmpty) ...[
+          MonoLabel('Added · ${diff.added.length}'),
+          for (final c in diff.added) _ChangeRow(change: c, sign: '+', color: BlockColors.success),
+        ],
+        if (diff.added.isEmpty && diff.removed.isEmpty)
+          BlockCard(
+            child: Text(
+              'These two solutions are identical.',
+              style: BlockType.bodySm,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _DiffStat extends StatelessWidget {
+  const _DiffStat({required this.label, required this.value, required this.color});
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: BlockType.monoLabel.copyWith(fontSize: 9)),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: BlockType.subhead.copyWith(fontSize: 20, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChangeRow extends StatelessWidget {
+  const _ChangeRow({required this.change, required this.sign, required this.color});
+  final api.AssignmentChange change;
+  final String sign;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: BlockCard(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 16,
+              child: Text(
+                sign,
+                style: BlockType.subhead.copyWith(color: color, fontSize: 18),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(change.personId, style: BlockType.body.copyWith(fontSize: 14)),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${(change.role ?? "—").toUpperCase()} · EVENT ${change.eventId.toUpperCase()}',
+                    style: BlockType.monoTiny.copyWith(fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/lib/features/admin/publish_provider.dart
+++ b/mobile/lib/features/admin/publish_provider.dart
@@ -1,0 +1,63 @@
+// Publish / unpublish / rollback flow — Sprint 7.10.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/features/admin/dashboard_provider.dart';
+import 'package:signupflow_mobile/features/admin/solver_provider.dart';
+
+class PublishMutationsController extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  Future<String?> publish(int solutionId) async => _wrap(() async {
+        await ref
+            .read(signupflowApiProvider)
+            .getSolutionsApi()
+            .publishSolution(solutionId: solutionId);
+      }, solutionId);
+
+  Future<String?> unpublish(int solutionId) async => _wrap(() async {
+        await ref
+            .read(signupflowApiProvider)
+            .getSolutionsApi()
+            .unpublishSolution(solutionId: solutionId);
+      }, solutionId);
+
+  Future<String?> rollback(int solutionId) async => _wrap(() async {
+        await ref
+            .read(signupflowApiProvider)
+            .getSolutionsApi()
+            .rollbackSolution(solutionId: solutionId);
+      }, solutionId);
+
+  Future<String?> _wrap(Future<void> Function() body, int solutionId) async {
+    state = true;
+    try {
+      await body();
+      ref
+        ..invalidate(dashboardProvider)
+        ..invalidate(solutionDetailProvider(solutionId));
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+}
+
+final publishMutationsProvider =
+    NotifierProvider<PublishMutationsController, bool>(
+  PublishMutationsController.new,
+);
+
+/// Light-weight provider for the most-recent few solutions (used by both
+/// the publish picker and the rollback history list). Reuses the same
+/// listSolutions call the dashboard does, but here scoped to the publish
+/// screen so refresh is local.
+final recentSolutionsProvider =
+    FutureProvider<List<api.SolutionResponse>>((ref) async {
+  final dashboard = await ref.watch(dashboardProvider.future);
+  return dashboard.recentSolutions;
+});

--- a/mobile/lib/features/admin/publish_screen.dart
+++ b/mobile/lib/features/admin/publish_screen.dart
@@ -1,14 +1,283 @@
+// Admin Publish + Rollback — Sprint 7.10.
+// Visual target: mobile/prototype/screenshots/v2/14-a-publish.png.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/publish_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class PublishScreen extends StatelessWidget {
+class PublishScreen extends ConsumerWidget {
   const PublishScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Publish',
-        endpoint: 'POST /solutions/{id}/{publish,unpublish,rollback}',
-        willLandIn: 'PR 7.10',
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncRecent = ref.watch(recentSolutionsProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: () => GoRouter.of(context).pop(),
+                    style: TextButton.styleFrom(foregroundColor: BlockColors.accent),
+                    child: Text(
+                      '‹ BACK',
+                      style: BlockType.monoLabel.copyWith(
+                        color: BlockColors.accent,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    'PUBLISH',
+                    style: BlockType.monoLabel.copyWith(
+                      color: BlockColors.ink1,
+                      fontSize: 13,
+                    ),
+                  ),
+                  const SizedBox(width: 60),
+                ],
+              ),
+            ),
+            Expanded(
+              child: asyncRecent.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text('Failed: $e', style: BlockType.bodySm),
+                  ),
+                ),
+                data: (solutions) => _Body(solutions: solutions),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.solutions});
+  final List<api.SolutionResponse> solutions;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    api.SolutionResponse? published;
+    for (final s in solutions) {
+      if (s.isPublished ?? false) {
+        published = s;
+        break;
+      }
+    }
+    final pending = solutions.where((s) => !(s.isPublished ?? false)).toList();
+    final everPublished = solutions
+        .where((s) => s.publishedAt != null && !(s.isPublished ?? false))
+        .take(5)
+        .toList();
+    final busy = ref.watch(publishMutationsProvider);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const MonoLabel('Currently published'),
+          if (published != null)
+            _PublishedCard(published: published, busy: busy)
+          else
+            BlockCard(
+              child: Text(
+                'No solution is published yet.',
+                style: BlockType.bodySm,
+              ),
+            ),
+          const MonoLabel('Publish a draft'),
+          if (pending.isEmpty)
+            BlockCard(
+              child: Text(
+                'No draft solutions to publish.',
+                style: BlockType.bodySm,
+              ),
+            )
+          else
+            for (final s in pending) _PublishRow(solution: s),
+          const MonoLabel('Rollback history'),
+          if (everPublished.isEmpty)
+            BlockCard(
+              child: Text(
+                'No prior published solutions yet.',
+                style: BlockType.bodySm,
+              ),
+            )
+          else
+            for (final s in everPublished) _RollbackRow(solution: s),
+        ],
+      ),
+    );
+  }
+}
+
+class _PublishedCard extends ConsumerWidget {
+  const _PublishedCard({required this.published, required this.busy});
+  final api.SolutionResponse published;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlockCard(
+      color: BlockColors.accentSoft,
+      borderColor: BlockColors.accent,
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Solution #${published.id}', style: BlockType.subhead),
+                const SizedBox(height: 4),
+                const StatusText(kind: StatusKind.confirmed, label: 'LIVE'),
+                const SizedBox(height: 2),
+                Text(
+                  'HEALTH ${published.healthScore.toInt()} · ${published.assignmentCount ?? 0} ASSIGNMENTS',
+                  style: BlockType.monoTiny.copyWith(fontSize: 10),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 132,
+            child: BlockButton(
+              label: busy ? 'Working…' : 'Unpublish',
+              kind: BlockButtonKind.destructive,
+              onPressed: busy
+                  ? null
+                  : () async {
+                      final err = await ref
+                          .read(publishMutationsProvider.notifier)
+                          .unpublish(published.id);
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(err ?? 'Unpublished')),
+                      );
+                    },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PublishRow extends ConsumerWidget {
+  const _PublishRow({required this.solution});
+  final api.SolutionResponse solution;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final busy = ref.watch(publishMutationsProvider);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Solution #${solution.id}', style: BlockType.subhead),
+                  const SizedBox(height: 2),
+                  Text(
+                    'DRAFT · HEALTH ${solution.healthScore.toInt()}',
+                    style: BlockType.monoTiny.copyWith(fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              width: 110,
+              child: BlockButton(
+                label: busy ? '…' : 'Publish',
+                kind: BlockButtonKind.go,
+                onPressed: busy
+                    ? null
+                    : () async {
+                        final err = await ref
+                            .read(publishMutationsProvider.notifier)
+                            .publish(solution.id);
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(err ?? 'Published')),
+                        );
+                      },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RollbackRow extends ConsumerWidget {
+  const _RollbackRow({required this.solution});
+  final api.SolutionResponse solution;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final busy = ref.watch(publishMutationsProvider);
+    final when = solution.publishedAt != null
+        ? DateFormat('d MMM y').format(solution.publishedAt!.toLocal())
+        : '—';
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Solution #${solution.id}', style: BlockType.subhead),
+                  const SizedBox(height: 2),
+                  Text(
+                    'PUBLISHED $when · HEALTH ${solution.healthScore.toInt()}',
+                    style: BlockType.monoTiny.copyWith(fontSize: 10),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              width: 120,
+              child: BlockButton(
+                label: busy ? '…' : 'Rollback',
+                kind: BlockButtonKind.secondary,
+                onPressed: busy
+                    ? null
+                    : () async {
+                        final err = await ref
+                            .read(publishMutationsProvider.notifier)
+                            .rollback(solution.id);
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(err ?? 'Rolled back')),
+                        );
+                      },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/test/compare_publish_test.dart
+++ b/mobile/test/compare_publish_test.dart
@@ -1,0 +1,117 @@
+// Compare + Publish widget tests.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/compare_screen.dart';
+import 'package:signupflow_mobile/features/admin/publish_provider.dart';
+import 'package:signupflow_mobile/features/admin/publish_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.SolutionResponse _solution({
+  required int id,
+  required bool isPublished,
+  DateTime? publishedAt,
+  int health = 96,
+}) =>
+    (api.SolutionResponseBuilder()
+          ..id = id
+          ..orgId = 'hcc'
+          ..solveMs = 274
+          ..hardViolations = 0
+          ..softScore = 1
+          ..healthScore = health
+          ..isPublished = isPublished
+          ..publishedAt = publishedAt
+          ..assignmentCount = 24
+          ..createdAt = DateTime(2026, 5, 1).toUtc()
+          ..metrics = MapBuilder<String, JsonObject?>())
+        .build();
+
+void main() {
+  testWidgets('compare screen shows pickers when 2+ solutions exist',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recentSolutionsProvider.overrideWith((ref) async => [
+                _solution(id: 142, isPublished: false),
+                _solution(id: 141, isPublished: true, publishedAt: DateTime(2026, 5, 4)),
+              ]),
+        ],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const CompareScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('COMPARE'), findsOneWidget);
+    expect(find.text('SOLUTION A'), findsOneWidget);
+    expect(find.text('SOLUTION B'), findsOneWidget);
+  });
+
+  testWidgets('compare requires 2+ solutions, falls back gracefully',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recentSolutionsProvider.overrideWith(
+            (ref) async => [_solution(id: 1, isPublished: false)],
+          ),
+        ],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const CompareScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('You need at least 2 solutions'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('publish screen renders currently-published + drafts',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recentSolutionsProvider.overrideWith((ref) async => [
+                _solution(id: 142, isPublished: false, health: 98),
+                _solution(
+                  id: 141,
+                  isPublished: true,
+                  publishedAt: DateTime(2026, 5, 4),
+                  health: 96,
+                ),
+              ]),
+        ],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const PublishScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('PUBLISH'), findsAtLeastNWidgets(1));
+    expect(find.text('CURRENTLY PUBLISHED'), findsOneWidget);
+    expect(find.text('Solution #141'), findsOneWidget);
+    expect(find.text('Solution #142'), findsOneWidget);
+    expect(find.text('UNPUBLISH'), findsOneWidget);
+  });
+
+  testWidgets('publish screen handles no published solution', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recentSolutionsProvider.overrideWith(
+            (ref) async => [_solution(id: 1, isPublished: false)],
+          ),
+        ],
+        child: MaterialApp(theme: buildBlockMonoTheme(), home: const PublishScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No solution is published'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Real Compare + Publish flows, closing the admin journey end-to-end. Replaces the last two StubScreens with API-wired implementations matching `mobile/prototype/screenshots/v2/{13-a-compare,14-a-publish}.png`.

## Compare

- `compareDiffProvider.family(CompareIds)` wraps `SolutionsApi.compareSolutions` (the Sprint 5 PR 5.5 endpoint).
- Two `DropdownButton`s (Solution A / Solution B) sourced from `recentSolutionsProvider`. Once both are picked, the diff card fetches and renders.
- **Diff summary**: ADDED / REMOVED / UNCHANGED / AFFECTED PERSONS as a 4-column KPI strip.
- **REMOVED** + **ADDED** groups as colored cards with `personId` + role + event metadata.
- Identical-solutions case shows a friendly empty state.

## Publish / Unpublish / Rollback

- `publishMutationsProvider` exposes `publish` / `unpublish` / `rollback` methods. Each invalidates `dashboardProvider` + `solutionDetailProvider` on success so cards refresh everywhere.
- `recentSolutionsProvider` derives from `dashboardProvider` — same data, no extra HTTP call.
- Sections: **CURRENTLY PUBLISHED** (teal-soft card with Unpublish button), **PUBLISH A DRAFT** (rows with Publish button), **ROLLBACK HISTORY** (prior published solutions with Rollback button).
- Empty fallbacks for each section.

## Tests (25 / 25 passing)

- `compare_publish_test.dart` (new):
  - Compare shows pickers when 2+ solutions exist
  - Compare requires 2+ solutions, falls back gracefully
  - Publish renders currently-published + drafts
  - Publish handles no published solution

## Sprint 7 status

This PR closes the admin journey. Sprint 7 is **functionally complete** end-to-end against the real backend:

- ✅ 7.0 Spec + prototype
- ✅ 7.1 Skeleton + theme + role-aware nav
- ✅ 7.2 Auth flow (login, JWT in Keychain)
- ✅ 7.2b OpenAPI codegen → real `signupflow_api` package
- ✅ 7.3 Volunteer Schedule
- ✅ 7.4 Assignment Detail (Accept/Decline/Swap)
- ✅ 7.5 Availability (TimeOff)
- ✅ 7.6 Profile + ICS export
- ✅ 7.7 Admin Dashboard
- ✅ 7.8 Admin People + Events
- ✅ 7.9 Solver flow + Solution Review
- ✅ 7.10 **Compare + Publish + Rollback** ← this PR
- ⬜ 7.11 TestFlight build

## Validation

- `flutter analyze` — **0 issues**
- `flutter test` — **25 passed**
- Backend Python tests untouched

## Follow-ups

- **7.11** — TestFlight build, smoke test on real iPhone, fix any platform-specific bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)