### PR TITLE
Mobile create-org signup flow (Sprint 8 PR 8.6)

### DIFF
--- a/mobile/lib/auth/auth_provider.dart
+++ b/mobile/lib/auth/auth_provider.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:signupflow_mobile/auth/login_repository.dart';
 import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+import 'package:signupflow_mobile/auth/signup_repository.dart';
 
 enum AuthRole { unauth, volunteer, admin }
 
@@ -57,6 +58,33 @@ class AuthController extends Notifier<AuthState> {
       state = next;
       return null;
     } on LoginFailure catch (e) {
+      return e.message;
+    } on Exception catch (e) {
+      return 'Unexpected error: $e';
+    }
+  }
+
+  /// Create-org admin signup: chains POST /organizations + POST /auth/signup,
+  /// stores the JWT, and applies the auth state. Returns null on success;
+  /// returns a user-facing message on failure.
+  Future<String?> createOrgAndSignUp({
+    required String orgId,
+    required String orgName,
+    required String adminName,
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final next = await ref.read(signupRepositoryProvider).createOrgAndSignUp(
+            orgId: orgId,
+            orgName: orgName,
+            adminName: adminName,
+            email: email.trim(),
+            password: password,
+          );
+      state = next;
+      return null;
+    } on SignupFailure catch (e) {
       return e.message;
     } on Exception catch (e) {
       return 'Unexpected error: $e';

--- a/mobile/lib/auth/login_repository.dart
+++ b/mobile/lib/auth/login_repository.dart
@@ -46,7 +46,11 @@ class LoginRepository {
 
   Future<void> signOut() => _storage.clearToken();
 
-  static AuthRole _resolveRole(List<String> roles) {
+  static AuthRole _resolveRole(List<String> roles) => resolveRole(roles);
+
+  /// Public helper so signup / invitation / reset flows map server roles
+  /// to [AuthRole] the same way login does.
+  static AuthRole resolveRole(List<String> roles) {
     final lower = roles.map((r) => r.toLowerCase()).toSet();
     if (lower.contains('admin')) return AuthRole.admin;
     if (lower.contains('volunteer')) return AuthRole.volunteer;

--- a/mobile/lib/auth/signup_repository.dart
+++ b/mobile/lib/auth/signup_repository.dart
@@ -1,0 +1,91 @@
+// SignupRepository — chains POST /organizations + POST /auth/signup. The
+// first user in a new org is automatically admin (see api/routers/auth.py).
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/login_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+class SignupRepository {
+  SignupRepository(this._client, this._storage);
+  final api.SignupflowApi _client;
+  final SecureTokenStorage _storage;
+
+  /// Create a fresh organization, then sign up the admin account inside it.
+  /// Returns the resulting auth state on success; throws [SignupFailure].
+  Future<AuthState> createOrgAndSignUp({
+    required String orgId,
+    required String orgName,
+    required String adminName,
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final orgReq = (api.OrganizationCreateBuilder()
+            ..id = orgId
+            ..name = orgName)
+          .build();
+      await _client.getOrganizationsApi().createOrganization(
+            organizationCreate: orgReq,
+          );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 409) {
+        throw const SignupFailure('That organization ID is already taken.');
+      }
+      if (code == 422) {
+        throw const SignupFailure('Organization details are invalid.');
+      }
+      throw SignupFailure('Network error: ${e.message ?? code}');
+    }
+
+    try {
+      final signupReq = (api.SignupRequestBuilder()
+            ..orgId = orgId
+            ..name = adminName
+            ..email = email
+            ..password = password)
+          .build();
+      final res = await _client.getAuthApi().signup(signupRequest: signupReq);
+      final body = res.data;
+      if (body == null || body.token.isEmpty) {
+        throw const SignupFailure('Server returned an empty token.');
+      }
+      await _storage.writeToken(body.token);
+      return AuthState(
+        role: LoginRepository.resolveRole(body.roles.toList()),
+        token: body.token,
+        personId: body.personId,
+        email: body.email,
+        orgId: body.orgId,
+        name: body.name,
+      );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 409) {
+        throw const SignupFailure('An account with that email already exists.');
+      }
+      if (code == 422) {
+        throw const SignupFailure('Email or password did not pass validation.');
+      }
+      throw SignupFailure('Network error: ${e.message ?? code}');
+    }
+  }
+}
+
+class SignupFailure implements Exception {
+  const SignupFailure(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+final signupRepositoryProvider = Provider<SignupRepository>((ref) {
+  return SignupRepository(
+    ref.watch(signupflowApiProvider),
+    ref.watch(secureTokenStorageProvider),
+  );
+});

--- a/mobile/lib/features/auth/create_org_screen.dart
+++ b/mobile/lib/features/auth/create_org_screen.dart
@@ -1,0 +1,230 @@
+// Create-organization signup. First user in a new org becomes admin.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/shared/widgets/brand.dart';
+import 'package:signupflow_mobile/shared/widgets/labeled_field.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
+
+class CreateOrgScreen extends ConsumerStatefulWidget {
+  const CreateOrgScreen({super.key});
+
+  @override
+  ConsumerState<CreateOrgScreen> createState() => _CreateOrgScreenState();
+}
+
+class _CreateOrgScreenState extends ConsumerState<CreateOrgScreen> {
+  final _orgName = TextEditingController();
+  final _orgId = TextEditingController();
+  final _adminName = TextEditingController();
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  bool _busy = false;
+  String? _error;
+  bool _slugManuallyEdited = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _orgName.addListener(_maybeAutofillSlug);
+    _orgId.addListener(_trackManualEdit);
+  }
+
+  @override
+  void dispose() {
+    _orgName.dispose();
+    _orgId.dispose();
+    _adminName.dispose();
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  void _maybeAutofillSlug() {
+    if (_slugManuallyEdited) return;
+    final auto = _slugify(_orgName.text);
+    if (_orgId.text != auto) {
+      // Setting via setText would re-trigger our own listener; bypass with a
+      // direct assignment + selection-preserving update.
+      _orgId.value = TextEditingValue(
+        text: auto,
+        selection: TextSelection.collapsed(offset: auto.length),
+      );
+    }
+  }
+
+  void _trackManualEdit() {
+    final auto = _slugify(_orgName.text);
+    if (_orgId.text != auto) _slugManuallyEdited = true;
+    if (_orgId.text.isEmpty) _slugManuallyEdited = false;
+  }
+
+  static String _slugify(String name) {
+    final lower = name.toLowerCase().trim();
+    final cleaned = lower.replaceAll(RegExp('[^a-z0-9]+'), '-');
+    // Trim leading/trailing dashes; need a literal dollar sign so the regex
+    // anchors to end-of-string, hence the explicit string concat.
+    return cleaned.replaceAll(RegExp('^-+|-+' r'$'), '');
+  }
+
+  Future<void> _submit() async {
+    if (_busy) return;
+    final orgName = _orgName.text.trim();
+    final orgId = _orgId.text.trim();
+    final adminName = _adminName.text.trim();
+    final email = _email.text.trim();
+    final pw = _password.text;
+
+    if (orgName.isEmpty ||
+        orgId.isEmpty ||
+        adminName.isEmpty ||
+        email.isEmpty ||
+        pw.isEmpty) {
+      setState(() => _error = 'All fields are required.');
+      return;
+    }
+    if (pw.length < 6) {
+      setState(() => _error = 'Password must be at least 6 characters.');
+      return;
+    }
+    if (!RegExp(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$').hasMatch(orgId)) {
+      setState(() =>
+          _error = 'Org ID must be lowercase letters, numbers, and dashes.');
+      return;
+    }
+
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final err =
+        await ref.read(authProvider.notifier).createOrgAndSignUp(
+              orgId: orgId,
+              orgName: orgName,
+              adminName: adminName,
+              email: email,
+              password: pw,
+            );
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (err != null) {
+      setState(() => _error = err);
+      return;
+    }
+    final role = ref.read(authProvider).role;
+    if (role == AuthRole.admin) {
+      context.go('/a/dashboard');
+    } else if (role == AuthRole.volunteer) {
+      context.go('/v/schedule');
+    } else {
+      setState(() => _error = 'No role assigned. Contact your admin.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(height: 28),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () => context.go('/login'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.ink2,
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(0, 24),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: Text(
+                      '← Back to sign in',
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.ink2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const BrandMark(size: 56),
+                const SizedBox(height: 14),
+                const Wordmark(size: 22),
+                const SizedBox(height: 8),
+                Text(
+                  'CREATE A NEW ORGANIZATION',
+                  style: BlockType.monoTiny.copyWith(fontSize: 10),
+                ),
+                const SizedBox(height: 28),
+
+                LabeledField(
+                  label: 'Organization name',
+                  controller: _orgName,
+                  hint: 'Hope Community Church',
+                  textCapitalization: TextCapitalization.words,
+                  autocorrect: true,
+                ),
+                const SizedBox(height: 10),
+                LabeledField(
+                  label: 'Org ID (used in URLs)',
+                  controller: _orgId,
+                  hint: 'hope-community',
+                ),
+                const SizedBox(height: 22),
+                LabeledField(
+                  label: 'Your name',
+                  controller: _adminName,
+                  hint: 'Pastor Sarah',
+                  textCapitalization: TextCapitalization.words,
+                ),
+                const SizedBox(height: 10),
+                LabeledField(
+                  label: 'Email',
+                  controller: _email,
+                  hint: 'you@church.org',
+                  keyboard: TextInputType.emailAddress,
+                ),
+                const SizedBox(height: 10),
+                LabeledField(
+                  label: 'Password',
+                  controller: _password,
+                  hint: 'min 6 characters',
+                  obscure: true,
+                ),
+
+                if (_error != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    _error!,
+                    style:
+                        BlockType.bodySm.copyWith(color: BlockColors.danger),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+
+                const SizedBox(height: 18),
+                BlockButton(
+                  label: _busy ? 'Creating…' : 'Create organization',
+                  onPressed: _busy ? null : _submit,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'You become the first admin of the new organization.',
+                  textAlign: TextAlign.center,
+                  style: BlockType.bodySm.copyWith(color: BlockColors.ink3),
+                ),
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/auth/login_screen.dart
+++ b/mobile/lib/features/auth/login_screen.dart
@@ -154,6 +154,15 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   ),
                 ),
 
+                const SizedBox(height: 18),
+                TextButton(
+                  onPressed: () => context.go('/signup'),
+                  child: Text(
+                    'Create a new organization →',
+                    style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                  ),
+                ),
+
                 const SizedBox(height: 24),
               ],
             ),

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -21,6 +21,7 @@ import 'package:signupflow_mobile/features/admin/publish_screen.dart';
 import 'package:signupflow_mobile/features/admin/shell.dart';
 import 'package:signupflow_mobile/features/admin/solution_review_screen.dart';
 import 'package:signupflow_mobile/features/admin/solver_screen.dart';
+import 'package:signupflow_mobile/features/auth/create_org_screen.dart';
 import 'package:signupflow_mobile/features/auth/invitation_screen.dart';
 import 'package:signupflow_mobile/features/auth/login_screen.dart';
 import 'package:signupflow_mobile/features/volunteer/assignment_detail_screen.dart';
@@ -36,7 +37,9 @@ GoRouter buildRouter(WidgetRef ref) {
     redirect: (context, state) {
       final auth = ref.read(authProvider);
       final loc = state.matchedLocation;
-      final isAuth = loc == '/login' || loc == '/invitation';
+      final isAuth = loc == '/login' ||
+          loc == '/signup' ||
+          loc == '/invitation';
 
       if (auth.role == AuthRole.unauth && !isAuth) return '/login';
       if (auth.role == AuthRole.volunteer && loc.startsWith('/a/')) {
@@ -48,6 +51,7 @@ GoRouter buildRouter(WidgetRef ref) {
     },
     routes: [
       GoRoute(path: '/login', builder: (_, __) => const LoginScreen()),
+      GoRoute(path: '/signup', builder: (_, __) => const CreateOrgScreen()),
       GoRoute(path: '/invitation', builder: (_, __) => const InvitationScreen()),
 
       ShellRoute(

--- a/mobile/lib/shared/widgets/labeled_field.dart
+++ b/mobile/lib/shared/widgets/labeled_field.dart
@@ -1,0 +1,60 @@
+// LabeledField — Block-Mono themed labeled text input. Extracted from
+// the login screen so signup, invitation, and password-reset reuse it.
+
+import 'package:flutter/material.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
+
+class LabeledField extends StatelessWidget {
+  const LabeledField({
+    required this.label,
+    required this.controller,
+    required this.hint,
+    super.key,
+    this.obscure = false,
+    this.keyboard,
+    this.autocorrect = false,
+    this.textCapitalization = TextCapitalization.none,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final String hint;
+  final bool obscure;
+  final TextInputType? keyboard;
+  final bool autocorrect;
+  final TextCapitalization textCapitalization;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label.toUpperCase(),
+            style: BlockType.monoLabel.copyWith(fontSize: 10),
+          ),
+          TextField(
+            controller: controller,
+            obscureText: obscure,
+            keyboardType: keyboard,
+            autocorrect: autocorrect,
+            enableSuggestions: !obscure && autocorrect,
+            textCapitalization: textCapitalization,
+            style: BlockType.body,
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: BlockType.body.copyWith(color: BlockColors.ink3),
+              border: InputBorder.none,
+              isDense: true,
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/test/create_org_test.dart
+++ b/mobile/test/create_org_test.dart
@@ -1,0 +1,138 @@
+// Create-org signup test — exercises AuthController.createOrgAndSignUp
+// + the CreateOrgScreen form using a fake SignupRepository.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+import 'package:signupflow_mobile/auth/signup_repository.dart';
+import 'package:signupflow_mobile/features/auth/create_org_screen.dart';
+
+class _FakeSignupRepo implements SignupRepository {
+  _FakeSignupRepo({this.shouldSucceed = true});
+  bool shouldSucceed;
+  String? lastOrgId;
+
+  @override
+  Future<AuthState> createOrgAndSignUp({
+    required String orgId,
+    required String orgName,
+    required String adminName,
+    required String email,
+    required String password,
+  }) async {
+    lastOrgId = orgId;
+    if (!shouldSucceed) {
+      throw const SignupFailure('That organization ID is already taken.');
+    }
+    return AuthState(
+      role: AuthRole.admin,
+      token: 'fake-jwt-$email',
+      orgId: orgId,
+      email: email,
+      name: adminName,
+    );
+  }
+}
+
+void main() {
+  group('AuthController.createOrgAndSignUp', () {
+    test('success applies admin role + token', () async {
+      final repo = _FakeSignupRepo();
+      final container = ProviderContainer(
+        overrides: [
+          signupRepositoryProvider.overrideWithValue(repo),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final err = await container.read(authProvider.notifier).createOrgAndSignUp(
+            orgId: 'hope',
+            orgName: 'Hope Community Church',
+            adminName: 'Pastor Sarah',
+            email: 'sarah@hope.org',
+            password: 'sec!ret',
+          );
+
+      expect(err, isNull);
+      final state = container.read(authProvider);
+      expect(state.role, AuthRole.admin);
+      expect(state.token, 'fake-jwt-sarah@hope.org');
+      expect(state.orgId, 'hope');
+      expect(repo.lastOrgId, 'hope');
+    });
+
+    test('failure surfaces server message', () async {
+      final repo = _FakeSignupRepo(shouldSucceed: false);
+      final container = ProviderContainer(
+        overrides: [
+          signupRepositoryProvider.overrideWithValue(repo),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final err =
+          await container.read(authProvider.notifier).createOrgAndSignUp(
+                orgId: 'hope',
+                orgName: 'Hope',
+                adminName: 'S',
+                email: 's@h.org',
+                password: 'pw1234',
+              );
+      expect(err, 'That organization ID is already taken.');
+      expect(container.read(authProvider).role, AuthRole.unauth);
+    });
+  });
+
+  group('CreateOrgScreen', () {
+    Widget wrap(ProviderContainer container) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: CreateOrgScreen()),
+      );
+    }
+
+    testWidgets('autofills org id slug from org name', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          signupRepositoryProvider.overrideWithValue(_FakeSignupRepo()),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container));
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Hope Community Church'),
+        'Grace Sports League!',
+      );
+      await tester.pump();
+
+      final orgIdField = find.widgetWithText(TextField, 'hope-community');
+      expect(orgIdField, findsOneWidget);
+      expect(
+        (tester.widget<TextField>(orgIdField).controller!).text,
+        'grace-sports-league',
+      );
+    });
+
+    testWidgets('blocks submit when fields empty', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          signupRepositoryProvider.overrideWithValue(_FakeSignupRepo()),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container));
+
+      await tester.tap(find.text('CREATE ORGANIZATION'));
+      await tester.pump();
+
+      expect(find.text('All fields are required.'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes the auth gap that surfaced from TestFlight build #425: the user installed the app, opened the login screen, and had no way to make an account. The "Create new organization" path now ships. (Invitation accept lands in 8.7; forgot/reset password in 8.8.)

## What's new

- **`mobile/lib/auth/signup_repository.dart`** — chains `POST /organizations` + `POST /auth/signup`. Returns `AuthState` on success, throws `SignupFailure` with user-facing 409/422 messages.
- **`mobile/lib/features/auth/create_org_screen.dart`** — form: org name, org id (auto-slugified from name; user can override), admin name, email, password. Submits to `AuthController`, routes to `/a/dashboard` (first user is admin per `api/routers/auth.py:88-91`).
- **`LoginRepository._resolveRole` → `LoginRepository.resolveRole`** (public) so signup / invitation / reset flows map server roles consistently.
- **`mobile/lib/shared/widgets/labeled_field.dart`** — extracted from login screen so signup, invitation, reset all share the same input chrome.
- **`/signup`** route + **"Create a new organization →"** link on login screen.

## Tests

- `mobile/test/create_org_test.dart` — controller success/failure + widget tests for slug autofill and empty-form validation.
- `flutter analyze` clean.
- `flutter test` — 29 tests, all green.

## Backend

No backend changes. The `/organizations` POST and `/auth/signup` POST endpoints are unauthenticated + rate-limited, exactly the shape this flow needs.

Spec context: `specs/023-sprint-8-completion/spec.md` Phase C, PR 8.6 (#64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)