### PR TITLE
Mobile Volunteer Inbox tab (Sprint 8 PR 8.10)

### DIFF
--- a/mobile/lib/features/volunteer/inbox_provider.dart
+++ b/mobile/lib/features/volunteer/inbox_provider.dart
@@ -1,0 +1,118 @@
+// Inbox feed for volunteers — wraps NotificationsApi.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+
+class InboxRow {
+  const InboxRow({
+    required this.id,
+    required this.type,
+    required this.status,
+    required this.createdAt,
+    this.openedAt,
+    this.eventId,
+  });
+  final int id;
+  final String type;
+  final String status;
+  final DateTime createdAt;
+  final DateTime? openedAt;
+  final String? eventId;
+
+  bool get isUnread => openedAt == null;
+
+  /// Human-readable subject. The backend stores no rendered subject yet
+  /// (templates are rendered on send), so we synthesise one from the type.
+  String get subject {
+    switch (type) {
+      case 'assignment':
+        return 'You were assigned to an event';
+      case 'reminder':
+        return 'Reminder: upcoming event';
+      case 'update':
+        return 'Event details updated';
+      case 'cancellation':
+        return 'Event was cancelled';
+      case 'digest_daily':
+        return 'Daily schedule digest';
+      case 'digest_weekly':
+        return 'Weekly schedule digest';
+      case 'admin_summary':
+        return 'Weekly stats summary';
+      default:
+        return type;
+    }
+  }
+}
+
+class InboxData {
+  const InboxData({required this.rows, required this.unread});
+  final List<InboxRow> rows;
+  final int unread;
+}
+
+final inboxProvider = FutureProvider<InboxData>((ref) async {
+  final auth = ref.watch(authProvider);
+  final orgId = auth.orgId;
+  if (orgId == null) {
+    return const InboxData(rows: [], unread: 0);
+  }
+  final client = ref.watch(signupflowApiProvider);
+
+  final listRes = await client.getNotificationsApi().listNotifications(orgId: orgId);
+  final body = listRes.data;
+  final rows = <InboxRow>[];
+  if (body != null) {
+    for (final n in body.notifications) {
+      rows.add(_fromApi(n));
+    }
+  }
+
+  final countRes = await client.getNotificationsApi().getUnreadCount();
+  var unread = 0;
+  final raw = countRes.data;
+  if (raw != null) {
+    final asMap = raw.asMap;
+    final v = asMap['unread'];
+    if (v is num) unread = v.toInt();
+  }
+
+  return InboxData(rows: rows, unread: unread);
+});
+
+InboxRow _fromApi(api.NotificationResponse n) => InboxRow(
+      id: n.id,
+      type: n.type,
+      status: n.status,
+      createdAt: n.createdAt,
+      openedAt: n.openedAt,
+      eventId: n.eventId,
+    );
+
+class InboxMutationsController extends Notifier<bool> {
+  @override
+  bool build() => false; // busy flag
+
+  Future<String?> markRead(int notificationId) async {
+    state = true;
+    try {
+      await ref
+          .read(signupflowApiProvider)
+          .getNotificationsApi()
+          .markNotificationRead(notificationId: notificationId);
+      ref.invalidate(inboxProvider);
+      state = false;
+      return null;
+    } on Exception catch (e) {
+      state = false;
+      return e.toString();
+    }
+  }
+}
+
+final inboxMutationsProvider =
+    NotifierProvider<InboxMutationsController, bool>(
+  InboxMutationsController.new,
+);

--- a/mobile/lib/features/volunteer/inbox_provider.dart
+++ b/mobile/lib/features/volunteer/inbox_provider.dart
@@ -12,6 +12,7 @@ class InboxRow {
     required this.status,
     required this.createdAt,
     this.openedAt,
+    this.clickedAt,
     this.eventId,
   });
   final int id;
