### PR TITLE
Backend: /availability/{person_id}/rrule CRUD (Sprint 8 PR 8.3)

### DIFF
--- a/api/routers/availability.py
+++ b/api/routers/availability.py
@@ -13,6 +13,8 @@ from api.models import (
 from api.schemas.availability import (
     AvailabilityExceptionCreate,
     AvailabilityExceptionResponse,
+    AvailabilityRruleResponse,
+    AvailabilityRruleUpdate,
     TimeOffCreate,
 )
 
@@ -293,6 +295,45 @@ def delete_exception(person_id: str, exception_id: int, db: Session = Depends(ge
         )
     db.delete(row)
     db.commit()
+    return None
+
+
+@router.get("/{person_id}/rrule", response_model=AvailabilityRruleResponse)
+def get_rrule(person_id: str, db: Session = Depends(get_db)):
+    """Return the single recurring-availability rrule for a person.
+
+    Returns ``rrule: null`` when the person has no Availability row or has
+    not set an rrule. Mobile renders this as "no recurring rule yet."
+    """
+    availability = db.query(Availability).filter(Availability.person_id == person_id).first()
+    return AvailabilityRruleResponse(rrule=availability.rrule if availability else None)
+
+
+@router.put("/{person_id}/rrule", response_model=AvailabilityRruleResponse)
+def set_rrule(
+    person_id: str,
+    payload: AvailabilityRruleUpdate,
+    db: Session = Depends(get_db),
+):
+    """Set (or replace) the rrule string for a person."""
+    availability = _get_or_create_availability(person_id, db)
+    availability.rrule = payload.rrule
+    db.commit()
+    db.refresh(availability)
+    return AvailabilityRruleResponse(rrule=availability.rrule)
+
+
+@router.delete("/{person_id}/rrule", status_code=status.HTTP_204_NO_CONTENT)
+def clear_rrule(person_id: str, db: Session = Depends(get_db)):
+    """Clear the rrule string for a person.
+
+    Idempotent — succeeds with 204 even if the row never had an rrule, or
+    even if the Availability row doesn't exist yet.
+    """
+    availability = db.query(Availability).filter(Availability.person_id == person_id).first()
+    if availability is not None and availability.rrule is not None:
+        availability.rrule = None
+        db.commit()
     return None
 
 

--- a/tests/api/test_availability_rrule.py
+++ b/tests/api/test_availability_rrule.py
@@ -1,0 +1,107 @@
+"""Tests for /availability/{person_id}/rrule CRUD (Sprint 8 PR 8.3).
+
+Single rrule per person. Mobile renders this as a friendly preset picker
+("Every Monday", "Every other Friday", "Custom rrule…") that produces an
+iCalendar RRULE string the solver already understands.
+"""
+
+import pytest
+
+from tests.api.conftest import seed_org, seed_user
+
+PERSON_PW = "VolPass1!"
+
+
+def _person_for(client, org_id: str, suffix: str) -> str:
+    resp = seed_user(
+        client,
+        org_id,
+        email=f"vol-{suffix}@o.org",
+        name="Vol",
+        password=PERSON_PW,
+    )
+    return resp["person_id"]
+
+
+@pytest.mark.no_mock_auth
+class TestAvailabilityRrule:
+    def test_get_when_no_availability_row_returns_null(self, client):
+        org_id = "rr-empty"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "e")
+        resp = client.get(f"/api/v1/availability/{person_id}/rrule")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"rrule": None}
+
+    def test_put_sets_rrule_and_get_returns_it(self, client):
+        org_id = "rr-set"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "s")
+
+        put_resp = client.put(
+            f"/api/v1/availability/{person_id}/rrule",
+            json={"rrule": "FREQ=WEEKLY;BYDAY=MO"},
+        )
+        assert put_resp.status_code == 200, put_resp.text
+        assert put_resp.json() == {"rrule": "FREQ=WEEKLY;BYDAY=MO"}
+
+        get_resp = client.get(f"/api/v1/availability/{person_id}/rrule")
+        assert get_resp.json() == {"rrule": "FREQ=WEEKLY;BYDAY=MO"}
+
+    def test_put_replaces_existing_rrule(self, client):
+        org_id = "rr-replace"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "r")
+
+        client.put(
+            f"/api/v1/availability/{person_id}/rrule",
+            json={"rrule": "FREQ=WEEKLY;BYDAY=MO"},
+        )
+        client.put(
+            f"/api/v1/availability/{person_id}/rrule",
+            json={"rrule": "FREQ=WEEKLY;BYDAY=FR"},
+        )
+        resp = client.get(f"/api/v1/availability/{person_id}/rrule")
+        assert resp.json() == {"rrule": "FREQ=WEEKLY;BYDAY=FR"}
+
+    def test_delete_clears_rrule(self, client):
+        org_id = "rr-clear"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "c")
+
+        client.put(
+            f"/api/v1/availability/{person_id}/rrule",
+            json={"rrule": "FREQ=WEEKLY;BYDAY=MO"},
+        )
+        del_resp = client.delete(f"/api/v1/availability/{person_id}/rrule")
+        assert del_resp.status_code == 204
+
+        get_resp = client.get(f"/api/v1/availability/{person_id}/rrule")
+        assert get_resp.json() == {"rrule": None}
+
+    def test_delete_when_never_set_is_idempotent(self, client):
+        org_id = "rr-idempo"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "i")
+        resp = client.delete(f"/api/v1/availability/{person_id}/rrule")
+        assert resp.status_code == 204
+
+    def test_put_for_unknown_person_returns_404(self, client):
+        org_id = "rr-noperson"
+        seed_org(client, org_id)
+        _person_for(client, org_id, "n")
+        resp = client.put(
+            "/api/v1/availability/person_does_not_exist/rrule",
+            json={"rrule": "FREQ=WEEKLY"},
+        )
+        assert resp.status_code == 404
+
+    def test_put_empty_string_rejected(self, client):
+        org_id = "rr-validation"
+        seed_org(client, org_id)
+        person_id = _person_for(client, org_id, "v")
+        resp = client.put(
+            f"/api/v1/availability/{person_id}/rrule",
+            json={"rrule": ""},
+        )
+        assert resp.status_code == 422

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -382,6 +382,43 @@
         "title": "AvailabilityExceptionResponse",
         "type": "object"
       },
