### PR TITLE
Mobile per-event Solution Review assignments (Sprint 8 PR 8.11)

### DIFF
--- a/mobile/lib/features/admin/solution_assignments_provider.dart
+++ b/mobile/lib/features/admin/solution_assignments_provider.dart
@@ -1,0 +1,23 @@
+// Per-event assignments for a solution. Sprint 8.11.
+//
+// Wraps SolutionsApi.getSolutionAssignments (now typed as
+// SolutionAssignmentsResponse thanks to Sprint 8.1 / #68).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/api/api_client.dart';
+
+final solutionAssignmentsProvider =
+    FutureProvider.family<api.SolutionAssignmentsResponse, int>(
+  (ref, solutionId) async {
+    final apiClient = ref.watch(signupflowApiProvider);
+    final res = await apiClient.getSolutionsApi().getSolutionAssignments(
+          solutionId: solutionId,
+        );
+    final body = res.data;
+    if (body == null) {
+      throw StateError('Empty /solutions/$solutionId/assignments response');
+    }
+    return body;
+  },
+);

--- a/mobile/lib/features/admin/solution_review_screen.dart
+++ b/mobile/lib/features/admin/solution_review_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/solution_assignments_provider.dart';
 import 'package:signupflow_mobile/features/admin/solver_provider.dart';
 import 'package:signupflow_mobile/theme/colors.dart';
 import 'package:signupflow_mobile/theme/components.dart';
@@ -187,15 +189,17 @@ class _Segment extends StatelessWidget {
   }
 }
 
-class _AssignmentsView extends StatelessWidget {
+class _AssignmentsView extends ConsumerWidget {
   const _AssignmentsView({required this.data});
   final SolutionDetailData data;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final created = DateFormat('EEE d MMM y · h:mm a')
         .format(data.solution.createdAt.toLocal())
         .toUpperCase();
+    final asyncAssignments =
+        ref.watch(solutionAssignmentsProvider(data.solution.id));
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -230,20 +234,144 @@ class _AssignmentsView extends StatelessWidget {
             ],
           ),
         ),
-        const MonoLabel('Per-event breakdown — coming in 7.10'),
-        BlockCard(
-          color: const Color(0xFFFFF7ED),
-          borderColor: const Color(0xFFFED7AA),
-          child: Text(
-            'Listing assignments grouped by event needs an enriched API '
-            'response (event title + assignees in one call). The current '
-            'getSolutionAssignments returns a JsonObject; rendering it '
-            'cleanly will land alongside Compare in 7.10.',
-            style: BlockType.bodySm,
+        const MonoLabel('Per-event breakdown'),
+        asyncAssignments.when(
+          loading: () => const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
           ),
+          error: (e, _) => BlockCard(
+            child: Text('Failed to load assignments: $e', style: BlockType.bodySm),
+          ),
+          data: _AssignmentsList.new,
         ),
       ],
     );
+  }
+}
+
+class _AssignmentsList extends StatelessWidget {
+  const _AssignmentsList(this.body);
+  final api.SolutionAssignmentsResponse body;
+
+  @override
+  Widget build(BuildContext context) {
+    if (body.events.isEmpty) {
+      return BlockCard(
+        child: Text(
+          'No assignments in this solution.',
+          style: BlockType.bodySm.copyWith(color: BlockColors.ink2),
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final event in body.events) _EventGroup(event: event),
+      ],
+    );
+  }
+}
+
+class _EventGroup extends StatelessWidget {
+  const _EventGroup({required this.event});
+  final api.SolutionAssignmentEntry event;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = event.eventStart;
+    final dateLabel =
+        start == null ? '' : DateFormat('EEE d MMM').format(start.toLocal());
+    final timeLabel = start == null
+        ? ''
+        : DateFormat('HH:mm').format(start.toLocal());
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: BlockCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    event.eventType ?? event.eventId,
+                    style: BlockType.subhead,
+                  ),
+                ),
+                if (timeLabel.isNotEmpty) TimeChip(timeLabel),
+              ],
+            ),
+            if (dateLabel.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text(
+                dateLabel.toUpperCase(),
+                style: BlockType.monoTiny.copyWith(fontSize: 10),
+              ),
+            ],
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final a in event.assignees) _AssigneeChip(assignee: a),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AssigneeChip extends StatelessWidget {
+  const _AssigneeChip({required this.assignee});
+  final api.SolutionAssignmentAssignee assignee;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = assignee.personName ?? assignee.personId;
+    final initials = _initials(label);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: BlockColors.bgApp,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: BlockColors.line1),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 22,
+            height: 22,
+            decoration: const BoxDecoration(
+              color: BlockColors.ink1,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              initials,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(label, style: BlockType.bodySm),
+        ],
+      ),
+    );
+  }
+
+  static String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.isEmpty || parts.first.isEmpty) return '?';
+    if (parts.length == 1) return parts.first[0].toUpperCase();
+    return (parts.first[0] + parts.last[0]).toUpperCase();
   }
 }
 

--- a/mobile/test/solver_screen_test.dart
+++ b/mobile/test/solver_screen_test.dart
@@ -6,10 +6,46 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/solution_assignments_provider.dart';
 import 'package:signupflow_mobile/features/admin/solution_review_screen.dart';
 import 'package:signupflow_mobile/features/admin/solver_provider.dart';
 import 'package:signupflow_mobile/features/admin/solver_screen.dart';
 import 'package:signupflow_mobile/theme/theme.dart';