@@ -19,9 +20,15 @@ class InboxRow {
   final String status;
   final DateTime createdAt;
   final DateTime? openedAt;
+  final DateTime? clickedAt;
   final String? eventId;
 
-  bool get isUnread => openedAt == null;
+  /// Mirrors the backend unread predicate exactly:
+  /// ``Notification.opened_at IS NULL AND Notification.clicked_at IS NULL``
+  /// (api/routers/notifications.py:get_unread_count). A notification that
+  /// was clicked but never explicitly opened still counts as read so that
+  /// the row state agrees with the tab badge.
+  bool get isUnread => openedAt == null && clickedAt == null;
 
   /// Human-readable subject. The backend stores no rendered subject yet
   /// (templates are rendered on send), so we synthesise one from the type.
@@ -88,6 +95,7 @@ InboxRow _fromApi(api.NotificationResponse n) => InboxRow(
       status: n.status,
       createdAt: n.createdAt,
       openedAt: n.openedAt,
+      clickedAt: n.clickedAt,
       eventId: n.eventId,
     );
 

--- a/mobile/lib/features/volunteer/inbox_screen.dart
+++ b/mobile/lib/features/volunteer/inbox_screen.dart
@@ -1,14 +1,150 @@
+// Volunteer Inbox — Sprint 8.10.
+// Replaces the StubScreen with a real list against /notifications.
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:signupflow_mobile/features/volunteer/inbox_provider.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/components.dart';
+import 'package:signupflow_mobile/theme/typography.dart';
 
-import 'package:signupflow_mobile/shared/widgets/stub_screen.dart';
-
-class InboxScreen extends StatelessWidget {
+class InboxScreen extends ConsumerWidget {
   const InboxScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const StubScreen(
-        title: 'Inbox',
-        endpoint: 'no /notifications endpoint yet — DEFERRED FROM MVP',
-        willLandIn: 'TBD (backend decision)',
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncData = ref.watch(inboxProvider);
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const PageTitle('Inbox'),
+            Expanded(
+              child: asyncData.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'Failed to load: $e',
+                      style: BlockType.bodySm,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                data: (data) => _Body(data: data),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.data});
+  final InboxData data;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (data.rows.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'No notifications yet.\n\nWhen you get assigned to an event, '
+            'or when a schedule changes, a row will appear here.',
+            style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+            textAlign: TextAlign.center,
+          ),
+        ),
       );
+    }
+    return RefreshIndicator(
+      onRefresh: () async {
+        ref.invalidate(inboxProvider);
+        await ref.read(inboxProvider.future);
+      },
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+        itemCount: data.rows.length,
+        itemBuilder: (_, i) => _Row(row: data.rows[i]),
+      ),
+    );
+  }
+}
+
+class _Row extends ConsumerWidget {
+  const _Row({required this.row});
+  final InboxRow row;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final unreadDot = row.isUnread
+        ? Container(
+            width: 8,
+            height: 8,
+            margin: const EdgeInsets.only(right: 8, top: 6),
+            decoration: const BoxDecoration(
+              color: BlockColors.accent,
+              shape: BoxShape.circle,
+            ),
+          )
+        : const SizedBox(width: 16);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: InkWell(
+          onTap: () async {
+            if (row.isUnread) {
+              await ref.read(inboxMutationsProvider.notifier).markRead(row.id);
+            }
+            if (!context.mounted) return;
+            if (row.eventId != null) {
+              // The only detail route mobile has today is /v/assignment/:id,
+              // and notifications carry an event_id (not assignment_id).
+              // Bouncing to the schedule tab is the most useful destination
+              // for v1 — the user can find the event there.
+              context.go('/v/schedule');
+            }
+          },
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              unreadDot,
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      row.subject,
+                      style: BlockType.body.copyWith(
+                        fontWeight:
+                            row.isUnread ? FontWeight.w600 : FontWeight.w400,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      DateFormat('d MMM y · HH:mm').format(row.createdAt),
+                      style:
+                          BlockType.bodySm.copyWith(color: BlockColors.ink2),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                row.type.toUpperCase(),
+                style: BlockType.monoLabel.copyWith(fontSize: 9),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/lib/features/volunteer/shell.dart
+++ b/mobile/lib/features/volunteer/shell.dart
@@ -1,17 +1,23 @@
-// Volunteer 3-tab shell: Schedule / Avail / Profile.
-// Inbox is reachable only via deep-link or future notification dispatch —
-// it's not in the tab bar (deferred from MVP per spec 022).
+// Volunteer 4-tab shell: Schedule / Avail / Inbox / Profile.
+// Inbox got re-added in Sprint 8.10 once /notifications was registered.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:signupflow_mobile/features/volunteer/inbox_provider.dart';
 import 'package:signupflow_mobile/theme/colors.dart';
 
-class VolunteerShell extends StatelessWidget {
+class VolunteerShell extends ConsumerWidget {
   const VolunteerShell({required this.child, super.key});
   final Widget child;
 
-  static const _routes = ['/v/schedule', '/v/availability', '/v/profile'];
+  static const _routes = [
+    '/v/schedule',
+    '/v/availability',
+    '/v/inbox',
+    '/v/profile',
+  ];
 
   int _indexOf(String location) {
     for (var i = 0; i < _routes.length; i++) {
@@ -21,21 +27,75 @@ class VolunteerShell extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final location = GoRouterState.of(context).uri.toString();
     final idx = _indexOf(location);
+    final unread = ref.watch(inboxProvider).whenOrNull(data: (d) => d.unread) ?? 0;
     return Scaffold(
       backgroundColor: BlockColors.bgApp,
       body: child,
       bottomNavigationBar: BottomNavigationBar(
+        type: BottomNavigationBarType.fixed,
         currentIndex: idx,
         onTap: (i) => context.go(_routes[i]),
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.calendar_today_outlined), label: 'SCHEDULE'),
-          BottomNavigationBarItem(icon: Icon(Icons.event_available_outlined), label: 'AVAIL'),
-          BottomNavigationBarItem(icon: Icon(Icons.person_outline), label: 'PROFILE'),
+        items: [
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today_outlined),
+            label: 'SCHEDULE',
+          ),
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.event_available_outlined),
+            label: 'AVAIL',
+          ),
+          BottomNavigationBarItem(
+            icon: _InboxIcon(unread: unread),
+            label: 'INBOX',
+          ),
+          const BottomNavigationBarItem(
+            icon: Icon(Icons.person_outline),
+            label: 'PROFILE',
+          ),
         ],
       ),
+    );
+  }
+}
+
+class _InboxIcon extends StatelessWidget {
+  const _InboxIcon({required this.unread});
+  final int unread;
+
+  @override
+  Widget build(BuildContext context) {
+    if (unread == 0) {
+      return const Icon(Icons.inbox_outlined);
+    }
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        const Icon(Icons.inbox_outlined),
+        Positioned(
+          right: -4,
+          top: -2,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            decoration: BoxDecoration(
+              color: BlockColors.accent,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            constraints: const BoxConstraints(minWidth: 14, minHeight: 14),
+            child: Text(
+              unread > 9 ? '9+' : '$unread',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 9,
+                fontWeight: FontWeight.w700,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/inbox_test.dart
+++ b/mobile/test/inbox_test.dart
@@ -1,0 +1,68 @@
+// Inbox screen widget test — overrides inboxProvider with fake rows
+// and asserts the empty + populated states render.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_mobile/features/volunteer/inbox_provider.dart';
+import 'package:signupflow_mobile/features/volunteer/inbox_screen.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+InboxData _withRows() => InboxData(
+      unread: 1,
+      rows: [
+        InboxRow(
+          id: 1,
+          type: 'assignment',
+          status: 'sent',
+          createdAt: DateTime(2026, 5, 7, 9, 30),
+        ),
+        InboxRow(
+          id: 2,
+          type: 'reminder',
+          status: 'opened',
+          createdAt: DateTime(2026, 5, 6, 18, 0),
+          openedAt: DateTime(2026, 5, 6, 18, 5),
+        ),
+      ],
+    );
+
+void main() {
+  testWidgets('inbox renders empty state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          inboxProvider.overrideWith(
+            (ref) async => const InboxData(rows: [], unread: 0),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const InboxScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('INBOX'), findsOneWidget);
+    expect(find.textContaining('No notifications yet'), findsOneWidget);
+  });
+
+  testWidgets('inbox renders rows with subjects + read state', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          inboxProvider.overrideWith((ref) async => _withRows()),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const InboxScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('You were assigned to an event'), findsOneWidget);
+    expect(find.text('Reminder: upcoming event'), findsOneWidget);
+    expect(find.text('ASSIGNMENT'), findsOneWidget);
+    expect(find.text('REMINDER'), findsOneWidget);
+  });
+}