+      "AvailabilityRruleResponse": {
+        "description": "Schema for the single rrule string per person.",
+        "properties": {
+          "rrule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rrule"
+          }
+        },
+        "required": [
+          "rrule"
+        ],
+        "title": "AvailabilityRruleResponse",
+        "type": "object"
+      },
+      "AvailabilityRruleUpdate": {
+        "description": "Schema for setting the rrule string.",
+        "properties": {
+          "rrule": {
+            "description": "iCalendar RRULE expression",
+            "minLength": 1,
+            "title": "Rrule",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rrule"
+        ],
+        "title": "AvailabilityRruleUpdate",
+        "type": "object"
+      },
       "AvailablePerson": {
         "description": "Person available for an event.",
         "properties": {
@@ -5374,6 +5411,134 @@
           }
         },
         "summary": "Delete Exception",
+        "tags": [
+          "availability"
+        ]
+      }
+    },
+    "/api/v1/availability/{person_id}/rrule": {
+      "delete": {
+        "description": "Clear the rrule string for a person.\n\nIdempotent \u2014 succeeds with 204 even if the row never had an rrule, or\neven if the Availability row doesn't exist yet.",
+        "operationId": "clearRrule",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Clear Rrule",
+        "tags": [
+          "availability"
+        ]
+      },
+      "get": {
+        "description": "Return the single recurring-availability rrule for a person.\n\nReturns ``rrule: null`` when the person has no Availability row or has\nnot set an rrule. Mobile renders this as \"no recurring rule yet.\"",
+        "operationId": "getRrule",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailabilityRruleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Rrule",
+        "tags": [
+          "availability"
+        ]
+      },
+      "put": {
+        "description": "Set (or replace) the rrule string for a person.",
+        "operationId": "setRrule",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "title": "Person Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AvailabilityRruleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailabilityRruleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Set Rrule",
         "tags": [
           "availability"
         ]


### PR DESCRIPTION
Adds `GET` / `PUT` / `DELETE` on the single rrule string per person, using the existing `Availability.rrule` column (no migration needed).

## Endpoints

- `GET /api/v1/availability/{person_id}/rrule` → `{rrule: str | null}`. Returns `null` when no Availability row exists yet — mobile renders this as "no recurring rule yet."
- `PUT /api/v1/availability/{person_id}/rrule` → set or replace. Auto-creates the parent Availability row if needed (same pattern as `add_timeoff` and the new `add_exception` from #69). Body: `{rrule: <iCalendar RRULE string>}`, validated as non-empty.
- `DELETE /api/v1/availability/{person_id}/rrule` → clear. **Idempotent**: succeeds with 204 even when no rrule was ever set.

Why one rrule per person and not a list: the existing `Availability.rrule` column is a single nullable string, the solver only consumes one rrule per person, and mobile UX is a preset picker rather than rule-list management. Schema decision recorded in `specs/023-sprint-8-completion/spec.md`.

## Tests

`tests/api/test_availability_rrule.py` — GET-empty, PUT+GET, PUT replaces, DELETE clears, DELETE-never-set is idempotent, unknown person 404, empty string rejected (422). 7/7 pass; `tests/contract/openapi.snapshot.json` refreshed; black + ruff clean.

## Notes

- `AvailabilityRruleResponse` + `AvailabilityRruleUpdate` schemas were added in #69 (8.2) as a head-fake; same content lands here — rebase no-op.
- `_get_or_create_availability` helper is shared with #69 (8.2). Same content; rebase no-op.

Spec: `specs/023-sprint-8-completion/spec.md` Phase A, PR 8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)