### PR TITLE
Sprint 8 close: TestFlight build #438 + closeout doc (Sprint 9 PR 9.0)

### DIFF
--- a/mobile/TESTFLIGHT.md
+++ b/mobile/TESTFLIGHT.md
@@ -1,11 +1,18 @@
 # TestFlight Upload Runbook
 
-> Sprint 7 PR 7.11 · last step in the Flutter mobile sprint.
+> Last sprint pushed: Sprint 8 (build #438).
 >
-> The Flutter app is API-complete (Sprint 7 PR 7.0–7.10). This document is
-> the human-side runbook for getting a build onto TestFlight. It needs
-> sudo, Apple ID 2FA, and an Apple Developer account — all things this
-> agent can't do.
+> The Flutter app is API-complete (Sprint 7) + auth/feature complete
+> (Sprint 8). This document is the human-side runbook for getting a
+> build onto TestFlight. It needs sudo, Apple ID 2FA, and an Apple
+> Developer account.
+
+## Build history
+
+| Build | Sprint | Changelog |
+|-------|--------|-----------|
+| #425  | Sprint 7 | Volunteer journey + admin solver flow |
+| #438  | Sprint 8 | Auth (signup/invitation/reset) + every COMING SOON closed (availability rrule + exceptions, volunteer Inbox, per-event Solution Review) |
 
 ---
 
@@ -93,7 +100,7 @@ If multiple machines will build, set up `fastlane match` against a private git r
 
 ```bash
 cd mobile
-bundle exec fastlane beta changelog:"Volunteer journey + admin solver flow"
+bundle exec fastlane beta changelog:"Sprint 8 — auth + feature closeout"
 ```
 
 What this does:

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -14,11 +14,19 @@ platform :ios do
   lane :beta do |options|
     flutter_root = File.expand_path("..", __dir__)
 
+    # `flutter` may live outside the default PATH (e.g. ~/Projects/flutter/bin
+    # on this dev machine). Capture its directory now while the outer shell
+    # has it; we'll re-inject it into the `with_clean_env` subshell PATH.
+    flutter_bin = `which flutter`.strip
+    UI.user_error!("flutter not on PATH — install or `export PATH=/path/to/flutter/bin:$PATH`") if flutter_bin.empty?
+    flutter_dir = File.dirname(flutter_bin)
+
     # 1. Make sure CocoaPods are up to date (flutter_secure_storage etc.).
     # `pod` uses Homebrew's Ruby; if we leave BUNDLE_GEMFILE set, its bundler
     # tries to materialize *our* Gemfile.lock against a different Ruby ABI
     # and explodes. Clear bundler env vars for the inner shell.
     Bundler.with_clean_env do
+      ENV["PATH"] = "#{flutter_dir}:#{ENV['PATH']}"
       sh("cd #{flutter_root}/ios && pod install --repo-update")
     end
 
@@ -29,6 +37,7 @@ platform :ios do
     # 3. Build the signed ipa via flutter. `flutter build ipa` shells out
     # to xcodebuild + pod, which need a clean bundler env (see step 1).
     Bundler.with_clean_env do
+      ENV["PATH"] = "#{flutter_dir}:#{ENV['PATH']}"
       sh(
         "cd #{flutter_root} && flutter build ipa " \
         "--release " \
@@ -69,7 +78,11 @@ platform :ios do
   desc "Local-only: build the ipa without uploading (smoke test the build)"
   lane :build_only do
     flutter_root = File.expand_path("..", __dir__)
+    flutter_bin = `which flutter`.strip
+    UI.user_error!("flutter not on PATH") if flutter_bin.empty?
+    flutter_dir = File.dirname(flutter_bin)
     Bundler.with_clean_env do
+      ENV["PATH"] = "#{flutter_dir}:#{ENV['PATH']}"
       sh("cd #{flutter_root}/ios && pod install --repo-update")
       sh(
         "cd #{flutter_root} && flutter build ipa " \

--- a/specs/023-sprint-8-completion/spec.md
+++ b/specs/023-sprint-8-completion/spec.md
@@ -252,3 +252,41 @@ Sprint close (8.12):
 - **`org_id` field on the create-org form** — slug the user types (must be unique) or auto-generated from the org name? Defer the decision into 8.6 implementation; either is fine.
 - **Invitation deep-link delivery** — SendGrid is off, so the invitation email never goes out. PR 8.7 includes a manual-token-paste affordance on the login screen so the flow is testable end-to-end without email.
 - **`notification_reads` migration on prod** — Alembic migration is additive (new table, no existing-row rewrite); safe to roll forward.
+
+---
+
+## Closeout (2026-05-08)
+
+Sprint 8 shipped 12 PRs to main:
+
+| PR | Sprint task | Status |
+|----|----|----|
+| #64 | 8.0 Spec doc (this file) | merged |
+| #65 | 8.6 Mobile create-org signup flow | merged |
+| #66 | 8.7 Mobile invitation accept screen | merged |
+| #67 | 8.8 Mobile forgot + reset password screens | merged |
+| #68 | 8.1 Backend — typed + event-grouped /solutions/{id}/assignments | merged |
+| #69 | 8.2 Backend — /availability/{person_id}/exceptions CRUD | merged |
+| #70 | 8.3 Backend — /availability/{person_id}/rrule CRUD | merged |
+| #71 | 8.4 Backend — register /notifications router + mark-read + unread-count | merged |
+| #72 | 8.5 Mobile codegen refresh against new endpoints | merged |
+| #73 | 8.9 Mobile availability rrule editor + single-date exceptions UI | merged |
+| #74 | 8.10 Mobile Volunteer Inbox tab (re-added 4th tab) | merged |
+| #75 | 8.11 Mobile per-event Solution Review assignments | merged |
+
+Plus #63 (post-7.11 fastlane fixes for the iCloud xattr / simulator codesign issues that surfaced during 8.0 setup).
+
+### TestFlight build
+
+**Build #438** uploaded 2026-05-08 with changelog `"Sprint 8 — auth + feature closeout"`. Available at App Store Connect → SignUpFlow → TestFlight.
+
+The fastlane lane needed a small fix (rolled into PR 9.0): `Bundler.with_clean_env` was stripping `flutter` from PATH on this dev machine where Flutter lives at `~/Projects/flutter/bin`. Fastfile now captures Flutter's directory before the clean-env block and re-injects it.
+
+### What's still deferred (Sprint 9 + Sprint 10)
+
+- **Token refresh** (24h re-login still needed — Sprint 9 PRs 9.3 + 9.4)
+- **Real SendGrid sending** (Sprint 9 PRs 9.1 + 9.2)
+- **Android target** (Sprint 9 PRs 9.5 / 9.6 / 9.7)
+- **Dark mode** (Sprint 10)
+- **APNS / FCM push** (Sprint 10 — Inbox is poll-based today)
+- **Solution Review live refresh** (Sprint 10 — pull-to-refresh covers v1)


### PR DESCRIPTION
Sprint 8 close. Uploaded build #438 to TestFlight on 2026-05-08 with changelog `"Sprint 8 — auth + feature closeout"`. App Store Connect → SignUpFlow → TestFlight should show it after Apple's processing (~5-15 min).

## Fastfile fix (the only code change)

`Bundler.with_clean_env` was stripping `flutter` from PATH on this dev machine (Flutter lives at `~/Projects/flutter/bin`, not on default PATH). Fastfile now captures Flutter's directory via `which flutter` before the clean-env block and re-injects it into `ENV["PATH"]` inside. Same fix applied to both the `:beta` and `:build_only` lanes.

## Docs

- `mobile/TESTFLIGHT.md` — build-history table now lists #425 (Sprint 7) + #438 (Sprint 8); per-release changelog example updated.
- `specs/023-sprint-8-completion/spec.md` — appended a closeout section listing all 12 Sprint 8 PRs (#64-#75) + #63 fastlane fix + build #438 + Sprint 9/10 deferred list.

## What this PR does NOT include

- No behavior change to the app itself; build #438 is just `main` packaged for TestFlight.
- No new features (those start in PR 9.1 — `send_password_reset_email`).

Spec: `specs/023-sprint-8-completion/spec.md` Closeout, mapped to Sprint 9 plan as PR 9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)