--- a/mobile/test/inbox_test.dart
+++ b/mobile/test/inbox_test.dart
@@ -65,4 +65,36 @@ void main() {
     expect(find.text('ASSIGNMENT'), findsOneWidget);
     expect(find.text('REMINDER'), findsOneWidget);
   });
+
+  test('isUnread mirrors backend predicate (opened_at AND clicked_at null)',
+      () {
+    final pristine = InboxRow(
+      id: 1,
+      type: 'assignment',
+      status: 'sent',
+      createdAt: DateTime(2026, 5, 7),
+    );
+    expect(pristine.isUnread, isTrue);
+
+    final opened = InboxRow(
+      id: 2,
+      type: 'assignment',
+      status: 'opened',
+      createdAt: DateTime(2026, 5, 7),
+      openedAt: DateTime(2026, 5, 7, 9),
+    );
+    expect(opened.isUnread, isFalse);
+
+    // SendGrid can land a click webhook before an open webhook, so
+    // clicked_at can be set while opened_at is still null. The backend
+    // unread count excludes such rows; the row state must agree.
+    final clickedNotOpened = InboxRow(
+      id: 3,
+      type: 'assignment',
+      status: 'clicked',
+      createdAt: DateTime(2026, 5, 7),
+      clickedAt: DateTime(2026, 5, 7, 9, 5),
+    );
+    expect(clickedNotOpened.isUnread, isFalse);
+  });
 }


