### PR TITLE
Mobile invitation accept screen (Sprint 8 PR 8.7)

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -22,6 +22,19 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>app.signupflow.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>signupflow</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/lib/auth/auth_provider.dart
+++ b/mobile/lib/auth/auth_provider.dart
@@ -3,6 +3,7 @@
 // offline dev and the widget smoke test.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_mobile/auth/invitation_repository.dart';
 import 'package:signupflow_mobile/auth/login_repository.dart';
 import 'package:signupflow_mobile/auth/secure_token_storage.dart';
 import 'package:signupflow_mobile/auth/signup_repository.dart';
@@ -85,6 +86,29 @@ class AuthController extends Notifier<AuthState> {
       state = next;
       return null;
     } on SignupFailure catch (e) {
+      return e.message;
+    } on Exception catch (e) {
+      return 'Unexpected error: $e';
+    }
+  }
+
+  /// Accept an invitation token. Returns null on success; returns a
+  /// user-facing message on failure. Caller is expected to verify the
+  /// token first via [InvitationRepository.verify].
+  Future<String?> acceptInvitation({
+    required String token,
+    required String password,
+    String? timezone,
+  }) async {
+    try {
+      final next = await ref.read(invitationRepositoryProvider).accept(
+            token: token,
+            password: password,
+            timezone: timezone,
+          );
+      state = next;
+      return null;
+    } on InvitationFailure catch (e) {
       return e.message;
     } on Exception catch (e) {
       return 'Unexpected error: $e';

--- a/mobile/lib/auth/invitation_repository.dart
+++ b/mobile/lib/auth/invitation_repository.dart
@@ -1,0 +1,127 @@
+// InvitationRepository — verify invitation tokens and accept them.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/login_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+class InvitationPreview {
+  const InvitationPreview({
+    required this.token,
+    required this.orgId,
+    required this.invitedName,
+    required this.invitedEmail,
+    required this.invitedBy,
+    required this.roles,
+  });
+  final String token;
+  final String orgId;
+  final String invitedName;
+  final String invitedEmail;
+  final String invitedBy;
+  final List<String> roles;
+}
+
+class InvitationRepository {
+  InvitationRepository(this._client, this._storage);
+  final api.SignupflowApi _client;
+  final SecureTokenStorage _storage;
+
+  /// Verify an invitation token and return a preview of the invitation.
+  /// Throws [InvitationFailure] if the token is missing/used/expired.
+  Future<InvitationPreview> verify(String token) async {
+    try {
+      final res = await _client.getInvitationsApi().verifyInvitation(
+            token: token,
+          );
+      final body = res.data;
+      if (body == null) {
+        throw const InvitationFailure('Server returned an empty response.');
+      }
+      if (!body.valid || body.invitation == null) {
+        throw InvitationFailure(
+          body.message ?? 'This invitation is no longer valid.',
+        );
+      }
+      final inv = body.invitation!;
+      return InvitationPreview(
+        token: token,
+        orgId: inv.orgId,
+        invitedName: inv.name,
+        invitedEmail: inv.email,
+        invitedBy: inv.invitedBy,
+        roles: inv.roles.toList(),
+      );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 404) {
+        throw const InvitationFailure('Invitation not found.');
+      }
+      throw InvitationFailure('Network error: ${e.message ?? code}');
+    }
+  }
+
+  /// Accept an invitation. On success, persists the token and returns the
+  /// auth state to apply.
+  Future<AuthState> accept({
+    required String token,
+    required String password,
+    String? timezone,
+  }) async {
+    try {
+      final body = (api.InvitationAcceptBuilder()
+            ..password = password
+            ..timezone = timezone ?? 'UTC')
+          .build();
+      final res = await _client.getInvitationsApi().acceptInvitation(
+            token: token,
+            invitationAccept: body,
+          );
+      final data = res.data;
+      if (data == null || data.token.isEmpty) {
+        throw const InvitationFailure('Server returned an empty token.');
+      }
+      await _storage.writeToken(data.token);
+      return AuthState(
+        role: LoginRepository.resolveRole(data.roles.toList()),
+        token: data.token,
+        personId: data.personId,
+        email: data.email,
+        orgId: data.orgId,
+        name: data.name,
+      );
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 404) {
+        throw const InvitationFailure('Invitation not found.');
+      }
+      if (code == 409) {
+        throw const InvitationFailure('This invitation has already been used.');
+      }
+      if (code == 410) {
+        throw const InvitationFailure('This invitation has expired.');
+      }
+      if (code == 422) {
+        throw const InvitationFailure('Password did not pass validation.');
+      }
+      throw InvitationFailure('Network error: ${e.message ?? code}');
+    }
+  }
+}
+
+class InvitationFailure implements Exception {
+  const InvitationFailure(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+final invitationRepositoryProvider = Provider<InvitationRepository>((ref) {
+  return InvitationRepository(
+    ref.watch(signupflowApiProvider),
+    ref.watch(secureTokenStorageProvider),
+  );
+});

--- a/mobile/lib/features/auth/invitation_screen.dart
+++ b/mobile/lib/features/auth/invitation_screen.dart
@@ -1,14 +1,339 @@
+// Invitation accept screen — verifies the token (?token=...), shows the
+// invitation preview (org, role, inviter), and lets the user set a
+// password to claim the account.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/invitation_repository.dart';
+import 'package:signupflow_mobile/shared/widgets/brand.dart';
+import 'package:signupflow_mobile/shared/widgets/labeled_field.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
+class InvitationScreen extends ConsumerStatefulWidget {
+  const InvitationScreen({required this.token, super.key});
 
-class InvitationScreen extends StatelessWidget {
-  const InvitationScreen({super.key});
+  /// Token from the deep-link query param (`?token=...`). Empty string
+  /// when the user navigates here without one — we show a paste form.
+  final String token;
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Invitation',
-        endpoint: 'GET /invitations/verify · POST /invitations/accept',
-        willLandIn: 'PR 7.2 (auth flow)',
-      );
+  ConsumerState<InvitationScreen> createState() => _InvitationScreenState();
+}
+
+class _InvitationScreenState extends ConsumerState<InvitationScreen> {
+  final _password = TextEditingController();
+  final _pasteToken = TextEditingController();
+  Future<InvitationPreview>? _preview;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.token.isNotEmpty) {
+      _preview = ref.read(invitationRepositoryProvider).verify(widget.token);
+    }
+  }
+
+  @override
+  void didUpdateWidget(InvitationScreen old) {
+    super.didUpdateWidget(old);
+    if (old.token != widget.token && widget.token.isNotEmpty) {
+      setState(() {
+        _preview =
+            ref.read(invitationRepositoryProvider).verify(widget.token);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _password.dispose();
+    _pasteToken.dispose();
+    super.dispose();
+  }
+
+  Future<void> _accept(InvitationPreview preview) async {
+    if (_busy) return;
+    final pw = _password.text;
+    if (pw.length < 6) {
+      setState(() => _error = 'Password must be at least 6 characters.');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    final err = await ref.read(authProvider.notifier).acceptInvitation(
+          token: preview.token,
+          password: pw,
+        );
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (err != null) {
+      setState(() => _error = err);
+      return;
+    }
+    final role = ref.read(authProvider).role;
+    if (role == AuthRole.admin) {
+      context.go('/a/dashboard');
+    } else {
+      context.go('/v/schedule');
+    }
+  }
+
+  void _submitPastedToken() {
+    final t = _pasteToken.text.trim();
+    if (t.isEmpty) {
+      setState(() => _error = 'Paste your invitation token to continue.');
+      return;
+    }
+    context.go('/invitation?token=$t');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(height: 28),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () => context.go('/login'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.ink2,
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(0, 24),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: Text(
+                      '← Back to sign in',
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.ink2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const BrandMark(size: 56),
+                const SizedBox(height: 14),
+                const Wordmark(size: 22),
+                const SizedBox(height: 8),
+                Text(
+                  'ACCEPT INVITATION',
+                  style: BlockType.monoTiny.copyWith(fontSize: 10),
+                ),
+                const SizedBox(height: 24),
+                if (widget.token.isEmpty)
+                  _PasteTokenForm(
+                    controller: _pasteToken,
+                    error: _error,
+                    onSubmit: _submitPastedToken,
+                  )
+                else
+                  FutureBuilder<InvitationPreview>(
+                    future: _preview,
+                    builder: (context, snap) {
+                      if (snap.connectionState == ConnectionState.waiting) {
+                        return const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 32),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
+                      if (snap.hasError) {
+                        return _InvitationError(
+                          message: snap.error.toString(),
+                        );
+                      }
+                      final preview = snap.data!;
+                      return _AcceptForm(
+                        preview: preview,
+                        password: _password,
+                        busy: _busy,
+                        error: _error,
+                        onAccept: () => _accept(preview),
+                      );
+                    },
+                  ),
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PasteTokenForm extends StatelessWidget {
+  const _PasteTokenForm({
+    required this.controller,
+    required this.error,
+    required this.onSubmit,
+  });
+  final TextEditingController controller;
+  final String? error;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        BlockCard(
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('NO TOKEN IN LINK', style: BlockType.monoLabel),
+              const SizedBox(height: 6),
+              Text(
+                'Paste the invitation token from your email below.',
+                style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        LabeledField(
+          label: 'Invitation token',
+          controller: controller,
+          hint: 'inv_…',
+        ),
+        if (error != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            error!,
+            style: BlockType.bodySm.copyWith(color: BlockColors.danger),
+            textAlign: TextAlign.center,
+          ),
+        ],
+        const SizedBox(height: 18),
+        BlockButton(label: 'Continue', onPressed: onSubmit),
+      ],
+    );
+  }
+}
+
+class _AcceptForm extends StatelessWidget {
+  const _AcceptForm({
+    required this.preview,
+    required this.password,
+    required this.busy,
+    required this.error,
+    required this.onAccept,
+  });
+  final InvitationPreview preview;
+  final TextEditingController password;
+  final bool busy;
+  final String? error;
+  final VoidCallback onAccept;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        BlockCard(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('YOU ARE INVITED', style: BlockType.monoLabel),
+              const SizedBox(height: 8),
+              Text(
+                preview.invitedName,
+                style: BlockType.body.copyWith(fontWeight: FontWeight.w600),
+              ),
+              Text(
+                preview.invitedEmail,
+                style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+              ),
+              const SizedBox(height: 12),
+              _row('Organization', preview.orgId),
+              _row(
+                'Role${preview.roles.length == 1 ? '' : 's'}',
+                preview.roles.join(', '),
+              ),
+              _row('Invited by', preview.invitedBy),
+            ],
+          ),
+        ),
+        const SizedBox(height: 18),
+        LabeledField(
+          label: 'Choose a password',
+          controller: password,
+          hint: 'min 6 characters',
+          obscure: true,
+        ),
+        if (error != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            error!,
+            style: BlockType.bodySm.copyWith(color: BlockColors.danger),
+            textAlign: TextAlign.center,
+          ),
+        ],
+        const SizedBox(height: 18),
+        BlockButton(
+          label: busy ? 'Accepting…' : 'Accept invitation',
+          onPressed: busy ? null : onAccept,
+        ),
+      ],
+    );
+  }
+
+  Widget _row(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 110,
+            child: Text(
+              label.toUpperCase(),
+              style: BlockType.monoLabel.copyWith(fontSize: 10),
+            ),
+          ),
+          Expanded(child: Text(value, style: BlockType.bodySm)),
+        ],
+      ),
+    );
+  }
+}
+
+class _InvitationError extends StatelessWidget {
+  const _InvitationError({required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('INVITATION ERROR', style: BlockType.monoLabel),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            style: BlockType.body.copyWith(color: BlockColors.danger),
+          ),
+          const SizedBox(height: 14),
+          Text(
+            'Ask your admin to resend the invitation, or paste the token '
+            'manually below.',
+            style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/mobile/lib/features/auth/login_screen.dart
+++ b/mobile/lib/features/auth/login_screen.dart
@@ -116,7 +116,15 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
                   textAlign: TextAlign.center,
                 ),
-                const SizedBox(height: 36),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () => context.go('/invitation'),
+                  child: Text(
+                    'Have an invitation? Tap here →',
+                    style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                  ),
+                ),
+                const SizedBox(height: 28),
 
                 BlockCard(
                   padding: const EdgeInsets.all(14),

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -52,7 +52,12 @@ GoRouter buildRouter(WidgetRef ref) {
     routes: [
       GoRoute(path: '/login', builder: (_, __) => const LoginScreen()),
       GoRoute(path: '/signup', builder: (_, __) => const CreateOrgScreen()),
-      GoRoute(path: '/invitation', builder: (_, __) => const InvitationScreen()),
+      GoRoute(
+        path: '/invitation',
+        builder: (_, state) => InvitationScreen(
+          token: state.uri.queryParameters['token'] ?? '',
+        ),
+      ),
 
       ShellRoute(
         builder: (_, __, child) => VolunteerShell(child: child),

--- a/mobile/test/invitation_accept_test.dart
+++ b/mobile/test/invitation_accept_test.dart
@@ -1,0 +1,157 @@
+// Invitation accept test — controller success/failure + widget tests for
+// the verify → accept flow with a fake repository.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/invitation_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+import 'package:signupflow_mobile/features/auth/invitation_screen.dart';
+
+class _FakeInvitationRepo implements InvitationRepository {
+  _FakeInvitationRepo({this.verifyOk = true, this.acceptOk = true});
+  bool verifyOk;
+  bool acceptOk;
+  String? lastAcceptedToken;
+
+  @override
+  Future<InvitationPreview> verify(String token) async {
+    if (!verifyOk) {
+      throw const InvitationFailure('This invitation is no longer valid.');
+    }
+    return InvitationPreview(
+      token: token,
+      orgId: 'hope',
+      invitedName: 'New Volunteer',
+      invitedEmail: 'new@hope.org',
+      invitedBy: 'admin@hope.org',
+      roles: const ['volunteer'],
+    );
+  }
+
+  @override
+  Future<AuthState> accept({
+    required String token,
+    required String password,
+    String? timezone,
+  }) async {
+    lastAcceptedToken = token;
+    if (!acceptOk) {
+      throw const InvitationFailure('This invitation has already been used.');
+    }
+    return AuthState(
+      role: AuthRole.volunteer,
+      token: 'fake-jwt-$token',
+      orgId: 'hope',
+      email: 'new@hope.org',
+      name: 'New Volunteer',
+    );
+  }
+}
+
+void main() {
+  group('AuthController.acceptInvitation', () {
+    test('success applies volunteer role + token', () async {
+      final repo = _FakeInvitationRepo();
+      final container = ProviderContainer(
+        overrides: [
+          invitationRepositoryProvider.overrideWithValue(repo),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final err = await container.read(authProvider.notifier).acceptInvitation(
+            token: 'inv_abc',
+            password: 'pw1234',
+          );
+      expect(err, isNull);
+      expect(container.read(authProvider).role, AuthRole.volunteer);
+      expect(repo.lastAcceptedToken, 'inv_abc');
+    });
+
+    test('failure surfaces server message', () async {
+      final repo = _FakeInvitationRepo(acceptOk: false);
+      final container = ProviderContainer(
+        overrides: [
+          invitationRepositoryProvider.overrideWithValue(repo),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final err = await container.read(authProvider.notifier).acceptInvitation(
+            token: 'inv_abc',
+            password: 'pw1234',
+          );
+      expect(err, 'This invitation has already been used.');
+      expect(container.read(authProvider).role, AuthRole.unauth);
+    });
+  });
+
+  group('InvitationScreen', () {
+    Widget wrap(ProviderContainer container, String token) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(home: InvitationScreen(token: token)),
+      );
+    }
+
+    testWidgets('with no token shows paste form', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          invitationRepositoryProvider.overrideWithValue(_FakeInvitationRepo()),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, ''));
+      await tester.pump();
+
+      expect(find.text('NO TOKEN IN LINK'), findsOneWidget);
+      expect(find.text('CONTINUE'), findsOneWidget);
+    });
+
+    testWidgets('with valid token shows preview card', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          invitationRepositoryProvider.overrideWithValue(_FakeInvitationRepo()),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, 'inv_abc'));
+      // FutureBuilder resolves on next pump.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.text('YOU ARE INVITED'), findsOneWidget);
+      expect(find.text('New Volunteer'), findsOneWidget);
+      expect(find.text('new@hope.org'), findsOneWidget);
+      expect(find.text('hope'), findsOneWidget);
+      expect(find.text('volunteer'), findsOneWidget);
+    });
+
+    testWidgets('invalid token shows error card', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          invitationRepositoryProvider.overrideWithValue(
+            _FakeInvitationRepo(verifyOk: false),
+          ),
+          secureTokenStorageProvider.overrideWithValue(InMemoryTokenStorage()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, 'inv_bad'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.text('INVITATION ERROR'), findsOneWidget);
+      expect(
+        find.text('This invitation is no longer valid.'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -18,6 +18,7 @@ void main() {
     expect(find.text('DEMO SHORTCUT'), findsOneWidget);
 
     // Demo shortcut → Volunteer.
+    await tester.ensureVisible(find.text('VOLUNTEER'));
     await tester.tap(find.text('VOLUNTEER'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
Replaces the `StubScreen` at `/invitation` with the real flow.

## Behavior

1. Verify token (`?token=...`) → load org/role/inviter preview card.
2. Set password → `POST /invitations/{token}/accept` → store JWT in Keychain and route to `/v/schedule` (or `/a/dashboard` for admin invites).
3. When opened with **no** token, the screen offers a "paste your invitation token" form so the flow is testable end-to-end while `EMAIL_ENABLED=false` keeps SendGrid off in dev.

## What's new

- **`mobile/lib/auth/invitation_repository.dart`** — verify + accept wrappers with typed `InvitationFailure` for 404/409/410/422.
- **`mobile/lib/features/auth/invitation_screen.dart`** — preview + accept UI.
- **`mobile/ios/Runner/Info.plist`** — registers `signupflow://` URL scheme so invitation deep-links open the app at `/invitation?token=...`. (Same scheme will be used for `signupflow://reset-password` in 8.8.)
- **`/invitation` route** now reads `?token=` query param.
- **`LoginRepository._resolveRole` → `LoginRepository.resolveRole`** (public, shared with 8.6's signup).
- **`LabeledField`** extracted from login screen for reuse (shared with 8.6's signup).
- New **"Have an invitation? Tap here →"** link on the login screen.

## Tests

- `mobile/test/invitation_accept_test.dart` — controller success/failure + widget tests for paste-form / preview-card / invalid-token paths.
- `mobile/test/widget_test.dart` — smoke test now scrolls the VOLUNTEER button into view (the new invitation link adds vertical space to the login layout).
- `flutter analyze` clean.
- `flutter test` — 30 tests, all green.

## Notes

- Some files added here (`labeled_field.dart`, public `resolveRole`) are also added in PR #65. They're identical content; rebase will be a no-op.
- Manual deep-link verification once landed: `xcrun simctl openurl booted "signupflow://invite?token=fake"` should open the app at the InvitationScreen with that token.

Spec: `specs/023-sprint-8-completion/spec.md` Phase C, PR 8.7 (#64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)