+
+api.SolutionAssignmentsResponse _emptyAssignments(int id) {
+  return (api.SolutionAssignmentsResponseBuilder()
+        ..solutionId = id
+        ..events = ListBuilder<api.SolutionAssignmentEntry>()
+        ..totalAssignments = 0)
+      .build();
+}
+
+api.SolutionAssignmentsResponse _twoAssignees(int id) {
+  return (api.SolutionAssignmentsResponseBuilder()
+        ..solutionId = id
+        ..totalAssignments = 2
+        ..events = ListBuilder<api.SolutionAssignmentEntry>([
+          (api.SolutionAssignmentEntryBuilder()
+                ..eventId = 'evt-1'
+                ..eventType = 'Sunday Service'
+                ..eventStart = DateTime(2026, 5, 17, 10).toUtc()
+                ..eventEnd = DateTime(2026, 5, 17, 11, 30).toUtc()
+                ..assignees = ListBuilder<api.SolutionAssignmentAssignee>([
+                  (api.SolutionAssignmentAssigneeBuilder()
+                        ..personId = 'p1'
+                        ..personName = 'Alice Johnson'
+                        ..assignmentId = 1)
+                      .build(),
+                  (api.SolutionAssignmentAssigneeBuilder()
+                        ..personId = 'p2'
+                        ..personName = 'Bob Lee'
+                        ..assignmentId = 2)
+                      .build(),
+                ]))
+              .build(),
+        ]))
+      .build();
+}
 
 void main() {
   testWidgets('solver screen renders date range + mode + run button',
@@ -64,6 +100,8 @@ void main() {
       ProviderScope(
         overrides: [
           solutionDetailProvider(142).overrideWith((ref) async => data),
+          solutionAssignmentsProvider(142)
+              .overrideWith((ref) async => _emptyAssignments(142)),
         ],
         child: MaterialApp(
           theme: buildBlockMonoTheme(),
@@ -117,6 +155,8 @@ void main() {
       ProviderScope(
         overrides: [
           solutionDetailProvider(142).overrideWith((ref) async => data),
+          solutionAssignmentsProvider(142)
+              .overrideWith((ref) async => _emptyAssignments(142)),
         ],
         child: MaterialApp(
           theme: buildBlockMonoTheme(),
@@ -133,5 +173,47 @@ void main() {
     expect(find.text('4'), findsOneWidget);     // movesFromPublished KPI
     expect(find.text('3'), findsOneWidget);     // max/person KPI
     expect(find.text('0.42'), findsOneWidget);  // stdev
+  });
+
+  testWidgets('solution review ASSIGNMENTS segment groups assignees per event',
+      (tester) async {
+    final solution = (api.SolutionResponseBuilder()
+          ..id = 142
+          ..orgId = 'hcc'
+          ..solveMs = 274
+          ..hardViolations = 0
+          ..softScore = 1.5
+          ..healthScore = 98
+          ..isPublished = false
+          ..assignmentCount = 2
+          ..createdAt = DateTime(2026, 5, 7, 14, 14).toUtc()
+          ..metrics = MapBuilder<String, JsonObject?>())
+        .build();
+    final data = SolutionDetailData(solution: solution, stats: null);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          solutionDetailProvider(142).overrideWith((ref) async => data),
+          solutionAssignmentsProvider(142)
+              .overrideWith((ref) async => _twoAssignees(142)),
+        ],
+        child: MaterialApp(
+          theme: buildBlockMonoTheme(),
+          home: const SolutionReviewScreen(solutionId: '142'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Event card renders with assignees grouped under it.
+    expect(find.text('Sunday Service'), findsOneWidget);
+    expect(find.text('Alice Johnson'), findsOneWidget);
+    expect(find.text('Bob Lee'), findsOneWidget);
+    // Initials chip shows "AJ" / "BL".
+    expect(find.text('AJ'), findsOneWidget);
+    expect(find.text('BL'), findsOneWidget);
+    // Old "coming in 7.10" copy is gone.
+    expect(find.text('Per-event breakdown — coming in 7.10'), findsNothing);
   });
 }


### PR DESCRIPTION
Replaces the "Per-event breakdown — coming in 7.10" callout in the admin Solution Review screen with a real grouped list:

- Per-event card: event title + start-time chip + date label.
- Inside each card: per-assignee chips with initial-circle avatar.

Backed by the typed `SolutionAssignmentsResponse` from Sprint 8.1 (#68), served via the new `solutionAssignmentsProvider` (`FutureProvider.family<int>`).

## Files

- **`mobile/lib/features/admin/solution_assignments_provider.dart`** (new) — thin wrapper over `SolutionsApi.getSolutionAssignments`.
- **`mobile/lib/features/admin/solution_review_screen.dart`** — `_AssignmentsView` is now a `ConsumerWidget`, watches the new provider, renders empty / loading / error / data states. New `_EventGroup` + `_AssigneeChip` widgets; initials computed in-place.
- **`mobile/test/solver_screen_test.dart`** — new test asserting per-event grouping + assignee initials. Existing tests now override `solutionAssignmentsProvider` with empty data so they don't hit the network.

`flutter analyze` clean. 40/40 tests green.

Spec: `specs/023-sprint-8-completion/spec.md` Phase D, PR 8.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)