### PR DESCRIPTION
Replaces the StubScreen at `/v/inbox` with a real list backed by `NotificationsApi.listNotifications` + the new mark-read endpoint from #71. Re-adds the 4th tab to the volunteer shell (it was dropped in 7.1 v2 because the backend wasn't ready).

## What's new

- **`mobile/lib/features/volunteer/inbox_provider.dart`** — `InboxRow` + `InboxData` + `inboxProvider` (lists notifications + unread count) + `inboxMutationsProvider.markRead`.
- **`mobile/lib/features/volunteer/inbox_screen.dart`** — row list with unread dot, type label, timestamp; pull-to-refresh; tap marks read and bounces to `/v/schedule` when the row has an `event_id`.
- **`mobile/lib/features/volunteer/shell.dart`** — 3 → 4 tabs. Inbox tab icon shows an unread badge ("9+" for >9 unread). Made the shell a `ConsumerWidget` so it can watch `inboxProvider` for the badge count.

## Tests

`mobile/test/inbox_test.dart` — empty state + populated state with subject mapping (assignment / reminder type → friendly subject string).

`flutter analyze` clean. 41/41 tests green.

## v1 limitation worth flagging

Notifications carry an `event_id` (not an `assignment_id`), and the only mobile detail route today is `/v/assignment/:id`. Tapping a row with `event_id` therefore bounces to `/v/schedule` rather than into a specific detail view. A future PR can add `/v/event/:id` if we want that drill-down.

Spec: `specs/023-sprint-8-completion/spec.md` Phase D, PR 8.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)