### PR TITLE
Mobile forgot + reset password screens (Sprint 8 PR 8.8)

### DIFF
--- a/mobile/lib/auth/password_reset_repository.dart
+++ b/mobile/lib/auth/password_reset_repository.dart
@@ -1,0 +1,67 @@
+// PasswordResetRepository — request a reset token and confirm a new
+// password. The endpoint always returns the same generic message
+// regardless of whether the email exists (anti-enumeration), so the
+// "request" call has no failure-path branching.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+
+class PasswordResetRepository {
+  PasswordResetRepository(this._client);
+  final api.SignupflowApi _client;
+
+  /// Request a password-reset email. Always returns success, per spec.
+  Future<void> requestReset(String email) async {
+    try {
+      final body = (api.PasswordResetRequestBuilder()..email = email).build();
+      await _client.getAuthApi().requestPasswordReset(
+            passwordResetRequest: body,
+          );
+    } on DioException catch (e) {
+      throw PasswordResetFailure(
+        'Network error: ${e.message ?? e.response?.statusCode}',
+      );
+    }
+  }
+
+  /// Confirm a reset token + new password.
+  Future<void> confirmReset({
+    required String token,
+    required String newPassword,
+  }) async {
+    try {
+      final body = (api.PasswordResetConfirmBuilder()
+            ..token = token
+            ..newPassword = newPassword)
+          .build();
+      await _client.getAuthApi().resetPassword(passwordResetConfirm: body);
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      if (code == 400 || code == 404 || code == 410) {
+        throw const PasswordResetFailure(
+          'This reset link is invalid or has expired.',
+        );
+      }
+      if (code == 422) {
+        throw const PasswordResetFailure(
+          'Password did not pass validation.',
+        );
+      }
+      throw PasswordResetFailure('Network error: ${e.message ?? code}');
+    }
+  }
+}
+
+class PasswordResetFailure implements Exception {
+  const PasswordResetFailure(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+final passwordResetRepositoryProvider =
+    Provider<PasswordResetRepository>((ref) {
+  return PasswordResetRepository(ref.watch(signupflowApiProvider));
+});

--- a/mobile/lib/features/auth/forgot_password_screen.dart
+++ b/mobile/lib/features/auth/forgot_password_screen.dart
@@ -1,0 +1,172 @@
+// Forgot-password screen — email field → POST /auth/forgot-password
+// → confirmation message. The backend deliberately returns the same
+// generic response regardless of whether the email exists
+// (anti-enumeration), so the UI mirrors that.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:signupflow_mobile/auth/password_reset_repository.dart';
+import 'package:signupflow_mobile/shared/widgets/brand.dart';
+import 'package:signupflow_mobile/shared/widgets/labeled_field.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
+
+class ForgotPasswordScreen extends ConsumerStatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  ConsumerState<ForgotPasswordScreen> createState() =>
+      _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
+  final _email = TextEditingController();
+  bool _busy = false;
+  bool _submitted = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_busy) return;
+    final email = _email.text.trim();
+    if (email.isEmpty) {
+      setState(() => _error = 'Email required.');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(passwordResetRepositoryProvider)
+          .requestReset(email);
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _submitted = true;
+      });
+    } on PasswordResetFailure catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _error = e.message;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(height: 28),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () => context.go('/login'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.ink2,
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(0, 24),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: Text(
+                      '← Back to sign in',
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.ink2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const BrandMark(size: 56),
+                const SizedBox(height: 14),
+                const Wordmark(size: 22),
+                const SizedBox(height: 8),
+                Text(
+                  'RESET PASSWORD',
+                  style: BlockType.monoTiny.copyWith(fontSize: 10),
+                ),
+                const SizedBox(height: 28),
+                if (_submitted)
+                  _SubmittedCard(email: _email.text.trim())
+                else ...[
+                  LabeledField(
+                    label: 'Email',
+                    controller: _email,
+                    hint: 'you@church.org',
+                    keyboard: TextInputType.emailAddress,
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.danger),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 18),
+                  BlockButton(
+                    label: _busy ? 'Sending…' : 'Send reset link',
+                    onPressed: _busy ? null : _submit,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "We'll email you a reset link if your address has an "
+                    'account.',
+                    textAlign: TextAlign.center,
+                    style: BlockType.bodySm
+                        .copyWith(color: BlockColors.ink3),
+                  ),
+                ],
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SubmittedCard extends StatelessWidget {
+  const _SubmittedCard({required this.email});
+  final String email;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlockCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('CHECK YOUR EMAIL', style: BlockType.monoLabel),
+          const SizedBox(height: 8),
+          Text(
+            "If $email is registered with us, you'll receive a reset "
+            'link shortly. Open the link on this device — it will bring '
+            'you back here to set a new password.',
+            style: BlockType.bodySm,
+          ),
+          const SizedBox(height: 14),
+          Text(
+            "Didn't get an email? Check your spam folder or try again.",
+            style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/auth/login_screen.dart
+++ b/mobile/lib/features/auth/login_screen.dart
@@ -110,11 +110,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   label: _busy ? 'Signing in…' : 'Sign in',
                   onPressed: _busy ? null : _signIn,
                 ),
-                const SizedBox(height: 20),
-                Text(
-                  '· Forgot password? ·',
-                  style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
-                  textAlign: TextAlign.center,
+                const SizedBox(height: 14),
+                TextButton(
+                  onPressed: () => context.go('/forgot-password'),
+                  child: Text(
+                    'Forgot password?',
+                    style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                  ),
                 ),
                 const SizedBox(height: 8),
                 TextButton(

--- a/mobile/lib/features/auth/reset_password_screen.dart
+++ b/mobile/lib/features/auth/reset_password_screen.dart
@@ -1,0 +1,197 @@
+// Reset-password screen — takes ?token=... from a deep-link or paste,
+// asks for a new password, calls POST /auth/reset-password, routes
+// back to /login on success.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:signupflow_mobile/auth/password_reset_repository.dart';
+import 'package:signupflow_mobile/shared/widgets/brand.dart';
+import 'package:signupflow_mobile/shared/widgets/labeled_field.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
+
+class ResetPasswordScreen extends ConsumerStatefulWidget {
+  const ResetPasswordScreen({required this.token, super.key});
+
+  /// Token from the deep-link query param. Empty string when the user
+  /// navigates here without one — we show a paste form.
+  final String token;
+
+  @override
+  ConsumerState<ResetPasswordScreen> createState() =>
+      _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
+  final _password = TextEditingController();
+  final _confirm = TextEditingController();
+  final _pasteToken = TextEditingController();
+  bool _busy = false;
+  bool _done = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _password.dispose();
+    _confirm.dispose();
+    _pasteToken.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_busy) return;
+    final token = widget.token.isNotEmpty
+        ? widget.token
+        : _pasteToken.text.trim();
+    if (token.isEmpty) {
+      setState(() => _error = 'Paste your reset token to continue.');
+      return;
+    }
+    final pw = _password.text;
+    if (pw.length < 6) {
+      setState(() => _error = 'Password must be at least 6 characters.');
+      return;
+    }
+    if (pw != _confirm.text) {
+      setState(() => _error = "Passwords don't match.");
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await ref.read(passwordResetRepositoryProvider).confirmReset(
+            token: token,
+            newPassword: pw,
+          );
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _done = true;
+      });
+    } on PasswordResetFailure catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _busy = false;
+        _error = e.message;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(height: 28),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () => context.go('/login'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: BlockColors.ink2,
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(0, 24),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: Text(
+                      '← Back to sign in',
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.ink2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const BrandMark(size: 56),
+                const SizedBox(height: 14),
+                const Wordmark(size: 22),
+                const SizedBox(height: 8),
+                Text(
+                  'SET NEW PASSWORD',
+                  style: BlockType.monoTiny.copyWith(fontSize: 10),
+                ),
+                const SizedBox(height: 24),
+                if (_done)
+                  _DoneCard(onContinue: () => context.go('/login'))
+                else ...[
+                  if (widget.token.isEmpty) ...[
+                    LabeledField(
+                      label: 'Reset token',
+                      controller: _pasteToken,
+                      hint: 'rst_…',
+                    ),
+                    const SizedBox(height: 10),
+                  ],
+                  LabeledField(
+                    label: 'New password',
+                    controller: _password,
+                    hint: 'min 6 characters',
+                    obscure: true,
+                  ),
+                  const SizedBox(height: 10),
+                  LabeledField(
+                    label: 'Confirm password',
+                    controller: _confirm,
+                    hint: 'retype password',
+                    obscure: true,
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: BlockType.bodySm
+                          .copyWith(color: BlockColors.danger),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 18),
+                  BlockButton(
+                    label: _busy ? 'Resetting…' : 'Reset password',
+                    onPressed: _busy ? null : _submit,
+                  ),
+                ],
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DoneCard extends StatelessWidget {
+  const _DoneCard({required this.onContinue});
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        BlockCard(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('PASSWORD RESET', style: BlockType.monoLabel),
+              const SizedBox(height: 8),
+              Text(
+                'You can now sign in with your new password.',
+                style: BlockType.body,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 18),
+        BlockButton(label: 'Sign in', onPressed: onContinue),
+      ],
+    );
+  }
+}

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -22,8 +22,10 @@ import 'package:signupflow_mobile/features/admin/shell.dart';
 import 'package:signupflow_mobile/features/admin/solution_review_screen.dart';
 import 'package:signupflow_mobile/features/admin/solver_screen.dart';
 import 'package:signupflow_mobile/features/auth/create_org_screen.dart';
+import 'package:signupflow_mobile/features/auth/forgot_password_screen.dart';
 import 'package:signupflow_mobile/features/auth/invitation_screen.dart';
 import 'package:signupflow_mobile/features/auth/login_screen.dart';
+import 'package:signupflow_mobile/features/auth/reset_password_screen.dart';
 import 'package:signupflow_mobile/features/volunteer/assignment_detail_screen.dart';
 import 'package:signupflow_mobile/features/volunteer/availability_screen.dart';
 import 'package:signupflow_mobile/features/volunteer/inbox_screen.dart';
@@ -39,7 +41,9 @@ GoRouter buildRouter(WidgetRef ref) {
       final loc = state.matchedLocation;
       final isAuth = loc == '/login' ||
           loc == '/signup' ||
-          loc == '/invitation';
+          loc == '/invitation' ||
+          loc == '/forgot-password' ||
+          loc == '/reset-password';
 
       if (auth.role == AuthRole.unauth && !isAuth) return '/login';
       if (auth.role == AuthRole.volunteer && loc.startsWith('/a/')) {
@@ -55,6 +59,16 @@ GoRouter buildRouter(WidgetRef ref) {
       GoRoute(
         path: '/invitation',
         builder: (_, state) => InvitationScreen(
+          token: state.uri.queryParameters['token'] ?? '',
+        ),
+      ),
+      GoRoute(
+        path: '/forgot-password',
+        builder: (_, __) => const ForgotPasswordScreen(),
+      ),
+      GoRoute(
+        path: '/reset-password',
+        builder: (_, state) => ResetPasswordScreen(
           token: state.uri.queryParameters['token'] ?? '',
         ),
       ),

--- a/mobile/test/password_reset_test.dart
+++ b/mobile/test/password_reset_test.dart
@@ -1,0 +1,165 @@
+// Password reset tests — request + confirm flows with a fake repo.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/auth/password_reset_repository.dart';
+import 'package:signupflow_mobile/features/auth/forgot_password_screen.dart';
+import 'package:signupflow_mobile/features/auth/reset_password_screen.dart';
+
+class _FakeResetRepo implements PasswordResetRepository {
+  _FakeResetRepo({this.confirmOk = true});
+  bool confirmOk;
+  String? lastEmail;
+  String? lastToken;
+  String? lastNewPassword;
+
+  @override
+  Future<void> requestReset(String email) async {
+    lastEmail = email;
+  }
+
+  @override
+  Future<void> confirmReset({
+    required String token,
+    required String newPassword,
+  }) async {
+    lastToken = token;
+    lastNewPassword = newPassword;
+    if (!confirmOk) {
+      throw const PasswordResetFailure(
+        'This reset link is invalid or has expired.',
+      );
+    }
+  }
+}
+
+void main() {
+  group('ForgotPasswordScreen', () {
+    Widget wrap(ProviderContainer container) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: ForgotPasswordScreen()),
+      );
+    }
+
+    testWidgets('submitting email shows confirmation card', (tester) async {
+      final repo = _FakeResetRepo();
+      final container = ProviderContainer(
+        overrides: [
+          passwordResetRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container));
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'you@church.org'),
+        'sarah@hope.org',
+      );
+      await tester.tap(find.text('SEND RESET LINK'));
+      await tester.pump();
+
+      expect(find.text('CHECK YOUR EMAIL'), findsOneWidget);
+      expect(repo.lastEmail, 'sarah@hope.org');
+    });
+
+    testWidgets('blocks submit when email empty', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          passwordResetRepositoryProvider.overrideWithValue(_FakeResetRepo()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container));
+      await tester.tap(find.text('SEND RESET LINK'));
+      await tester.pump();
+      expect(find.text('Email required.'), findsOneWidget);
+    });
+  });
+
+  group('ResetPasswordScreen', () {
+    Widget wrap(ProviderContainer container, String token) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(home: ResetPasswordScreen(token: token)),
+      );
+    }
+
+    testWidgets('happy path with deep-link token shows done card',
+        (tester) async {
+      final repo = _FakeResetRepo();
+      final container = ProviderContainer(
+        overrides: [
+          passwordResetRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, 'rst_xyz'));
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'min 6 characters'),
+        'newpw1',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'retype password'),
+        'newpw1',
+      );
+      await tester.tap(find.text('RESET PASSWORD'));
+      await tester.pump();
+
+      expect(find.text('PASSWORD RESET'), findsOneWidget);
+      expect(repo.lastToken, 'rst_xyz');
+      expect(repo.lastNewPassword, 'newpw1');
+    });
+
+    testWidgets('mismatched passwords block submit', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          passwordResetRepositoryProvider.overrideWithValue(_FakeResetRepo()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, 'rst_xyz'));
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'min 6 characters'),
+        'newpw1',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'retype password'),
+        'different',
+      );
+      await tester.tap(find.text('RESET PASSWORD'));
+      await tester.pump();
+      expect(find.text("Passwords don't match."), findsOneWidget);
+    });
+
+    testWidgets('expired token surfaces server message', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          passwordResetRepositoryProvider.overrideWithValue(
+            _FakeResetRepo(confirmOk: false),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(wrap(container, 'rst_old'));
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'min 6 characters'),
+        'newpw1',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'retype password'),
+        'newpw1',
+      );
+      await tester.tap(find.text('RESET PASSWORD'));
+      await tester.pump();
+      expect(
+        find.text('This reset link is invalid or has expired.'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes the last auth gap on the mobile app: users who forget their password can now request a reset and set a new one. With this PR + #65 + #66, the signup/signin/recovery loop is complete.

## Behavior

**Forgot:** `/forgot-password` — email field → `POST /auth/forgot-password`. Backend always returns the same generic response regardless of whether the email exists (anti-enumeration), so the UI shows "If your email is registered, you'll receive a reset link" on every successful submit.

**Reset:** `/reset-password?token=...` — takes the token from a deep-link or a paste field, asks for new password + confirm, submits to `POST /auth/reset-password`. On success: "You can sign in now" → routes back to `/login`. Surfaces 400/404/410/422 with friendly messages.

## What's new

- `mobile/lib/auth/password_reset_repository.dart` — typed wrapper.
- `mobile/lib/features/auth/forgot_password_screen.dart` and `reset_password_screen.dart` — full UIs with the project's Block-Mono chrome.
- `/forgot-password` and `/reset-password` routes added; both whitelisted in the redirect guard.
- `mobile/ios/Runner/Info.plist` — `signupflow://` URL scheme (same content as #66; rebase no-op).
- `mobile/lib/shared/widgets/labeled_field.dart` — same content as #65/#66; rebase no-op.
- "Forgot password?" copy on login screen now wired to the screen.

## Tests

`mobile/test/password_reset_test.dart` — forgot-success / forgot-empty / reset-happy-path / reset-mismatch / reset-expired-token. `flutter analyze` clean. 30 tests, all green.

## Notes

- SendGrid is off in dev (`EMAIL_ENABLED=false`), so the email never actually sends. The reset token is created in the DB regardless. Set `DEBUG_RETURN_RESET_TOKEN=true` on the backend in dev to receive the token in the JSON body for E2E exercise.
- Manual deep-link verification once landed: `xcrun simctl openurl booted "signupflow://reset-password?token=fake"` should open the app at the ResetPasswordScreen with that token pre-filled.

Spec: `specs/023-sprint-8-completion/spec.md` Phase C, PR 8.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)