### PR TITLE
Backend: register /notifications router + mark-read + unread count (Sprint 8 PR 8.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ make migrate              # Run Alembic migrations
 /api/v1/calendar       — ICS export of personal schedules
 /api/v1/analytics      — volunteer stats, event stats
 /api/v1/password-reset — request/confirm password reset
+/api/v1/notifications  — list / read / unread-count, email preferences (mobile Inbox)
 
 Bare `/api` is a 308 redirect to `/api/v1` for one release.
 ```

--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,7 @@ from api.routers import (
     events,
     holidays,
     invitations,
+    notifications,
     organizations,
     password_reset,
     people,
@@ -144,6 +145,7 @@ app.include_router(audit.router, prefix="/api/v1")
 app.include_router(recurring_events.router, prefix="/api/v1")
 app.include_router(resources.router, prefix="/api/v1")
 app.include_router(holidays.router, prefix="/api/v1")
+app.include_router(notifications.router, prefix="/api/v1")
 
 
 @app.get("/api/v1", tags=["root"])

--- a/api/routers/notifications.py
+++ b/api/routers/notifications.py
@@ -112,6 +112,63 @@ async def get_notification(
     return notification
 
 
+@router.get("/notifications/unread/count")
+async def get_unread_count(
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the number of unread notifications for the current user.
+
+    Mobile Inbox uses this for the unread-dot badge on the tab bar.
+    A notification is "unread" when neither ``opened_at`` nor
+    ``clicked_at`` is set yet.
+    """
+    count = (
+        db.query(func.count(Notification.id))
+        .filter(
+            Notification.org_id == current_user.org_id,
+            Notification.recipient_id == current_user.id,
+            Notification.opened_at.is_(None),
+            Notification.clicked_at.is_(None),
+        )
+        .scalar()
+    )
+    return {"unread": int(count or 0)}
+
+
+@router.post("/notifications/{notification_id}/read", response_model=NotificationResponse)
+async def mark_notification_read(
+    notification_id: int,
+    current_user: Person = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mark a notification as read by the recipient.
+
+    Sets ``opened_at`` to now (idempotent — does nothing if already set).
+    The mobile Inbox calls this when the user taps a row.
+    """
+    from api.timeutils import utcnow
+
+    notification = db.query(Notification).filter(Notification.id == notification_id).first()
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    if notification.recipient_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: You can only mark your own notifications read",
+        )
+    if notification.opened_at is None:
+        notification.opened_at = utcnow()
+        if notification.status not in (
+            NotificationStatus.OPENED,
+            NotificationStatus.CLICKED,
+        ):
+            notification.status = NotificationStatus.OPENED
+        db.commit()
+        db.refresh(notification)
+    return notification
+
+
 @router.get("/notifications/preferences/me", response_model=EmailPreferenceResponse)
 async def get_my_email_preferences(
     current_user: Person = Depends(get_current_user), db: Session = Depends(get_db)

--- a/tests/api/test_notifications_router.py
+++ b/tests/api/test_notifications_router.py
@@ -1,0 +1,179 @@
+"""Smoke tests for the /notifications router (Sprint 8 PR 8.4).
+
+The router was already implemented (api/routers/notifications.py) but never
+registered in api/main.py. This PR registers it and adds two endpoints
+mobile Inbox needs (mark-read, unread-count).
+"""
+
+import pytest
+
+from api.models import Notification, NotificationStatus, NotificationType
+from api.timeutils import utcnow
+from tests.api.conftest import auth_headers, seed_org, seed_user
+
+
+@pytest.mark.no_mock_auth
+class TestNotificationsRouterRegistered:
+    def test_list_notifications_route_is_registered(self, client):
+        org_id = "n-reg"
+        seed_org(client, org_id)
+        seed_user(client, org_id, email="u@n-reg.org", name="U", password="UPass123!")
+        hdrs = auth_headers(client, email="u@n-reg.org", password="UPass123!")
+
+        # Pre-PR-8.4 this returned 404 (router not in app). Now 200.
+        resp = client.get(f"/api/v1/notifications/?org_id={org_id}", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["notifications"] == []
+        assert body["total"] == 0
+
+    def test_list_returns_only_recipients_notifications_for_volunteer(self, client, db):
+        org_id = "n-rbac"
+        seed_org(client, org_id)
+        # First user becomes admin.
+        admin_resp = seed_user(
+            client, org_id, email="admin@n-rbac.org", name="A", password="APass123!"
+        )
+        vol_resp = seed_user(client, org_id, email="vol@n-rbac.org", name="V", password="VPass123!")
+        admin_hdrs = auth_headers(client, email="admin@n-rbac.org", password="APass123!")
+        vol_hdrs = auth_headers(client, email="vol@n-rbac.org", password="VPass123!")
+
+        # Seed one notification for each user directly in the DB.
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=admin_resp["person_id"],
+                type=NotificationType.ASSIGNMENT,
+                status=NotificationStatus.SENT,
+            )
+        )
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=vol_resp["person_id"],
+                type=NotificationType.REMINDER,
+                status=NotificationStatus.SENT,
+            )
+        )
+        db.commit()
+
+        # Volunteer sees only their own.
+        v_list = client.get(f"/api/v1/notifications/?org_id={org_id}", headers=vol_hdrs)
+        assert v_list.status_code == 200
+        assert v_list.json()["total"] == 1
+        assert v_list.json()["notifications"][0]["type"] == NotificationType.REMINDER
+
+        # Admin sees both org-wide.
+        a_list = client.get(f"/api/v1/notifications/?org_id={org_id}", headers=admin_hdrs)
+        assert a_list.status_code == 200
+        assert a_list.json()["total"] == 2
+
+
+@pytest.mark.no_mock_auth
+class TestNotificationsUnreadAndRead:
+    def test_unread_count_excludes_opened_and_clicked(self, client, db):
+        org_id = "n-unread"
+        seed_org(client, org_id)
+        user_resp = seed_user(
+            client, org_id, email="u@n-unread.org", name="U", password="UPass123!"
+        )
+        hdrs = auth_headers(client, email="u@n-unread.org", password="UPass123!")
+        person_id = user_resp["person_id"]
+
+        # 2 unread + 1 opened + 1 clicked.
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=person_id,
+                type=NotificationType.ASSIGNMENT,
+                status=NotificationStatus.SENT,
+            )
+        )
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=person_id,
+                type=NotificationType.ASSIGNMENT,
+                status=NotificationStatus.SENT,
+            )
+        )
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=person_id,
+                type=NotificationType.ASSIGNMENT,
+                status=NotificationStatus.OPENED,
+                opened_at=utcnow(),
+            )
+        )
+        db.add(
+            Notification(
+                org_id=org_id,
+                recipient_id=person_id,
+                type=NotificationType.ASSIGNMENT,
+                status=NotificationStatus.CLICKED,
+                clicked_at=utcnow(),
+            )
+        )
+        db.commit()
+
+        resp = client.get("/api/v1/notifications/unread/count", headers=hdrs)
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"unread": 2}
+
+    def test_mark_read_sets_opened_at_idempotently(self, client, db):
+        org_id = "n-read"
+        seed_org(client, org_id)
+        user_resp = seed_user(client, org_id, email="u@n-read.org", name="U", password="UPass123!")
+        hdrs = auth_headers(client, email="u@n-read.org", password="UPass123!")
+        person_id = user_resp["person_id"]
+
+        notif = Notification(
+            org_id=org_id,
+            recipient_id=person_id,
+            type=NotificationType.ASSIGNMENT,
+            status=NotificationStatus.SENT,
+        )
+        db.add(notif)
+        db.commit()
+        db.refresh(notif)
+
+        first = client.post(f"/api/v1/notifications/{notif.id}/read", headers=hdrs)
+        assert first.status_code == 200, first.text
+        body1 = first.json()
+        assert body1["status"] == NotificationStatus.OPENED
+        assert body1["opened_at"] is not None
+        first_opened = body1["opened_at"]
+
+        # Idempotent: opened_at does not get overwritten on second call.
+        second = client.post(f"/api/v1/notifications/{notif.id}/read", headers=hdrs)
+        assert second.status_code == 200
+        assert second.json()["opened_at"] == first_opened
+
+    def test_mark_read_for_other_users_notification_returns_403(self, client, db):
+        org_id = "n-rbac-read"
+        seed_org(client, org_id)
+        owner_resp = seed_user(client, org_id, email="owner@n.org", name="O", password="OPass123!")
+        seed_user(client, org_id, email="intruder@n.org", name="I", password="IPass123!")
+        intruder_hdrs = auth_headers(client, email="intruder@n.org", password="IPass123!")
+
+        notif = Notification(
+            org_id=org_id,
+            recipient_id=owner_resp["person_id"],
+            type=NotificationType.ASSIGNMENT,
+            status=NotificationStatus.SENT,
+        )
+        db.add(notif)
+        db.commit()
+        db.refresh(notif)
+
+        resp = client.post(f"/api/v1/notifications/{notif.id}/read", headers=intruder_hdrs)
+        assert resp.status_code == 403
+
+    def test_mark_read_nonexistent_returns_404(self, client):
+        org_id = "n-read-404"
+        seed_org(client, org_id)
+        seed_user(client, org_id, email="u@n.org", name="U", password="UPass123!")
+        hdrs = auth_headers(client, email="u@n.org", password="UPass123!")
+        resp = client.post("/api/v1/notifications/999999/read", headers=hdrs)
+        assert resp.status_code == 404

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -806,6 +806,165 @@
         "title": "ConstraintUpdate",
         "type": "object"
       },
+      "EmailPreferenceResponse": {
+        "description": "Schema for email preference response.",
+        "properties": {
+          "digest_hour": {
+            "default": 8,
+            "description": "Hour to send digests (0-23)",
+            "maximum": 23.0,
+            "minimum": 0.0,
+            "title": "Digest Hour",
+            "type": "integer"
+          },
+          "enabled_types": {
+            "description": "List of enabled notification types",
+            "items": {
+              "type": "string"
+            },
+            "title": "Enabled Types",
+            "type": "array"
+          },
+          "frequency": {
+            "default": "immediate",
+            "description": "Email frequency (immediate, daily, weekly, disabled)",
+            "title": "Frequency",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "language": {
+            "default": "en",
+            "description": "Email language preference (ISO 639-1 code)",
+            "title": "Language",
+            "type": "string"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          },
+          "person_id": {
+            "title": "Person Id",
+            "type": "string"
+          },
+          "timezone": {
+            "default": "UTC",
+            "description": "Timezone for digest scheduling",
+            "title": "Timezone",
+            "type": "string"
+          },
+          "unsubscribe_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unsubscribe Token"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "person_id",
+          "org_id"
+        ],
+        "title": "EmailPreferenceResponse",
+        "type": "object"
+      },
+      "EmailPreferenceUpdate": {
+        "description": "Schema for updating email preferences.",
+        "properties": {
+          "digest_hour": {
+            "anyOf": [
+              {
+                "maximum": 23.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Hour to send digests (0-23)",
+            "title": "Digest Hour"
+          },
+          "enabled_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of enabled notification types",
+            "title": "Enabled Types"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Email frequency (immediate, daily, weekly, disabled)",
+            "title": "Frequency"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Email language preference",
+            "title": "Language"
+          },
+          "timezone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Timezone for digest scheduling",
+            "title": "Timezone"
+          }
+        },
+        "title": "EmailPreferenceUpdate",
+        "type": "object"
+      },
       "EventCreate": {
         "description": "Schema for creating an event.",
         "properties": {
@@ -1972,6 +2131,242 @@
           "password"
         ],
         "title": "LoginRequest",
+        "type": "object"
+      },
+      "NotificationListResponse": {
+        "description": "Schema for paginated notification list.",
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "notifications": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationResponse"
+            },
+            "title": "Notifications",
+            "type": "array"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "notifications",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "NotificationListResponse",
+        "type": "object"
+      },
+      "NotificationResponse": {
+        "description": "Schema for notification response.",
+        "properties": {
+          "clicked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clicked At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "delivered_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivered At"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Related event ID",
+            "title": "Event Id"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "opened_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Opened At"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          },
+          "recipient_id": {
+            "title": "Recipient Id",
+            "type": "string"
+          },
+          "retry_count": {
+            "title": "Retry Count",
+            "type": "integer"
+          },
+          "sendgrid_message_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sendgrid Message Id"
+          },
+          "sent_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sent At"
+          },
+          "status": {
+            "description": "Notification status (pending, sent, delivered, etc.)",
+            "title": "Status",
+            "type": "string"
+          },
+          "template_data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Template rendering data",
+            "title": "Template Data"
+          },
+          "type": {
+            "description": "Notification type (assignment, reminder, update, cancellation)",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "id",
+          "org_id",
+          "recipient_id",
+          "retry_count",
+          "created_at"
+        ],
+        "title": "NotificationResponse",
+        "type": "object"
+      },
+      "NotificationStatsResponse": {
+        "description": "Schema for organization notification statistics.",
+        "properties": {
+          "days_analyzed": {
+            "title": "Days Analyzed",
+            "type": "integer"
+          },
+          "delivered_notifications": {
+            "title": "Delivered Notifications",
+            "type": "integer"
+          },
+          "org_id": {
+            "title": "Org Id",
+            "type": "string"
+          },
+          "recent_failures": {
+            "description": "Recent failed notifications",
+            "items": {
+              "$ref": "#/components/schemas/NotificationResponse"
+            },
+            "title": "Recent Failures",
+            "type": "array"
+          },
+          "status_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of notifications by status",
+            "title": "Status Breakdown",
+            "type": "object"
+          },
+          "success_rate": {
+            "description": "Delivery success rate percentage",
+            "title": "Success Rate",
+            "type": "number"
+          },
+          "total_notifications": {
+            "title": "Total Notifications",
+            "type": "integer"
+          },
+          "type_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of notifications by type",
+            "title": "Type Breakdown",
+            "type": "object"
+          }
+        },
+        "required": [
+          "org_id",
+          "days_analyzed",
+          "total_notifications",
+          "delivered_notifications",
+          "success_rate",
+          "status_breakdown",
+          "type_breakdown",
+          "recent_failures"
+        ],
+        "title": "NotificationStatsResponse",
         "type": "object"
       },
       "OccurrencePreview": {
@@ -6778,6 +7173,435 @@
         "summary": "Accept Invitation",
         "tags": [
           "invitations"
+        ]
+      }
+    },
+    "/api/v1/notifications/": {
+      "get": {
+        "description": "List notifications for current user.\n\nVolunteers see only their own notifications.\nAdmins see all organization notifications.\n\n**RBAC**: Authenticated user (volunteer or admin)\n**Multi-tenant**: Filtered by org_id (and recipient_id for volunteers)",
+        "operationId": "listNotifications",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by status (pending, sent, delivered, etc.)",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by status (pending, sent, delivered, etc.)",
+              "title": "Status"
+            }
+          },
+          {
+            "description": "Filter by type (assignment, reminder, update, cancellation)",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by type (assignment, reminder, update, cancellation)",
+              "title": "Type"
+            }
+          },
+          {
+            "description": "Number of notifications to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Number of notifications to return",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Pagination offset",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Notifications",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/preferences/me": {
+      "get": {
+        "description": "Get current user's email notification preferences.\n\nReturns default preferences if none exist yet.\n\n**RBAC**: Authenticated user",
+        "operationId": "getMyEmailPreferences",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailPreferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get My Email Preferences",
+        "tags": [
+          "notifications"
+        ]
+      },
+      "put": {
+        "description": "Update current user's email notification preferences.\n\nAllows users to:\n- Change notification frequency (immediate, daily, weekly, disabled)\n- Enable/disable specific notification types\n- Set language and timezone for emails\n- Set preferred digest delivery hour\n\n**RBAC**: Authenticated user",
+        "operationId": "updateMyEmailPreferences",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailPreferenceUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailPreferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update My Email Preferences",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/stats/organization": {
+      "get": {
+        "description": "Get organization-wide notification statistics.\n\nProvides metrics for admins:\n- Total notifications sent by type\n- Delivery success rate\n- Open/click rates\n- Recent failures\n\n**RBAC**: Admin only\n**Multi-tenant**: Filtered by org_id",
+        "operationId": "getOrganizationNotificationStats",
+        "parameters": [
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of days to analyze",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 7,
+              "description": "Number of days to analyze",
+              "maximum": 90,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationStatsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Organization Notification Stats",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/test/send": {
+      "post": {
+        "description": "Send a test email notification to verify email configuration.\n\nSends a test assignment notification to the specified email address.\nUseful for testing SendGrid configuration, SMTP settings, and template rendering.\n\n**RBAC**: Admin only\n**Multi-tenant**: Verified by admin's org_id",
+        "operationId": "sendTestNotification",
+        "parameters": [
+          {
+            "description": "Email address to send test notification",
+            "in": "query",
+            "name": "recipient_email",
+            "required": true,
+            "schema": {
+              "description": "Email address to send test notification",
+              "title": "Recipient Email",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Organization ID",
+            "in": "query",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "description": "Organization ID",
+              "title": "Org Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Send Test Notification",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/unread/count": {
+      "get": {
+        "description": "Return the number of unread notifications for the current user.\n\nMobile Inbox uses this for the unread-dot badge on the tab bar.\nA notification is \"unread\" when neither ``opened_at`` nor\n``clicked_at`` is set yet.",
+        "operationId": "getUnreadCount",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Unread Count",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notification_id}": {
+      "get": {
+        "description": "Get single notification details.\n\nUsers can only view their own notifications.\n\n**RBAC**: Authenticated user (must be notification recipient)\n**Multi-tenant**: Verified by recipient_id",
+        "operationId": "getNotification",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "title": "Notification Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Notification",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notification_id}/read": {
+      "post": {
+        "description": "Mark a notification as read by the recipient.\n\nSets ``opened_at`` to now (idempotent \u2014 does nothing if already set).\nThe mobile Inbox calls this when the user taps a row.",
+        "operationId": "markNotificationRead",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "title": "Notification Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Mark Notification Read",
+        "tags": [
+          "notifications"
         ]
       }
     },


### PR DESCRIPTION
`api/routers/notifications.py` existed (338 lines, typed router for the in-app Inbox + email preferences) but was never registered in `api/main.py` — calling `/api/v1/notifications/` returned 404. This PR registers the router and adds the two endpoints mobile Inbox specifically needs.

## What's new

- `api/main.py`: `import notifications` + `include_router(notifications.router, prefix="/api/v1")`.
- **`GET /notifications/unread/count`** → `{unread: int}`. Filters by `Notification.org_id` (tenancy guard requires it on cross-table SELECT) and `recipient_id == current_user.id`, where neither `opened_at` nor `clicked_at` is set.
- **`POST /notifications/{id}/read`** → marks the notification read by setting `opened_at = now()` (idempotent — does nothing if already set); updates `status` to `OPENED` unless already `OPENED`/`CLICKED`.
- `CLAUDE.md`: `/api/v1/notifications` added to the active-routers block.

## Tests

`tests/api/test_notifications_router.py` — router registered (was 404 pre-PR), volunteer sees only own / admin sees all org-wide, unread-count excludes opened/clicked, mark-read idempotent, mark-read for other user 403, nonexistent 404. 6/6 pass; `tests/contract/openapi.snapshot.json` refreshed; black + ruff clean.

## Plan deviation

The original Sprint 8 plan said "build a new audit-log-derived router + `NotificationRead` table + Alembic migration." Discovery showed the `Notification` table already exists with `opened_at` columns suitable for read-state, so **no new model + no migration** are needed for v1. The plan file (in `/Users/tomwu/.claude/plans/dazzling-gathering-island.md`) flags this surprise.

This is the last Phase A backend PR. Next: PR 8.5 runs `make mobile-codegen` to consume all four backend changes (#68, #69, #70, this PR) into `mobile/api_client/`.

Spec: `specs/023-sprint-8-completion/spec.md` Phase A, PR 8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)