### PR TITLE
Backend: /availability/{person_id}/exceptions CRUD (Sprint 8 PR 8.2)

### DIFF
--- a/api/routers/availability.py
+++ b/api/routers/availability.py
@@ -6,10 +6,13 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.models import (
     Availability,
+    AvailabilityException,
     Person,
     VacationPeriod,
 )
 from api.schemas.availability import (
+    AvailabilityExceptionCreate,
+    AvailabilityExceptionResponse,
     TimeOffCreate,
 )
 
@@ -194,6 +197,103 @@ def update_timeoff(
         "reason": vacation.reason,
         "message": "Time-off period updated successfully",
     }
+
+
+def _get_or_create_availability(person_id: str, db: Session) -> Availability:
+    """Mirror of the inline lookup used by add_timeoff."""
+    availability = db.query(Availability).filter(Availability.person_id == person_id).first()
+    if availability is not None:
+        return availability
+    person = db.query(Person).filter(Person.id == person_id).first()
+    if not person:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Person '{person_id}' not found",
+        )
+    availability = Availability(person_id=person_id, rrule=None, extra_data={})
+    db.add(availability)
+    db.flush()
+    return availability
+
+
+@router.get(
+    "/{person_id}/exceptions",
+    response_model=list[AvailabilityExceptionResponse],
+)
+def list_exceptions(person_id: str, db: Session = Depends(get_db)):
+    """List single-date availability exceptions for a person."""
+    availability = db.query(Availability).filter(Availability.person_id == person_id).first()
+    if availability is None:
+        return []
+    rows = (
+        db.query(AvailabilityException)
+        .filter(AvailabilityException.availability_id == availability.id)
+        .order_by(AvailabilityException.exception_date.asc())
+        .all()
+    )
+    return rows
+
+
+@router.post(
+    "/{person_id}/exceptions",
+    response_model=AvailabilityExceptionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def add_exception(
+    person_id: str,
+    payload: AvailabilityExceptionCreate,
+    db: Session = Depends(get_db),
+):
+    """Add a single-date exception. Idempotent on (availability_id, date)."""
+    availability = _get_or_create_availability(person_id, db)
+    existing = (
+        db.query(AvailabilityException)
+        .filter(
+            AvailabilityException.availability_id == availability.id,
+            AvailabilityException.exception_date == payload.exception_date,
+        )
+        .first()
+    )
+    if existing is not None:
+        return existing
+    row = AvailabilityException(
+        availability_id=availability.id,
+        exception_date=payload.exception_date,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete(
+    "/{person_id}/exceptions/{exception_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_exception(person_id: str, exception_id: int, db: Session = Depends(get_db)):
+    """Delete a single-date exception by id."""
+    availability = db.query(Availability).filter(Availability.person_id == person_id).first()
+    if availability is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No availability found for person '{person_id}'",
+        )
+    row = (
+        db.query(AvailabilityException)
+        .filter(
+            AvailabilityException.id == exception_id,
+            AvailabilityException.availability_id == availability.id,
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Exception {exception_id} not found",
+        )
+    db.delete(row)
+    db.commit()
+    return None
 
 
 @router.delete("/{person_id}/timeoff/{timeoff_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/api/schemas/availability.py
+++ b/api/schemas/availability.py
@@ -43,3 +43,30 @@ class TimeOffResponse(BaseModel):
     start_date: date
     end_date: date
     reason: str | None = None
+
+
+class AvailabilityExceptionCreate(BaseModel):
+    """Schema for adding a single-date availability exception."""
+
+    exception_date: date = Field(..., description="Single date the volunteer is blocked")
+
+
+class AvailabilityExceptionResponse(BaseModel):
+    """Schema for an availability exception row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    exception_date: date
+
+
+class AvailabilityRruleResponse(BaseModel):
+    """Schema for the single rrule string per person."""
+
+    rrule: str | None
+
+
+class AvailabilityRruleUpdate(BaseModel):
+    """Schema for setting the rrule string."""
+
+    rrule: str = Field(..., min_length=1, description="iCalendar RRULE expression")

--- a/tests/api/test_availability_exceptions.py
+++ b/tests/api/test_availability_exceptions.py
@@ -1,0 +1,109 @@
+"""Tests for /availability/{person_id}/exceptions CRUD (Sprint 8 PR 8.2).
+
+Single-date availability exceptions are already consumed by the solver via
+the ``AvailabilityException`` model. This PR adds a tiny CRUD surface so the
+mobile Availability screen can let volunteers manage them directly.
+"""
+
+import pytest
+
+from tests.api.conftest import seed_org, seed_user
+
+PERSON_PW = "VolPass1!"
+
+
+def _person_for(client, org_id: str, suffix: str) -> str:
+    """Sign up a volunteer and return their person_id (which is also auth subject)."""
+    resp = seed_user(
+        client,
+        org_id,
+        email=f"vol-{suffix}@o.org",
+        name="Vol",
+        password=PERSON_PW,
+    )
+    return resp["person_id"]
+
+
+@pytest.mark.no_mock_auth
+class TestAvailabilityExceptions:
+    def test_list_empty_returns_empty_list(self, client):
+        org_id = "ax-empty"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "e")
+        resp = client.get(f"/api/v1/availability/{person_id}/exceptions")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    def test_post_creates_exception(self, client):
+        org_id = "ax-create"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "c")
+
+        resp = client.post(
+            f"/api/v1/availability/{person_id}/exceptions",
+            json={"exception_date": "2026-12-25"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["exception_date"] == "2026-12-25"
+        assert "id" in body
+
+        # GET reflects the new row.
+        listed = client.get(f"/api/v1/availability/{person_id}/exceptions")
+        assert listed.status_code == 200
+        assert len(listed.json()) == 1
+        assert listed.json()[0]["exception_date"] == "2026-12-25"
+
+    def test_post_same_date_is_idempotent(self, client):
+        org_id = "ax-idempo"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "i")
+
+        first = client.post(
+            f"/api/v1/availability/{person_id}/exceptions",
+            json={"exception_date": "2026-07-04"},
+        )
+        second = client.post(
+            f"/api/v1/availability/{person_id}/exceptions",
+            json={"exception_date": "2026-07-04"},
+        )
+        assert first.status_code == 201
+        # Second POST returns the same row (Pydantic doesn't change the
+        # status_code we declared, so it's still 201 — but the id matches).
+        assert second.json()["id"] == first.json()["id"]
+        listed = client.get(f"/api/v1/availability/{person_id}/exceptions")
+        assert len(listed.json()) == 1
+
+    def test_delete_removes_exception(self, client):
+        org_id = "ax-del"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "d")
+
+        created = client.post(
+            f"/api/v1/availability/{person_id}/exceptions",
+            json={"exception_date": "2026-03-15"},
+        )
+        ex_id = created.json()["id"]
+
+        deleted = client.delete(f"/api/v1/availability/{person_id}/exceptions/{ex_id}")
+        assert deleted.status_code == 204
+
+        listed = client.get(f"/api/v1/availability/{person_id}/exceptions")
+        assert listed.json() == []
+
+    def test_delete_unknown_returns_404(self, client):
+        org_id = "ax-404"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "n")
+        resp = client.delete(f"/api/v1/availability/{person_id}/exceptions/999999")
+        assert resp.status_code == 404
+
+    def test_post_for_unknown_person_returns_404(self, client):
+        org_id = "ax-noperson"
+        seed_org(client, org_id)
+        _person_for(client, org_id, "p")  # unrelated, just to land an org
+        resp = client.post(
+            "/api/v1/availability/person_does_not_exist/exceptions",
+            json={"exception_date": "2026-01-01"},
+        )
+        assert resp.status_code == 404

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -346,6 +346,42 @@
         "title": "AuthResponse",
         "type": "object"
       },
+      "AvailabilityExceptionCreate": {
+        "description": "Schema for adding a single-date availability exception.",
+        "properties": {
+          "exception_date": {
+            "description": "Single date the volunteer is blocked",
+            "format": "date",
+            "title": "Exception Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "exception_date"
+        ],
+        "title": "AvailabilityExceptionCreate",
+        "type": "object"
+      },
+      "AvailabilityExceptionResponse": {
+        "description": "Schema for an availability exception row.",
+        "properties": {
+          "exception_date": {
+            "format": "date",
+            "title": "Exception Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "exception_date"
+        ],
+        "title": "AvailabilityExceptionResponse",
+        "type": "object"
+      },
       "AvailablePerson": {
         "description": "Person available for an event.",
         "properties": {
@@ -4674,6 +4710,149 @@
           }
         },
         "summary": "Create Availability",
+        "tags": [
+          "availability"
+        ]
+      }
+    },
+    "/api/v1/availability/{person_id}/exceptions": {
+      "get": {
+        "description": "List single-date availability exceptions for a person.",
+        "operationId": "listExceptions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AvailabilityExceptionResponse"
+                  },
+                  "title": "Response List Exceptions Api V1 Availability  Person Id  Exceptions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Exceptions",
+        "tags": [
+          "availability"
+        ]
+      },
+      "post": {
+        "description": "Add a single-date exception. Idempotent on (availability_id, date).",
+        "operationId": "addException",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AvailabilityExceptionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailabilityExceptionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Add Exception",
+        "tags": [
+          "availability"
+        ]
+      }
+    },
+    "/api/v1/availability/{person_id}/exceptions/{exception_id}": {
+      "delete": {
+        "description": "Delete a single-date exception by id.",
+        "operationId": "deleteException",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "exception_id",
+            "required": true,
+            "schema": {
+              "title": "Exception Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Exception",
         "tags": [
           "availability"
         ]


### PR DESCRIPTION
Sprint 5 PR 5.4 added the `AvailabilityException` model that the solver consumes; this PR adds the API surface so the mobile Availability screen can let volunteers manage their single-date blocked dates.

## Endpoints

- `GET /api/v1/availability/{person_id}/exceptions` → list (empty list when no Availability row exists yet).
- `POST /api/v1/availability/{person_id}/exceptions` → create (auto-creates the parent Availability row; **idempotent** on `(availability_id, exception_date)`).
- `DELETE /api/v1/availability/{person_id}/exceptions/{exception_id}` → delete.

Same auto-create-Availability pattern `add_timeoff` already uses (`api/routers/availability.py:84-97`), so behavior is consistent.

## Tests

`tests/api/test_availability_exceptions.py` — list-empty, POST creates + GET reflects, POST same date is idempotent, DELETE removes, DELETE unknown 404, POST for unknown person 404. All 6 pass; `tests/contract/openapi.snapshot.json` refreshed; black + ruff clean.

## Notes

- `AvailabilityException` has no `reason` column on the model. The plan dropped it (no mobile UI for free-text reason). If we ever want it, an Alembic migration adds the column.
- I also added `AvailabilityRruleResponse` + `AvailabilityRruleUpdate` to `api/schemas/availability.py` as a head-fake for PR 8.3 (rrule CRUD) — they're tiny schemas, doesn't matter where the import line lands.

Spec: `specs/023-sprint-8-completion/spec.md` Phase A, PR 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)