### PR TITLE
Mobile availability rrule editor + single-date exceptions UI (Sprint 8 PR 8.9)

### DIFF
--- a/mobile/lib/features/volunteer/availability_provider.dart
+++ b/mobile/lib/features/volunteer/availability_provider.dart
@@ -1,10 +1,9 @@
-// Availability flow — Sprint 7.5.
+// Availability flow — Sprint 7.5 + Sprint 8.9.
 //
-// The OpenAPI snapshot only exposes TimeOff endpoints (multi-day vacation
-// periods). The Sprint 5 backend work that added single-date exceptions +
-// rrule rules is consumed by the solver but doesn't have CRUD routes yet —
-// so the recurring-rules section in mobile/prototype/screenshots/v2/05-…
-// stays in a "coming soon" state until the backend exposes those endpoints.
+// Wraps three groups of endpoints:
+// - TimeOff (multi-day vacation periods): listed since 7.5.
+// - Recurring rrule (single string per person): added Sprint 8.3, wired here.
+// - Single-date exceptions: added Sprint 8.2, wired here.
 
 import 'dart:convert';
 
@@ -35,14 +34,27 @@ class TimeOffEntry {
   }
 }
 
+class ExceptionEntry {
+  const ExceptionEntry({required this.id, required this.date});
+  final int id;
+  final DateTime date;
+}
+
 class AvailabilityData {
-  const AvailabilityData({required this.entries});
+  const AvailabilityData({
+    required this.entries,
+    this.exceptions = const [],
+  });
   final List<TimeOffEntry> entries;
+  final List<ExceptionEntry> exceptions;
 
   Set<DateTime> get blockedDays {
     final s = <DateTime>{};
     for (final e in entries) {
       s.addAll(e.daysCovered());
+    }
+    for (final e in exceptions) {
+      s.add(e.date);
     }
     return s;
   }
@@ -55,35 +67,57 @@ DateTime _parseDate(String iso) {
   return DateTime(parts[0], parts[1], parts[2]);
 }
 
+DateTime _dateOnly(api.Date d) => DateTime(d.year, d.month, d.day);
+
 final availabilityProvider = FutureProvider<AvailabilityData>((ref) async {
   final personId = ref.watch(authProvider).personId;
   if (personId == null) return const AvailabilityData(entries: []);
 
   final apiClient = ref.watch(signupflowApiProvider);
+
+  // Time-off (existing pre-Sprint-8 endpoint — still returns JsonObject).
   final res = await apiClient.getAvailabilityApi().getTimeoff(personId: personId);
   final body = res.data;
-  if (body == null) return const AvailabilityData(entries: []);
-
-  // body is JsonObject — re-encode + decode to plain Dart types.
-  final decoded = json.decode(body.toString());
-  if (decoded is! Map<String, dynamic>) {
-    return const AvailabilityData(entries: []);
-  }
-  final raw = decoded['timeoff'];
-  if (raw is! List) return const AvailabilityData(entries: []);
-
   final entries = <TimeOffEntry>[];
-  for (final e in raw) {
-    if (e is! Map<String, dynamic>) continue;
-    entries.add(TimeOffEntry(
-      id: (e['id'] as num).toInt(),
-      startDate: _parseDate(e['start_date'] as String),
-      endDate: _parseDate(e['end_date'] as String),
-      reason: e['reason'] as String?,
-    ));
+  if (body != null) {
+    final decoded = json.decode(body.toString());
+    if (decoded is Map<String, dynamic>) {
+      final raw = decoded['timeoff'];
+      if (raw is List) {
+        for (final e in raw) {
+          if (e is! Map<String, dynamic>) continue;
+          entries.add(TimeOffEntry(
+            id: (e['id'] as num).toInt(),
+            startDate: _parseDate(e['start_date'] as String),
+            endDate: _parseDate(e['end_date'] as String),
+            reason: e['reason'] as String?,
+          ));
+        }
+        entries.sort((a, b) => a.startDate.compareTo(b.startDate));
+      }
+    }
   }
-  entries.sort((a, b) => a.startDate.compareTo(b.startDate));
-  return AvailabilityData(entries: entries);
+
+  // Single-date exceptions (Sprint 8.2). Typed list response.
+  final excRes = await apiClient
+      .getAvailabilityApi()
+      .listExceptions(personId: personId);
+  final exceptions = <ExceptionEntry>[];
+  for (final row in excRes.data ?? const <api.AvailabilityExceptionResponse>[]) {
+    exceptions.add(ExceptionEntry(id: row.id, date: _dateOnly(row.exceptionDate)));
+  }
+  exceptions.sort((a, b) => a.date.compareTo(b.date));
+
+  return AvailabilityData(entries: entries, exceptions: exceptions);
+});
+
+/// Single rrule string per person (null when unset).
+final availabilityRruleProvider = FutureProvider<String?>((ref) async {
+  final personId = ref.watch(authProvider).personId;
+  if (personId == null) return null;
+  final apiClient = ref.watch(signupflowApiProvider);
+  final res = await apiClient.getAvailabilityApi().getRrule(personId: personId);
+  return res.data?.rrule;
 });
 
 class AvailabilityMutationsController extends Notifier<bool> {
@@ -130,9 +164,100 @@ class AvailabilityMutationsController extends Notifier<bool> {
       return e.toString();
     }
   }
+
+  Future<String?> addException(DateTime date) async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      final body = (api.AvailabilityExceptionCreateBuilder()
+            ..exceptionDate = api.Date(date.year, date.month, date.day))
+          .build();
+      await ref.read(signupflowApiProvider).getAvailabilityApi().addException(
+            personId: personId,
+            availabilityExceptionCreate: body,
+          );
+      ref.invalidate(availabilityProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+
+  Future<String?> deleteException(int exceptionId) async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      await ref
+          .read(signupflowApiProvider)
+          .getAvailabilityApi()
+          .deleteException(personId: personId, exceptionId: exceptionId);
+      ref.invalidate(availabilityProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+
+  Future<String?> setRrule(String rrule) async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      final body = (api.AvailabilityRruleUpdateBuilder()..rrule = rrule).build();
+      await ref.read(signupflowApiProvider).getAvailabilityApi().setRrule(
+            personId: personId,
+            availabilityRruleUpdate: body,
+          );
+      ref.invalidate(availabilityRruleProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+
+  Future<String?> clearRrule() async {
+    final personId = ref.read(authProvider).personId;
+    if (personId == null) return 'Not signed in';
+    state = true;
+    try {
+      await ref
+          .read(signupflowApiProvider)
+          .getAvailabilityApi()
+          .clearRrule(personId: personId);
+      ref.invalidate(availabilityRruleProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
 }
 
 final availabilityMutationsProvider =
     NotifierProvider<AvailabilityMutationsController, bool>(
   AvailabilityMutationsController.new,
 );
+
+/// Friendly preset → raw RRULE string. Used by the rrule editor card.
+class RrulePreset {
+  const RrulePreset({required this.label, required this.rrule});
+  final String label;
+  final String rrule;
+}
+
+const List<RrulePreset> kRrulePresets = [
+  RrulePreset(label: 'Every Monday', rrule: 'FREQ=WEEKLY;BYDAY=MO'),
+  RrulePreset(label: 'Every Friday', rrule: 'FREQ=WEEKLY;BYDAY=FR'),
+  RrulePreset(label: 'Every weekend', rrule: 'FREQ=WEEKLY;BYDAY=SA,SU'),
+  RrulePreset(label: 'Every other Friday', rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=FR'),
+  RrulePreset(label: 'First Sunday of month', rrule: 'FREQ=MONTHLY;BYDAY=1SU'),
+];

--- a/mobile/lib/features/volunteer/availability_screen.dart
+++ b/mobile/lib/features/volunteer/availability_screen.dart
@@ -230,7 +230,7 @@ class _Body extends ConsumerWidget {
                       style: BlockType.subhead,
                     ),
                     Text(
-                      '${data.entries.length} BLOCKED',
+                      '${data.blockedDays.length} BLOCKED',
                       style: BlockType.monoData.copyWith(fontSize: 10),
                     ),
                   ],

--- a/mobile/lib/features/volunteer/availability_screen.dart
+++ b/mobile/lib/features/volunteer/availability_screen.dart
@@ -260,26 +260,9 @@ class _Body extends ConsumerWidget {
           else
             for (final e in data.entries) _TimeOffRow(entry: e),
           const MonoLabel('Recurring rules · weekly / biweekly'),
-          BlockCard(
-            color: const Color(0xFFFFF7ED),
-            borderColor: const Color(0xFFFED7AA),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'COMING SOON',
-                  style: BlockType.monoLabel.copyWith(color: BlockColors.warning),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  'Recurring availability rules (e.g. "Every Monday") are honoured by '
-                  'the solver but not yet exposed via the API. They land once the '
-                  'backend ships /availability/rrule endpoints.',
-                  style: BlockType.bodySm,
-                ),
-              ],
-            ),
-          ),
+          const _RruleCard(),
+          const MonoLabel('One-off blocked dates'),
+          _ExceptionsCard(exceptions: data.exceptions),
         ],
       ),
     );
@@ -426,6 +409,262 @@ class _TimeOffRow extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+class _RruleCard extends ConsumerWidget {
+  const _RruleCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncRrule = ref.watch(availabilityRruleProvider);
+    return BlockCard(
+      child: asyncRrule.when(
+        loading: () => const SizedBox(
+          height: 40,
+          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+        error: (e, _) => Text('Failed to load: $e', style: BlockType.bodySm),
+        data: (rrule) {
+          if (rrule == null || rrule.isEmpty) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'No recurring rule yet.',
+                  style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                ),
+                const SizedBox(height: 10),
+                BlockButton(
+                  label: 'Set recurring rule',
+                  onPressed: () => _openPresetSheet(context, ref, current: null),
+                ),
+              ],
+            );
+          }
+          final presetLabel = kRrulePresets
+              .firstWhere(
+                (p) => p.rrule == rrule,
+                orElse: () => RrulePreset(label: rrule, rrule: rrule),
+              )
+              .label;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('CURRENT', style: BlockType.monoLabel.copyWith(fontSize: 10)),
+              const SizedBox(height: 4),
+              Text(presetLabel, style: BlockType.body),
+              if (presetLabel != rrule) ...[
+                const SizedBox(height: 4),
+                Text(rrule, style: BlockType.bodySm.copyWith(color: BlockColors.ink2)),
+              ],
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: BlockButton(
+                      label: 'Change',
+                      kind: BlockButtonKind.secondary,
+                      onPressed: () =>
+                          _openPresetSheet(context, ref, current: rrule),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: BlockButton(
+                      label: 'Clear',
+                      kind: BlockButtonKind.destructive,
+                      onPressed: () async {
+                        final err = await ref
+                            .read(availabilityMutationsProvider.notifier)
+                            .clearRrule();
+                        if (!context.mounted) return;
+                        if (err != null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Failed: $err')),
+                          );
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openPresetSheet(
+    BuildContext context,
+    WidgetRef ref, {
+    required String? current,
+  }) async {
+    final customCtrl = TextEditingController(
+      text: current != null &&
+              !kRrulePresets.any((p) => p.rrule == current)
+          ? current
+          : '',
+    );
+    final picked = await showModalBottomSheet<String?>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: BlockColors.bgCard,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) => Padding(
+        padding: EdgeInsets.fromLTRB(
+          20,
+          16,
+          20,
+          MediaQuery.of(sheetCtx).viewInsets.bottom + 20,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'CHOOSE A RULE',
+              style: BlockType.monoLabel.copyWith(color: BlockColors.ink1),
+            ),
+            const SizedBox(height: 10),
+            for (final p in kRrulePresets)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: BlockButton(
+                  label: p.label,
+                  kind: current == p.rrule
+                      ? BlockButtonKind.primary
+                      : BlockButtonKind.secondary,
+                  onPressed: () => Navigator.of(sheetCtx).pop(p.rrule),
+                ),
+              ),
+            const SizedBox(height: 10),
+            Text(
+              'OR CUSTOM RRULE',
+              style: BlockType.monoLabel.copyWith(fontSize: 10),
+            ),
+            const SizedBox(height: 4),
+            TextField(
+              controller: customCtrl,
+              style: BlockType.bodySm,
+              decoration: InputDecoration(
+                hintText: 'FREQ=WEEKLY;BYDAY=MO,WE',
+                hintStyle: BlockType.bodySm.copyWith(color: BlockColors.ink3),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: BlockColors.line1),
+                ),
+              ),
+            ),
+            const SizedBox(height: 10),
+            BlockButton(
+              label: 'Save custom',
+              onPressed: () {
+                final t = customCtrl.text.trim();
+                if (t.isEmpty) return;
+                Navigator.of(sheetCtx).pop(t);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (picked == null || !context.mounted) return;
+    final err =
+        await ref.read(availabilityMutationsProvider.notifier).setRrule(picked);
+    if (!context.mounted) return;
+    if (err != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed: $err')),
+      );
+    }
+  }
+}
+
+class _ExceptionsCard extends ConsumerWidget {
+  const _ExceptionsCard({required this.exceptions});
+  final List<ExceptionEntry> exceptions;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (exceptions.isEmpty)
+          BlockCard(
+            child: Text(
+              'No one-off blocked dates yet.',
+              style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+              textAlign: TextAlign.center,
+            ),
+          )
+        else
+          for (final e in exceptions)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: BlockCard(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        DateFormat('EEEE, d MMM y').format(e.date),
+                        style: BlockType.body,
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () async {
+                        final err = await ref
+                            .read(availabilityMutationsProvider.notifier)
+                            .deleteException(e.id);
+                        if (!context.mounted) return;
+                        if (err != null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Failed: $err')),
+                          );
+                        }
+                      },
+                      icon: const Icon(
+                        Icons.close,
+                        color: BlockColors.danger,
+                        size: 20,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        const SizedBox(height: 4),
+        BlockButton(
+          label: '+ Add date',
+          kind: BlockButtonKind.secondary,
+          onPressed: () => _openAddDate(context, ref),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _openAddDate(BuildContext context, WidgetRef ref) async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: DateTime(now.year, now.month - 1),
+      lastDate: DateTime(now.year + 2),
+    );
+    if (picked == null || !context.mounted) return;
+    final err = await ref
+        .read(availabilityMutationsProvider.notifier)
+        .addException(picked);
+    if (!context.mounted) return;
+    if (err != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed: $err')),
+      );
+    }
   }
 }
 

--- a/mobile/test/availability_screen_test.dart
+++ b/mobile/test/availability_screen_test.dart
@@ -50,7 +50,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('AVAILABILITY'), findsOneWidget);
-      // Calendar block count is timeoff days + exceptions (3 + 1 + 1 = 5).
+      // BLOCKED header counts every day in blockedDays — 3 days from the
+      // 2-day timeoff range (May 12-13) + 1 day from the single-day timeoff
+      // (May 27) + 1 exception (Jul 4) = 4 distinct blocked days.
+      expect(find.text('4 BLOCKED'), findsOneWidget);
       expect(find.text('Family trip'), findsOneWidget);
       // rrule preset matched and shown by friendly label.
       expect(find.text('Every Monday'), findsOneWidget);
@@ -58,6 +61,39 @@ void main() {
       expect(find.textContaining('Jul 2026'), findsOneWidget);
       // No COMING SOON anywhere.
       expect(find.text('COMING SOON'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'BLOCKED header counts exception-only days (no time-off)',
+    (tester) async {
+      // Regression for Codex review on PR 8.9: header used to bind to
+      // `entries.length`, which would say "0 BLOCKED" for a volunteer with
+      // only single-date exceptions even though the calendar shaded those
+      // days. Header must derive from blockedDays.
+      final exceptionsOnly = AvailabilityData(
+        entries: const [],
+        exceptions: [
+          ExceptionEntry(id: 1, date: DateTime(2026, 7, 4)),
+          ExceptionEntry(id: 2, date: DateTime(2026, 7, 11)),
+          ExceptionEntry(id: 3, date: DateTime(2026, 7, 18)),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            availabilityProvider.overrideWith((ref) async => exceptionsOnly),
+            availabilityRruleProvider.overrideWith((ref) async => null),
+          ],
+          child: MaterialApp(
+            theme: buildBlockMonoTheme(),
+            home: const AvailabilityScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('3 BLOCKED'), findsOneWidget);
+      expect(find.text('0 BLOCKED'), findsNothing);
     },
   );
 

--- a/mobile/test/availability_screen_test.dart
+++ b/mobile/test/availability_screen_test.dart
@@ -1,6 +1,6 @@
-// Availability screen widget test — overrides availabilityProvider with
-// fake data, asserts the calendar grid + time-off list + the
-// "coming soon" recurring-rules panel render.
+// Availability screen widget test — covers the calendar grid + time-off
+// list (Sprint 7.5) and the rrule editor + one-off exceptions card
+// (Sprint 8.9).
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,50 +9,66 @@ import 'package:signupflow_mobile/features/volunteer/availability_provider.dart'
 import 'package:signupflow_mobile/features/volunteer/availability_screen.dart';
 import 'package:signupflow_mobile/theme/theme.dart';
 
-AvailabilityData _data() => AvailabilityData(entries: [
-      TimeOffEntry(
-        id: 1,
-        startDate: DateTime(2026, 5, 12),
-        endDate: DateTime(2026, 5, 13),
-        reason: 'Family trip',
-      ),
-      TimeOffEntry(
-        id: 2,
-        startDate: DateTime(2026, 5, 27),
-        endDate: DateTime(2026, 5, 27),
-      ),
-    ]);
-
-void main() {
-  testWidgets('availability renders calendar + time-off list + rrule callout',
-      (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          availabilityProvider.overrideWith((ref) async => _data()),
-        ],
-        child: MaterialApp(
-          theme: buildBlockMonoTheme(),
-          home: const AvailabilityScreen(),
+AvailabilityData _data() => AvailabilityData(
+      entries: [
+        TimeOffEntry(
+          id: 1,
+          startDate: DateTime(2026, 5, 12),
+          endDate: DateTime(2026, 5, 13),
+          reason: 'Family trip',
         ),
-      ),
+        TimeOffEntry(
+          id: 2,
+          startDate: DateTime(2026, 5, 27),
+          endDate: DateTime(2026, 5, 27),
+        ),
+      ],
+      exceptions: [
+        ExceptionEntry(id: 10, date: DateTime(2026, 7, 4)),
+      ],
     );
 
-    await tester.pumpAndSettle();
+void main() {
+  testWidgets(
+    'availability renders calendar + time-off list + rrule editor + exceptions',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            availabilityProvider.overrideWith((ref) async => _data()),
+            availabilityRruleProvider.overrideWith(
+              (ref) async => 'FREQ=WEEKLY;BYDAY=MO',
+            ),
+          ],
+          child: MaterialApp(
+            theme: buildBlockMonoTheme(),
+            home: const AvailabilityScreen(),
+          ),
+        ),
+      );
 
-    expect(find.text('AVAILABILITY'), findsOneWidget);
-    expect(find.text('2 BLOCKED'), findsOneWidget);
-    expect(find.text('Family trip'), findsOneWidget);
-    expect(find.text('COMING SOON'), findsOneWidget);
-  });
+      await tester.pumpAndSettle();
 
-  testWidgets('empty time-off shows the empty state copy', (tester) async {
+      expect(find.text('AVAILABILITY'), findsOneWidget);
+      // Calendar block count is timeoff days + exceptions (3 + 1 + 1 = 5).
+      expect(find.text('Family trip'), findsOneWidget);
+      // rrule preset matched and shown by friendly label.
+      expect(find.text('Every Monday'), findsOneWidget);
+      // Exception date renders the formatted full date.
+      expect(find.textContaining('Jul 2026'), findsOneWidget);
+      // No COMING SOON anywhere.
+      expect(find.text('COMING SOON'), findsNothing);
+    },
+  );
+
+  testWidgets('empty rrule shows "no recurring rule yet" copy', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           availabilityProvider.overrideWith(
             (ref) async => const AvailabilityData(entries: []),
           ),
+          availabilityRruleProvider.overrideWith((ref) async => null),
         ],
         child: MaterialApp(
           theme: buildBlockMonoTheme(),
@@ -64,6 +80,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('No time off scheduled'), findsOneWidget);
-    expect(find.text('0 BLOCKED'), findsOneWidget);
+    expect(find.text('No recurring rule yet.'), findsOneWidget);
+    expect(find.textContaining('No one-off blocked dates'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Replaces the COMING SOON callout in the volunteer Availability screen with two real sections that wrap the new endpoints from Phase A.

## What's new

- **Recurring rules** — friendly preset picker ("Every Monday", "Every Friday", "Every weekend", "Every other Friday", "First Sunday of month") that builds the rrule string, plus a custom-rrule text field for power users. Wired to `AvailabilityApi.setRrule` / `clearRrule` (Sprint 8.3 / #70).
- **One-off blocked dates** — list with `+ Add date` sheet and per-row delete. Wired to `AvailabilityApi.{listExceptions, addException, deleteException}` (Sprint 8.2 / #69). Exception dates also light up the calendar grid alongside time-off ranges.

## Files

- `mobile/lib/features/volunteer/availability_provider.dart` — `availabilityProvider` now folds exceptions into `AvailabilityData.blockedDays`. New `availabilityRruleProvider` + `addException` / `deleteException` / `setRrule` / `clearRrule` mutations + `kRrulePresets`.
- `mobile/lib/features/volunteer/availability_screen.dart` — Removed COMING SOON `BlockCard`; added `_RruleCard` + `_ExceptionsCard` widgets.
- `mobile/test/availability_screen_test.dart` — updated to assert the new sections render under provider overrides.

## Verification

- `flutter analyze` — 0 issues.
- `flutter test` — 39/39 green.

Spec: `specs/023-sprint-8-completion/spec.md` Phase D, PR 8.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)