### PR TITLE
Backend — type + group /solutions/{id}/assignments by event (Sprint 8 PR 8.1)

### DIFF
--- a/api/routers/solutions.py
+++ b/api/routers/solutions.py
@@ -22,6 +22,9 @@ from api.schemas.solver import (
     AssignmentChange,
     ExportFormat,
     FairnessStats,
+    SolutionAssignmentAssignee,
+    SolutionAssignmentEntry,
+    SolutionAssignmentsResponse,
     SolutionDiffResponse,
     SolutionList,
     SolutionResponse,
@@ -84,9 +87,13 @@ def get_solution(solution_id: int, db: Session = Depends(get_db)):
     return response
 
 
-@router.get("/{solution_id}/assignments")
+@router.get("/{solution_id}/assignments", response_model=SolutionAssignmentsResponse)
 def get_solution_assignments(solution_id: int, db: Session = Depends(get_db)):
-    """Get all assignments for a solution."""
+    """Get all assignments for a solution, grouped by event.
+
+    Mobile Solution Review renders an event-grouped list, so we group server-side
+    rather than forcing the client to do O(n²) regrouping every render.
+    """
     solution = db.query(Solution).filter(Solution.id == solution_id).first()
     if not solution:
         raise HTTPException(
@@ -94,28 +101,45 @@ def get_solution_assignments(solution_id: int, db: Session = Depends(get_db)):
             detail=f"Solution {solution_id} not found",
         )
 
-    assignments = db.query(Assignment).filter(Assignment.solution_id == solution_id).all()
+    # Tenancy-guard requires an org_id filter on any cross-table SELECT;
+    # all three tables carry org_id and a single solution belongs to one org.
+    rows = (
+        db.query(Assignment, Event, Person)
+        .outerjoin(Event, Event.id == Assignment.event_id)
+        .outerjoin(Person, Person.id == Assignment.person_id)
+        .filter(Assignment.solution_id == solution_id)
+        .filter((Event.org_id == solution.org_id) | (Event.org_id.is_(None)))
+        .filter((Person.org_id == solution.org_id) | (Person.org_id.is_(None)))
+        .order_by(Event.start_time.asc().nullslast(), Event.id.asc())
+        .all()
+    )
 
-    # Group by event
-    result = []
-    for assignment in assignments:
-        event = db.query(Event).filter(Event.id == assignment.event_id).first()
-        person = db.query(Person).filter(Person.id == assignment.person_id).first()
-
-        result.append(
-            {
-                "assignment_id": assignment.id,
-                "event_id": assignment.event_id,
-                "event_type": event.type if event else None,
-                "event_start": event.start_time if event else None,
-                "event_end": event.end_time if event else None,
-                "person_id": assignment.person_id,
-                "person_name": person.name if person else None,
-                "assigned_at": assignment.assigned_at,
-            }
+    by_event: dict[str, SolutionAssignmentEntry] = {}
+    for assignment, event, person in rows:
+        entry = by_event.get(assignment.event_id)
+        if entry is None:
+            entry = SolutionAssignmentEntry(
+                event_id=assignment.event_id,
+                event_type=event.type if event else None,
+                event_start=event.start_time if event else None,
+                event_end=event.end_time if event else None,
+                assignees=[],
+            )
+            by_event[assignment.event_id] = entry
+        entry.assignees.append(
+            SolutionAssignmentAssignee(
+                person_id=assignment.person_id,
+                person_name=person.name if person else None,
+                assignment_id=assignment.id,
+                assigned_at=assignment.assigned_at,
+            )
         )
 
-    return {"assignments": result, "total": len(result)}
+    return SolutionAssignmentsResponse(
+        solution_id=solution_id,
+        events=list(by_event.values()),
+        total_assignments=sum(len(e.assignees) for e in by_event.values()),
+    )
 
 
 @router.post("/", response_model=SolutionResponse, status_code=status.HTTP_201_CREATED)

--- a/api/schemas/solver.py
+++ b/api/schemas/solver.py
@@ -144,3 +144,30 @@ class SolutionStatsResponse(BaseModel):
     fairness: FairnessStats
     stability: StabilityMetrics
     workload: WorkloadStats
+
+
+class SolutionAssignmentAssignee(BaseModel):
+    """One assignee inside a per-event assignment group."""
+
+    person_id: str
+    person_name: str | None = None
+    assignment_id: int
+    assigned_at: datetime | None = None
+
+
+class SolutionAssignmentEntry(BaseModel):
+    """All assignees for one event in a solution."""
+
+    event_id: str
+    event_type: str | None = None
+    event_start: datetime | None = None
+    event_end: datetime | None = None
+    assignees: list[SolutionAssignmentAssignee]
+
+
+class SolutionAssignmentsResponse(BaseModel):
+    """Typed response for ``GET /solutions/{id}/assignments`` — events grouped."""
+
+    solution_id: int
+    events: list[SolutionAssignmentEntry]
+    total_assignments: int

--- a/tests/api/test_solution_assignments_enriched.py
+++ b/tests/api/test_solution_assignments_enriched.py
@@ -1,0 +1,154 @@
+"""Tests for the typed, event-grouped /solutions/{id}/assignments response.
+
+Sprint 8 PR 8.1 swaps the untyped flat list for a typed
+``SolutionAssignmentsResponse`` that groups assignees per event so the mobile
+Solution Review screen can render the per-event breakdown without client-side
+regrouping.
+"""
+
+import pytest
+
+from api.models import Assignment, Event, Person, Solution
+from api.timeutils import utcnow
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+def _admin_for(client, org_id: str, suffix: str):
+    seed_user(
+        client,
+        org_id,
+        email=f"admin-{suffix}@o.org",
+        name="Admin",
+        password="AdminPass1!",
+    )
+    return auth_headers(client, email=f"admin-{suffix}@o.org", password="AdminPass1!")
+
+
+def _seed_solution(db, org_id: str) -> Solution:
+    sol = Solution(
+        org_id=org_id,
+        solve_ms=10.0,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=99.0,
+        metrics={},
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    return sol
+
+
+def _seed_event(db, org_id: str, event_id: str, event_type: str = "Sunday Service") -> Event:
+    start = utcnow()
+    evt = Event(
+        id=event_id,
+        org_id=org_id,
+        type=event_type,
+        start_time=start,
+        end_time=start,
+        extra_data={},
+    )
+    db.add(evt)
+    db.commit()
+    db.refresh(evt)
+    return evt
+
+
+def _seed_person(db, org_id: str, person_id: str, name: str) -> Person:
+    p = Person(
+        id=person_id,
+        org_id=org_id,
+        name=name,
+        roles=["volunteer"],
+        timezone="UTC",
+        language="en",
+        extra_data={},
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _seed_assignment(db, solution_id: int, event_id: str, person_id: str) -> Assignment:
+    a = Assignment(
+        solution_id=solution_id,
+        event_id=event_id,
+        person_id=person_id,
+        assigned_at=utcnow(),
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.mark.no_mock_auth
+class TestSolutionAssignmentsEnriched:
+    def test_groups_assignees_by_event(self, client, db):
+        org_id = "sa-grouping"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "g")
+
+        sol = _seed_solution(db, org_id)
+        _seed_event(db, org_id, "evt-a", event_type="Sunday Service")
+        _seed_person(db, org_id, "p1", "Alice")
+        _seed_person(db, org_id, "p2", "Bob")
+        _seed_assignment(db, sol.id, "evt-a", "p1")
+        _seed_assignment(db, sol.id, "evt-a", "p2")
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/assignments")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["solution_id"] == sol.id
+        assert body["total_assignments"] == 2
+        assert len(body["events"]) == 1
+        event = body["events"][0]
+        assert event["event_id"] == "evt-a"
+        assert event["event_type"] == "Sunday Service"
+        names = {a["person_name"] for a in event["assignees"]}
+        assert names == {"Alice", "Bob"}
+
+    def test_empty_solution_returns_zero_events(self, client, db):
+        org_id = "sa-empty"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "e")
+        sol = _seed_solution(db, org_id)
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/assignments")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["solution_id"] == sol.id
+        assert body["total_assignments"] == 0
+        assert body["events"] == []
+
+    def test_unknown_solution_returns_404(self, client):
+        org_id = "sa-404"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "x")
+        resp = client.get("/api/v1/solutions/999999/assignments")
+        assert resp.status_code == 404
+
+    def test_two_events_in_one_solution(self, client, db):
+        org_id = "sa-twoevt"
+        seed_org(client, org_id)
+        _admin_for(client, org_id, "t")
+
+        sol = _seed_solution(db, org_id)
+        _seed_event(db, org_id, "evt-1", event_type="Practice")
+        _seed_event(db, org_id, "evt-2", event_type="Sunday Service")
+        _seed_person(db, org_id, "p1", "Alice")
+        _seed_assignment(db, sol.id, "evt-1", "p1")
+        _seed_assignment(db, sol.id, "evt-2", "p1")
+
+        resp = client.get(f"/api/v1/solutions/{sol.id}/assignments")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total_assignments"] == 2
+        assert len(body["events"]) == 2
+        # Each event has exactly one assignee.
+        for event in body["events"]:
+            assert len(event["assignees"]) == 1
+            assert event["assignees"][0]["person_id"] == "p1"

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -3207,6 +3207,132 @@
         "title": "SignupRequest",
         "type": "object"
       },
+      "SolutionAssignmentAssignee": {
+        "description": "One assignee inside a per-event assignment group.",
+        "properties": {
+          "assigned_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assigned At"
+          },
+          "assignment_id": {
+            "title": "Assignment Id",
+            "type": "integer"
+          },
+          "person_id": {
+            "title": "Person Id",
+            "type": "string"
+          },
+          "person_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Person Name"
+          }
+        },
+        "required": [
+          "person_id",
+          "assignment_id"
+        ],
+        "title": "SolutionAssignmentAssignee",
+        "type": "object"
+      },
+      "SolutionAssignmentEntry": {
+        "description": "All assignees for one event in a solution.",
+        "properties": {
+          "assignees": {
+            "items": {
+              "$ref": "#/components/schemas/SolutionAssignmentAssignee"
+            },
+            "title": "Assignees",
+            "type": "array"
+          },
+          "event_end": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event End"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "event_start": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Start"
+          },
+          "event_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type"
+          }
+        },
+        "required": [
+          "event_id",
+          "assignees"
+        ],
+        "title": "SolutionAssignmentEntry",
+        "type": "object"
+      },
+      "SolutionAssignmentsResponse": {
+        "description": "Typed response for ``GET /solutions/{id}/assignments`` \u2014 events grouped.",
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/SolutionAssignmentEntry"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "solution_id": {
+            "title": "Solution Id",
+            "type": "integer"
+          },
+          "total_assignments": {
+            "title": "Total Assignments",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "solution_id",
+          "events",
+          "total_assignments"
+        ],
+        "title": "SolutionAssignmentsResponse",
+        "type": "object"
+      },
       "SolutionDiffResponse": {
         "description": "Diff between two solutions in the same org.",
         "properties": {
@@ -8580,7 +8706,7 @@
     },
     "/api/v1/solutions/{solution_id}/assignments": {
       "get": {
-        "description": "Get all assignments for a solution.",
+        "description": "Get all assignments for a solution, grouped by event.\n\nMobile Solution Review renders an event-grouped list, so we group server-side\nrather than forcing the client to do O(n\u00b2) regrouping every render.",
         "operationId": "getSolutionAssignments",
         "parameters": [
           {
@@ -8597,7 +8723,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/SolutionAssignmentsResponse"
+                }
               }
             },
             "description": "Successful Response"


### PR DESCRIPTION
Mobile Solution Review needs the per-event assignment breakdown to render without client-side O(n²) regrouping every frame. Server now groups assignees per event in one query and returns a typed `SolutionAssignmentsResponse`.

## What's new

- **`api/schemas/solver.py`** — `SolutionAssignmentAssignee` + `SolutionAssignmentEntry` + `SolutionAssignmentsResponse`.
- **`api/routers/solutions.py::get_solution_assignments`** — swaps the inline 2-queries-per-assignment loop for one `Assignment ⨝ Event ⨝ Person` query (with the tenancy-guard `org_id` filter), groups by `event_id` in Python, returns the typed response.

## Tests

- `tests/api/test_solution_assignments_enriched.py` — grouping with two assignees on one event; empty solution returns zero events; unknown solution_id 404; two distinct events in one solution.
- `tests/contract/openapi.snapshot.json` refreshed.
- 234 `tests/api/` passing locally; black + ruff clean.

## Notes

- The previous handler returned a flat `{assignments: [...], total: int}` shape via `return {...}`. Mobile callers are now strongly typed; flat-list consumers (none in the repo, since the prior return was untyped `JsonObject`) would break. **Snapshot diff confirms this is the only impacted route.**
- Tenancy guard required adding an `org_id` filter on the cross-table SELECT — done by joining `Solution.org_id` into the predicate.
- This is the first of four Phase A backend PRs (8.1 → 8.2 → 8.3 → 8.4); 8.5 then runs `make mobile-codegen` to consume the new types.

Spec: `specs/023-sprint-8-completion/spec.md` Phase A, PR 8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)