### PR TITLE
Backend: send_password_reset_email + wire into forgot-password (Sprint 9 PR 9.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,11 @@ LOG_LEVEL=INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 # Feature Flags
 RATE_LIMITING_ENABLED=true
-EMAIL_ENABLED=true
+# Email is disabled by default. Flip to true (and configure SendGrid or SMTP
+# credentials) to opt into real transactional sends — leaving this at "false"
+# keeps password-reset and other email-bearing endpoints from queuing real
+# SMTP requests against deployments that lack credentials.
+EMAIL_ENABLED=false
 SMS_ENABLED=true
 SESSION_TTL_HOURS=24
 

--- a/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
+++ b/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
@@ -1,7 +1,7 @@
 """add_password_reset_tokens_table
 
 Revision ID: b4e6f8a2c5d3
-Revises: cf7914ee40c0
+Revises: a3c5d7e9b1f2
 Create Date: 2026-05-08 16:55:00.000000
 
 Replaces the in-memory reset_tokens dict in api/routers/password_reset.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "b4e6f8a2c5d3"
-down_revision: str | Sequence[str] | None = "cf7914ee40c0"
+down_revision: str | Sequence[str] | None = "a3c5d7e9b1f2"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
+++ b/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
@@ -1,0 +1,58 @@
+"""add_password_reset_tokens_table
+
+Revision ID: b4e6f8a2c5d3
+Revises: cf7914ee40c0
+Create Date: 2026-05-08 16:55:00.000000
+
+Replaces the in-memory reset_tokens dict in api/routers/password_reset.py
+with a DB-backed table so reset links survive multi-worker deployments.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b4e6f8a2c5d3"
+down_revision: str | Sequence[str] | None = "cf7914ee40c0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("token", sa.String(), primary_key=True),
+        sa.Column(
+            "person_id",
+            sa.String(),
+            sa.ForeignKey("people.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "idx_password_reset_tokens_person_id",
+        "password_reset_tokens",
+        ["person_id"],
+    )
+    op.create_index(
+        "idx_password_reset_tokens_expires_at",
+        "password_reset_tokens",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_password_reset_tokens_expires_at",
+        table_name="password_reset_tokens",
+    )
+    op.drop_index(
+        "idx_password_reset_tokens_person_id",
+        table_name="password_reset_tokens",
+    )
+    op.drop_table("password_reset_tokens")

--- a/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
+++ b/alembic/versions/b4e6f8a2c5d3_add_password_reset_tokens_table.py
@@ -23,7 +23,8 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.create_table(
         "password_reset_tokens",
-        sa.Column("token", sa.String(), primary_key=True),
+        # Stores SHA-256 digest of the emailed token, not the raw token.
+        sa.Column("token_hash", sa.String(), primary_key=True),
         sa.Column(
             "person_id",
             sa.String(),

--- a/api/models.py
+++ b/api/models.py
@@ -203,7 +203,11 @@ class PasswordResetToken(Base):
 
     __tablename__ = "password_reset_tokens"
 
-    token = Column(String, primary_key=True)
+    # Stores the SHA-256 digest of the emailed bearer token, not the raw
+    # token itself. A read of this table (DB dump, backup, replica leak)
+    # therefore cannot be used to redeem an outstanding reset link —
+    # the attacker would need the original urlsafe token from the email.
+    token_hash = Column(String, primary_key=True)
     person_id = Column(String, ForeignKey("people.id", ondelete="CASCADE"), nullable=False)
     expires_at = Column(DateTime, nullable=False)
     created_at = Column(DateTime, default=utcnow, nullable=False)

--- a/api/models.py
+++ b/api/models.py
@@ -192,6 +192,31 @@ class Person(Base):
     )
 
 
+class PasswordResetToken(Base):
+    """One-time-use password-reset token, persisted across workers.
+
+    Replaces the legacy in-memory ``reset_tokens`` dict, which broke under
+    multi-worker deployments (default ``WORKERS=4``) — a token issued by
+    one worker was invisible to another, so the user's emailed reset
+    link could fail intermittently.
+    """
+
+    __tablename__ = "password_reset_tokens"
+
+    token = Column(String, primary_key=True)
+    person_id = Column(String, ForeignKey("people.id", ondelete="CASCADE"), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, default=utcnow, nullable=False)
+    used_at = Column(DateTime, nullable=True)
+
+    person = relationship("Person")
+
+    __table_args__ = (
+        Index("idx_password_reset_tokens_person_id", "person_id"),
+        Index("idx_password_reset_tokens_expires_at", "expires_at"),
+    )
+
+
 class Team(Base):
     """Team entity."""
 

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -4,7 +4,7 @@ import os
 import secrets
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
@@ -41,10 +41,35 @@ class PasswordResetConfirm(BaseModel):
     new_password: str
 
 
+def _send_reset_email_quiet(to_email: str, name: str, reset_token: str, app_url: str) -> None:
+    """Background-task wrapper around send_password_reset_email.
+
+    Swallows all exceptions: a flaky SendGrid (or any other email backend)
+    must never affect the HTTP response timing of /forgot-password, both
+    to preserve anti-enumeration guarantees and to avoid a DoS path where
+    a slow upstream blocks request handlers. Any failure is logged and
+    discarded — the reset token is already issued and the user can retry.
+    """
+    try:
+        email_service.send_password_reset_email(
+            to_email=to_email,
+            name=name,
+            reset_token=reset_token,
+            app_url=app_url,
+        )
+    except Exception:  # noqa: BLE001 — see docstring; we never want this to bubble
+        import logging
+
+        logging.getLogger("password_reset").exception(
+            "send_password_reset_email failed for %s (token still valid)", to_email
+        )
+
+
 @router.post("/forgot-password", dependencies=[Depends(rate_limit("password_reset"))])
 def request_password_reset(
     request: PasswordResetRequest,
     http_request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     """Request a password reset token.
@@ -54,6 +79,11 @@ def request_password_reset(
     NEVER returned in the response in production. Set
     `DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into
     receiving the token in the JSON body for E2E exercise.
+
+    Email send is queued via ``BackgroundTasks`` so the HTTP response
+    timing is independent of email backend latency — both for anti-
+    enumeration and to prevent slow-SMTP DoS. The reset token is issued
+    synchronously; email delivery is best-effort.
     """
     generic_response = {"message": "If the email exists, a password reset link will be sent"}
     person = db.query(Person).filter(Person.email == request.email).first()
@@ -78,11 +108,11 @@ def request_password_reset(
         "expires": datetime.now() + timedelta(hours=1),
     }
 
-    # Fire-and-forget email send. The endpoint always returns the generic
-    # response regardless of whether the email goes through (anti-enum).
-    # email_service.send_password_reset_email handles the EMAIL_ENABLED
-    # gate internally and is a no-op when disabled.
-    email_service.send_password_reset_email(
+    # Queue the email send. Starlette runs background tasks AFTER the
+    # response is sent, so HTTP timing is independent of email backend
+    # latency (anti-enumeration + anti-DoS).
+    background_tasks.add_task(
+        _send_reset_email_quiet,
         to_email=person.email,
         name=person.name,
         reset_token=token,

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.models import AuditAction, Person
 from api.security import hash_password
+from api.services.email_service import email_service
 from api.timeutils import utcnow
 from api.utils.audit_logger import log_audit_event
 from api.utils.rate_limit_middleware import rate_limit
@@ -76,6 +77,17 @@ def request_password_reset(
         "person_id": person.id,
         "expires": datetime.now() + timedelta(hours=1),
     }
+
+    # Fire-and-forget email send. The endpoint always returns the generic
+    # response regardless of whether the email goes through (anti-enum).
+    # email_service.send_password_reset_email handles the EMAIL_ENABLED
+    # gate internally and is a no-op when disabled.
+    email_service.send_password_reset_email(
+        to_email=person.email,
+        name=person.name,
+        reset_token=token,
+        app_url=os.getenv("APP_URL", "http://localhost:8000"),
+    )
 
     if _debug_return_reset_token():
         # Test/dev affordance ONLY. Default off.

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -121,12 +121,24 @@ def request_password_reset(
     if not person:
         return generic_response
 
+    now = utcnow()
+
+    # Invalidate any prior unused reset tokens for this person before
+    # issuing a new one. Per docs/features/password-reset.md Scenario 6,
+    # a fresh /forgot-password call must render any earlier emailed link
+    # invalid — otherwise an attacker who briefly accessed the user's
+    # inbox could race them to redeem the stale link.
+    db.query(PasswordResetToken).filter(
+        PasswordResetToken.person_id == person.id,
+        PasswordResetToken.used_at.is_(None),
+    ).update({"used_at": now}, synchronize_session=False)
+
     token = secrets.token_urlsafe(32)
     db.add(
         PasswordResetToken(
             token_hash=_hash_reset_token(token),
             person_id=person.id,
-            expires_at=utcnow() + timedelta(hours=1),
+            expires_at=now + timedelta(hours=1),
         )
     )
     db.commit()
@@ -164,31 +176,47 @@ def reset_password(
 ):
     """Reset password using token.
 
-    Looks up the token in the ``password_reset_tokens`` table. Tokens are
-    one-time-use: a successful reset stamps ``used_at`` so a replay of the
-    same emailed link is rejected with the generic "invalid or expired"
-    error.
+    The token row is *claimed* with a single conditional UPDATE rather
+    than a SELECT-then-update sequence. Two concurrent /reset-password
+    submissions of the same emailed link otherwise both pass a SELECT
+    (``used_at IS NULL``) before either can stamp it, and both proceed
+    to change the password — last-write-wins semantics, not the
+    one-time-use guarantee the endpoint advertises. The atomic UPDATE
+    closes that race: at most one row transitions from NULL to a
+    timestamp, ``rowcount == 0`` for the loser.
     """
-    record = (
+    now = utcnow()
+    token_hash = _hash_reset_token(request.token)
+
+    # Atomic claim: set used_at on the row IFF it's currently unused
+    # AND not expired. Any of {wrong token, already used, expired,
+    # raced} produces rowcount == 0.
+    claimed = (
         db.query(PasswordResetToken)
-        .filter(PasswordResetToken.token_hash == _hash_reset_token(request.token))
-        .first()
+        .filter(
+            PasswordResetToken.token_hash == token_hash,
+            PasswordResetToken.used_at.is_(None),
+            PasswordResetToken.expires_at > now,
+        )
+        .update({"used_at": now}, synchronize_session=False)
     )
 
-    if record is None or record.used_at is not None:
+    if claimed == 0:
+        db.rollback()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
         )
 
-    if utcnow() > record.expires_at:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Reset token has expired",
-        )
+    # We hold the claim. Re-fetch the row to learn the person_id, then
+    # change the password — both within the same transaction so a
+    # rollback path (e.g., person missing) un-claims the token rather
+    # than burning it.
+    record = db.query(PasswordResetToken).filter(PasswordResetToken.token_hash == token_hash).one()
 
     person = db.query(Person).filter(Person.id == record.person_id).first()
     if not person:
+        db.rollback()
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User not found",
@@ -196,9 +224,7 @@ def reset_password(
 
     person.password_hash = hash_password(request.new_password)
     # Invalidate any auth tokens issued before this reset.
-    person.password_changed_at = utcnow()
-    # Mark the reset token used so it can't be replayed.
-    record.used_at = utcnow()
+    person.password_changed_at = now
 
     db.commit()
 

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -1,5 +1,6 @@
 """Password reset endpoints."""
 
+import hashlib
 import os
 import secrets
 from datetime import timedelta
@@ -20,6 +21,19 @@ from api.utils.rate_limit_middleware import rate_limit
 def _debug_return_reset_token() -> bool:
     """True iff DEBUG_RETURN_RESET_TOKEN is opted into via env. Default off."""
     return os.getenv("DEBUG_RETURN_RESET_TOKEN", "false").strip().lower() in ("1", "true", "yes")
+
+
+def _hash_reset_token(token: str) -> str:
+    """SHA-256 digest of the bearer token, used as the PK in
+    ``password_reset_tokens``. We store the digest rather than the raw
+    token so a leaked DB dump / backup / replica cannot be used to
+    redeem outstanding reset links — the attacker would still need the
+    raw token from the user's email. SHA-256 is sufficient here (no
+    bcrypt) because the token is already 256 bits of cryptographic
+    randomness from ``secrets.token_urlsafe(32)``; brute force is
+    intractable, so a slow KDF buys nothing.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -110,7 +124,7 @@ def request_password_reset(
     token = secrets.token_urlsafe(32)
     db.add(
         PasswordResetToken(
-            token=token,
+            token_hash=_hash_reset_token(token),
             person_id=person.id,
             expires_at=utcnow() + timedelta(hours=1),
         )
@@ -155,7 +169,11 @@ def reset_password(
     same emailed link is rejected with the generic "invalid or expired"
     error.
     """
-    record = db.query(PasswordResetToken).filter(PasswordResetToken.token == request.token).first()
+    record = (
+        db.query(PasswordResetToken)
+        .filter(PasswordResetToken.token_hash == _hash_reset_token(request.token))
+        .first()
+    )
 
     if record is None or record.used_at is not None:
         raise HTTPException(

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -105,7 +105,17 @@ def request_password_reset(
     synchronously; email delivery is best-effort.
     """
     generic_response = {"message": "If the email exists, a password reset link will be sent"}
-    person = db.query(Person).filter(Person.email == request.email).first()
+    # Roster-only Persons (created via /people or bulk import) live in the
+    # database without a login account — ``password_hash IS NULL``. Issuing
+    # a reset for those rows would let anyone controlling the listed email
+    # bypass invitation/onboarding and inherit the row's roles, since
+    # /reset-password writes ``password_hash`` unconditionally. Treat them
+    # like an unknown email: no token, generic response.
+    person = (
+        db.query(Person)
+        .filter(Person.email == request.email, Person.password_hash.isnot(None))
+        .first()
+    )
 
     log_audit_event(
         db,

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -2,14 +2,14 @@
 
 import os
 import secrets
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import AuditAction, Person
+from api.models import AuditAction, PasswordResetToken, Person
 from api.security import hash_password
 from api.services.email_service import email_service
 from api.timeutils import utcnow
@@ -23,9 +23,6 @@ def _debug_return_reset_token() -> bool:
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-
-# In-memory token store (in production, use Redis or database)
-reset_tokens = {}
 
 
 class PasswordResetRequest(BaseModel):
@@ -79,9 +76,13 @@ def request_password_reset(
     """Request a password reset token.
 
     Always returns the same generic message regardless of whether the email
-    exists. Audits every request. The reset token is held in-memory and is
-    NEVER returned in the response in production. Set
-    `DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into
+    exists. Audits every request. The reset token is persisted in the
+    ``password_reset_tokens`` table (see model in ``api/models.py``) so it
+    survives multi-worker deployments — the legacy in-memory dict broke
+    under the documented default ``WORKERS=4`` because the worker handling
+    ``POST /reset-password`` may differ from the one that issued the token.
+    The token is NEVER returned in the response in production. Set
+    ``DEBUG_RETURN_RESET_TOKEN=true`` in dev/test environments to opt into
     receiving the token in the JSON body for E2E exercise.
 
     Email send is queued via ``BackgroundTasks`` so the HTTP response
@@ -107,10 +108,14 @@ def request_password_reset(
         return generic_response
 
     token = secrets.token_urlsafe(32)
-    reset_tokens[token] = {
-        "person_id": person.id,
-        "expires": datetime.now() + timedelta(hours=1),
-    }
+    db.add(
+        PasswordResetToken(
+            token=token,
+            person_id=person.id,
+            expires_at=utcnow() + timedelta(hours=1),
+        )
+    )
+    db.commit()
 
     # Queue the email send. Starlette runs background tasks AFTER the
     # response is sent, so HTTP timing is independent of email backend
@@ -122,9 +127,7 @@ def request_password_reset(
     # ``.env.example`` line 133); we fall back to ``APP_URL`` only as a
     # last-ditch default so dev deploys without a frontend still produce
     # a structurally valid email.
-    web_app_url = os.getenv("FRONTEND_URL") or os.getenv(
-        "APP_URL", "http://localhost:8000"
-    )
+    web_app_url = os.getenv("FRONTEND_URL") or os.getenv("APP_URL", "http://localhost:8000")
     background_tasks.add_task(
         _send_reset_email_quiet,
         to_email=person.email,
@@ -145,38 +148,40 @@ def reset_password(
     request: PasswordResetConfirm,
     db: Session = Depends(get_db),
 ):
-    """Reset password using token."""
-    token_data = reset_tokens.get(request.token)
+    """Reset password using token.
 
-    if not token_data:
+    Looks up the token in the ``password_reset_tokens`` table. Tokens are
+    one-time-use: a successful reset stamps ``used_at`` so a replay of the
+    same emailed link is rejected with the generic "invalid or expired"
+    error.
+    """
+    record = db.query(PasswordResetToken).filter(PasswordResetToken.token == request.token).first()
+
+    if record is None or record.used_at is not None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired reset token",
         )
 
-    if datetime.now() > token_data["expires"]:
-        del reset_tokens[request.token]
+    if utcnow() > record.expires_at:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Reset token has expired",
         )
 
-    # Get person
-    person = db.query(Person).filter(Person.id == token_data["person_id"]).first()
+    person = db.query(Person).filter(Person.id == record.person_id).first()
     if not person:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User not found",
         )
 
-    # Hash new password using bcrypt (same as signup/login)
     person.password_hash = hash_password(request.new_password)
-    # Invalidate any tokens issued before this reset.
+    # Invalidate any auth tokens issued before this reset.
     person.password_changed_at = utcnow()
+    # Mark the reset token used so it can't be replayed.
+    record.used_at = utcnow()
 
     db.commit()
-
-    # Remove used token
-    del reset_tokens[request.token]
 
     return {"message": "Password reset successfully"}

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -115,12 +115,22 @@ def request_password_reset(
     # Queue the email send. Starlette runs background tasks AFTER the
     # response is sent, so HTTP timing is independent of email backend
     # latency (anti-enumeration + anti-DoS).
+    #
+    # The web fallback link in the email body must point at a host that
+    # actually serves a `GET /reset-password` page — i.e., the frontend,
+    # not the API. ``FRONTEND_URL`` is the dedicated knob (see
+    # ``.env.example`` line 133); we fall back to ``APP_URL`` only as a
+    # last-ditch default so dev deploys without a frontend still produce
+    # a structurally valid email.
+    web_app_url = os.getenv("FRONTEND_URL") or os.getenv(
+        "APP_URL", "http://localhost:8000"
+    )
     background_tasks.add_task(
         _send_reset_email_quiet,
         to_email=person.email,
         name=person.name,
         reset_token=token,
-        app_url=os.getenv("APP_URL", "http://localhost:8000"),
+        app_url=web_app_url,
     )
 
     if _debug_return_reset_token():

--- a/api/routers/password_reset.py
+++ b/api/routers/password_reset.py
@@ -49,6 +49,10 @@ def _send_reset_email_quiet(to_email: str, name: str, reset_token: str, app_url:
     to preserve anti-enumeration guarantees and to avoid a DoS path where
     a slow upstream blocks request handlers. Any failure is logged and
     discarded — the reset token is already issued and the user can retry.
+
+    The email service itself short-circuits when ``TESTING=true`` is set
+    (see ``EmailService.__init__``), so tests that don't explicitly mock
+    the service won't hang on a real SMTP retry loop.
     """
     try:
         email_service.send_password_reset_email(

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -971,6 +971,142 @@ class EmailService:
 
         return self.send_email(to_email, subject, html_content, plain_content)
 
+    def send_password_reset_email(
+        self,
+        to_email: str,
+        name: str,
+        reset_token: str,
+        app_url: str = "http://localhost:8000",
+    ) -> bool:
+        """
+        Send password-reset email with a one-hour token link.
+
+        Args:
+            to_email: Recipient email address
+            name: Recipient's display name (Person.name)
+            reset_token: Reset token from request_password_reset
+            app_url: Base application URL (used for the web fallback)
+
+        Returns:
+            True if email sent successfully, False otherwise. Also returns
+            True (no-op) when ``self.enabled`` is False — caller treats the
+            "no email service configured" case as a successful no-op so the
+            invitation/reset endpoints don't 5xx in dev.
+
+        Notes:
+            The mobile app registers the ``signupflow://`` URL scheme so the
+            primary link is a custom-scheme deep link that opens the iOS or
+            Android app at the reset screen. The web fallback exists for
+            users opening the email on desktop without the app installed.
+        """
+        # Custom-scheme deep link → opens the mobile app at /reset-password.
+        deep_link = f"signupflow://reset-password?token={reset_token}"
+        # Web fallback for desktop / no-app users.
+        web_url = f"{app_url}/reset-password?token={reset_token}"
+
+        subject = "Reset your SignUpFlow password"
+
+        html_content = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                body {{
+                    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                    line-height: 1.6;
+                    color: #333;
+                    max-width: 600px;
+                    margin: 0 auto;
+                    padding: 20px;
+                }}
+                .header {{
+                    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                    color: white;
+                    padding: 30px;
+                    text-align: center;
+                    border-radius: 10px 10px 0 0;
+                }}
+                .content {{
+                    background: white;
+                    padding: 30px;
+                    border: 1px solid #e0e0e0;
+                    border-top: none;
+                }}
+                .button {{
+                    display: inline-block;
+                    padding: 12px 30px;
+                    background: #667eea;
+                    color: white !important;
+                    text-decoration: none;
+                    border-radius: 5px;
+                    margin: 10px 5px;
+                }}
+                .alt-link {{
+                    color: #667eea;
+                    word-break: break-all;
+                }}
+                .footer {{
+                    text-align: center;
+                    padding: 20px;
+                    color: #666;
+                    font-size: 12px;
+                }}
+            </style>
+        </head>
+        <body>
+            <div class="header">
+                <h1>Reset your password</h1>
+            </div>
+            <div class="content">
+                <p>Hi {name},</p>
+
+                <p>We received a request to reset your SignUpFlow password.
+                Tap the button below to set a new one:</p>
+
+                <div style="text-align: center; margin: 30px 0;">
+                    <a href="{deep_link}" class="button">Open in SignUpFlow app</a>
+                </div>
+
+                <p>If the button doesn't open the app, paste this link into a
+                browser instead:</p>
+
+                <p><a href="{web_url}" class="alt-link">{web_url}</a></p>
+
+                <p>This link expires in <strong>1 hour</strong>. If you
+                didn't request a reset, you can safely ignore this email.</p>
+
+                <p>Best,<br>
+                The SignUpFlow Team</p>
+            </div>
+            <div class="footer">
+                <p>SignUpFlow - Volunteer Scheduling Made Simple</p>
+            </div>
+        </body>
+        </html>
+        """
+
+        plain_content = f"""
+        Hi {name},
+
+        We received a request to reset your SignUpFlow password.
+
+        Open in the SignUpFlow app:
+        {deep_link}
+
+        Or paste this URL into a browser:
+        {web_url}
+
+        This link expires in 1 hour. If you didn't request a reset, you can
+        safely ignore this email.
+
+        Best,
+        The SignUpFlow Team
+        """
+
+        return self.send_email(to_email, subject, html_content, plain_content)
+
 
 # Global email service instance
 email_service = EmailService()

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -9,6 +9,7 @@ Supports:
 - Database notification tracking
 """
 
+import html
 import logging
 import os
 import smtplib
@@ -1008,6 +1009,12 @@ class EmailService:
         # Web fallback for desktop / no-app users.
         web_url = f"{app_url}/reset-password?token={reset_token}"
 
+        # Escape the recipient name before HTML interpolation. Person.name is
+        # user-supplied (signup form / admin-created) and not constrained to
+        # plain text, so an unescaped f-string would let a malicious display
+        # name inject arbitrary markup into the reset email body.
+        safe_name = html.escape(name, quote=True)
+
         subject = "Reset your SignUpFlow password"
 
         html_content = f"""
@@ -1064,7 +1071,7 @@ class EmailService:
                 <h1>Reset your password</h1>
             </div>
             <div class="content">
-                <p>Hi {name},</p>
+                <p>Hi {safe_name},</p>
 
                 <p>We received a request to reset your SignUpFlow password.
                 Tap the button below to set a new one:</p>

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -990,7 +990,13 @@ class EmailService:
             to_email: Recipient email address
             name: Recipient's display name (Person.name)
             reset_token: Reset token from request_password_reset
-            app_url: Base application URL (used for the web fallback)
+            app_url: Base **frontend** URL used to build the web fallback
+                link (``{app_url}/reset-password?token=...``). Must point
+                at a host that serves a ``GET /reset-password`` page; in
+                this codebase the caller passes ``FRONTEND_URL`` (with
+                ``APP_URL`` as a last-ditch fallback). The mobile deep
+                link uses the hard-coded ``signupflow://`` scheme and is
+                independent of this argument.
 
         Returns:
             True if email sent successfully, False otherwise. Also returns

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -108,12 +108,16 @@ class EmailService:
 
         # Email enabled flag
         # Auto-enable if explicit SMTP credentials provided (for integration tests)
-        # Otherwise respect EMAIL_ENABLED environment variable (defaults to true)
+        # Otherwise respect EMAIL_ENABLED environment variable (defaults to false).
+        # Default-off matches the repo's safety contract that transactional
+        # email stays disabled until an operator opts in — without this,
+        # /forgot-password queues real SMTP sends in dev/Docker deployments
+        # that lack credentials and burns 60/120/240s retry sleeps per request.
         # Forced OFF under TESTING=true so synchronous BackgroundTasks (e.g.
         # via FastAPI TestClient) don't block on real SMTP retries when a
         # test doesn't explicitly mock the email service.
         explicit_smtp_config = bool(smtp_user and smtp_password)
-        env_enabled = os.getenv("EMAIL_ENABLED", "true").lower() == "true"
+        env_enabled = os.getenv("EMAIL_ENABLED", "false").lower() == "true"
         testing_mode = os.getenv("TESTING", "").lower() == "true"
         self.enabled = (explicit_smtp_config or env_enabled) and not testing_mode
 

--- a/api/services/email_service.py
+++ b/api/services/email_service.py
@@ -108,9 +108,13 @@ class EmailService:
         # Email enabled flag
         # Auto-enable if explicit SMTP credentials provided (for integration tests)
         # Otherwise respect EMAIL_ENABLED environment variable (defaults to true)
+        # Forced OFF under TESTING=true so synchronous BackgroundTasks (e.g.
+        # via FastAPI TestClient) don't block on real SMTP retries when a
+        # test doesn't explicitly mock the email service.
         explicit_smtp_config = bool(smtp_user and smtp_password)
         env_enabled = os.getenv("EMAIL_ENABLED", "true").lower() == "true"
-        self.enabled = explicit_smtp_config or env_enabled
+        testing_mode = os.getenv("TESTING", "").lower() == "true"
+        self.enabled = (explicit_smtp_config or env_enabled) and not testing_mode
 
         # Initialize Jinja2 template environment
         template_dir = Path(__file__).parent.parent / "templates" / "email"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       # Email Configuration (SendGrid)
       SENDGRID_API_KEY: ${SENDGRID_API_KEY}
       FROM_EMAIL: ${FROM_EMAIL:-noreply@signupflow.io}
-      EMAIL_ENABLED: ${EMAIL_ENABLED:-true}
+      EMAIL_ENABLED: ${EMAIL_ENABLED:-false}
 
       # SMS Configuration (Twilio)
       TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}

--- a/tests/api/test_password_reset.py
+++ b/tests/api/test_password_reset.py
@@ -92,6 +92,51 @@ class TestForgotPasswordDebugFlag:
         assert "token" in login.json()
 
 
+class TestForgotPasswordRosterOnlyPerson:
+    """Roster-only Persons (password_hash IS NULL) must NOT receive reset tokens.
+
+    A Person row created via /people or bulk import is just a roster entry,
+    not a login account. Issuing a reset token would let anyone in control
+    of the listed email bypass invitation/onboarding and pick up whatever
+    roles the row carries — /reset-password writes password_hash without
+    re-checking that the row was ever activated.
+    """
+
+    def test_no_token_issued_for_person_without_password_hash(self, db, monkeypatch):
+        from api.models import PasswordResetToken
+
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+
+        org = Organization(id="roster_only_org", name="Roster Only Org", region="Test")
+        db.add(org)
+        db.add(
+            Person(
+                id="roster_only_person",
+                org_id="roster_only_org",
+                name="Roster Only",
+                email="roster-only@example.com",
+                password_hash=None,
+                roles=["volunteer"],
+            )
+        )
+        db.commit()
+
+        before = db.query(PasswordResetToken).count()
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password", json={"email": "roster-only@example.com"}
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        # Even with DEBUG_RETURN_RESET_TOKEN=true the response must not carry
+        # a token, because the lookup should treat this email as unknown.
+        assert "token" not in body
+        assert "reset_link" not in body
+        assert db.query(PasswordResetToken).count() == before
+
+
 class TestForgotPasswordAuditTrail:
     """The forgot-password endpoint should leave an audit row regardless of leak flag."""
 

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -1,0 +1,105 @@
+"""Tests for the send_password_reset_email wiring (Sprint 9 PR 9.1).
+
+The forgot-password endpoint now invokes
+``email_service.send_password_reset_email`` after issuing a reset token.
+These tests pin the call shape — they don't actually send any email.
+"""
+
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.models import Organization, Person
+from api.routers import password_reset as password_reset_router
+
+
+def _seed_reset_user(db):
+    org = Organization(id="reset_email_org", name="Reset Email Org", region="Test")
+    db.add(org)
+    person = Person(
+        id="reset_email_person",
+        org_id="reset_email_org",
+        name="Reset Email Tester",
+        email="reset-email@example.com",
+        password_hash="$2b$12$dummy_hash",
+        roles=["volunteer"],
+    )
+    db.add(person)
+    db.commit()
+    return person
+
+
+class TestForgotPasswordSendsEmail:
+    def test_send_password_reset_email_called_with_user_token(self, db, monkeypatch):
+        """When the user exists, the email service is called with the freshly
+        issued token, the user's email, and the user's name."""
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+
+        mock_send = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            mock_send,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        assert response.status_code == 200, response.text
+
+        # send_password_reset_email is called exactly once with kwargs.
+        assert mock_send.call_count == 1
+        kwargs = mock_send.call_args.kwargs
+        assert kwargs["to_email"] == "reset-email@example.com"
+        assert kwargs["name"] == "Reset Email Tester"
+        # Token is non-empty and reasonably long (secrets.token_urlsafe(32)).
+        assert isinstance(kwargs["reset_token"], str)
+        assert len(kwargs["reset_token"]) >= 32
+        # Includes app_url so the email can build the web fallback link.
+        assert "app_url" in kwargs
+
+    def test_send_password_reset_email_not_called_for_unknown_email(self, db, monkeypatch):
+        """No user → no email send. The endpoint still returns the generic
+        response so we don't leak whether the email exists."""
+        mock_send = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            mock_send,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "ghost@example.com"},
+        )
+        assert response.status_code == 200, response.text
+        assert mock_send.call_count == 0
+
+
+class TestSendPasswordResetEmailReturnValue:
+    """The endpoint never propagates email-service failures to the caller —
+    a flaky SendGrid must not block reset-token issuance."""
+
+    def test_endpoint_succeeds_when_email_send_returns_false(self, db, monkeypatch):
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+
+        mock_send = MagicMock(return_value=False)
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            mock_send,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        assert response.status_code == 200
+        assert mock_send.call_count == 1

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -247,6 +247,100 @@ class TestForgotPasswordTimingDoesNotLeakExistence:
         assert t_unknown < 0.5, f"unknown-email path took {t_unknown:.2f}s"
 
 
+class TestResetTokenPersistedToDatabase:
+    """Regression for Codex review on PR #78 — the reset token must NOT
+    live in a per-process in-memory dict, because the default deployment
+    runs ``WORKERS=4`` and the worker handling ``POST /reset-password``
+    isn't guaranteed to be the one that issued the token. The token is
+    persisted to the ``password_reset_tokens`` table; we verify by:
+
+    1. Requesting a reset and checking the token row exists in the DB.
+    2. Issuing the reset on a *fresh* SQLAlchemy session (proxy for a
+       different worker) and confirming the password actually changed.
+    """
+
+    def test_token_row_persisted_after_forgot_password(self, db, monkeypatch):
+        from api.models import PasswordResetToken
+
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        person = _seed_reset_user(db)
+
+        # Mock the email send so we don't depend on EmailService at all.
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            MagicMock(return_value=True),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        assert response.status_code == 200, response.text
+        token = response.json()["token"]
+
+        # Re-query through a fresh expire-on-commit cycle so we're not
+        # reading the same identity-mapped object the router commited.
+        db.expire_all()
+        row = db.query(PasswordResetToken).filter(PasswordResetToken.token == token).one()
+        assert row.person_id == person.id
+        assert row.used_at is None
+        assert row.expires_at is not None
+
+    def test_reset_succeeds_on_separate_session(self, db, monkeypatch):
+        """Proxy for the multi-worker scenario: issue the token on one
+        SQLAlchemy session, then redeem it via a TestClient request that
+        gets a fresh session through ``Depends(get_db)``. If this works
+        (it does, because the token is in the DB rather than a per-process
+        dict), the multi-worker case works too."""
+        from api.models import PasswordResetToken
+        from api.security import verify_password
+
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        person = _seed_reset_user(db)
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            MagicMock(return_value=True),
+        )
+
+        client = TestClient(app)
+        forgot_response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        token = forgot_response.json()["token"]
+
+        # The forgot-password handler used its own get_db session; the
+        # token is now committed and visible to anyone — including the
+        # next TestClient request, which gets a fresh session.
+        reset_response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "NewPassword!2026"},
+        )
+        assert reset_response.status_code == 200, reset_response.text
+
+        # Verify the password actually changed by reloading the person
+        # on yet another fresh fetch.
+        db.expire_all()
+        person_reloaded = db.query(person.__class__).filter_by(id=person.id).one()
+        assert verify_password("NewPassword!2026", person_reloaded.password_hash)
+
+        # Replay must be rejected: token now marked used.
+        replay = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "DifferentPassword!2026"},
+        )
+        assert replay.status_code == 400
+
+        # And the token row exists with used_at stamped.
+        db.expire_all()
+        row = db.query(PasswordResetToken).filter(PasswordResetToken.token == token).one()
+        assert row.used_at is not None
+
+
 class TestSendPasswordResetEmailEscapesUserContent:
     """Regression for Codex review on PR #78 — Person.name flows directly
     into the reset email's HTML body. An unescaped name like

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -245,3 +245,45 @@ class TestForgotPasswordTimingDoesNotLeakExistence:
         # Both should be << 2s (i.e., the slow-email-backend never blocks).
         assert t_known < 0.5, f"known-email path took {t_known:.2f}s"
         assert t_unknown < 0.5, f"unknown-email path took {t_unknown:.2f}s"
+
+
+class TestSendPasswordResetEmailEscapesUserContent:
+    """Regression for Codex review on PR #78 — Person.name flows directly
+    into the reset email's HTML body. An unescaped name like
+    ``<script>alert(1)</script>`` or ``<a href=evil>Click</a>`` would let a
+    malicious display name inject markup into a security-sensitive email
+    that arrives in the victim's inbox. Build the email content in isolation
+    (no router, no DB) and assert HTML escaping at the source.
+    """
+
+    def test_html_escapes_name_in_body(self, monkeypatch):
+        from api.services.email_service import EmailService
+
+        captured: dict[str, str] = {}
+
+        def _capture(self, to_email, subject, html_content, plain_content=None):
+            captured["html"] = html_content
+            captured["plain"] = plain_content or ""
+            return True
+
+        monkeypatch.setattr(EmailService, "send_email", _capture)
+        # Force-enable the service for this isolated test (TESTING gate
+        # would short-circuit send_password_reset_email before our capture
+        # ran). We replaced send_email above, so no real I/O happens.
+        svc = EmailService()
+        svc.enabled = True
+
+        nasty = '<script>alert("xss")</script>'
+        ok = svc.send_password_reset_email(
+            to_email="victim@example.com",
+            name=nasty,
+            reset_token="t" * 40,
+            app_url="http://localhost:8000",
+        )
+        assert ok is True
+        # Raw markup must NOT appear; the escaped form MUST.
+        assert nasty not in captured["html"]
+        assert "&lt;script&gt;" in captured["html"]
+        # Plain-text variant is plain text by definition; no escaping needed
+        # there, but the test pins that the function still produces it.
+        assert "Hi " in captured["plain"]

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -356,6 +356,173 @@ class TestResetTokenPersistedToDatabase:
         assert row.used_at is not None
 
 
+class TestForgotPasswordInvalidatesPriorTokens:
+    """Regression for Codex review on PR #78 (and docs/features/
+    password-reset.md Scenario 6) — when a user requests a second
+    password reset, any earlier emailed link must be invalidated.
+    Otherwise a brief mailbox compromise lets an attacker race the user
+    to redeem a stale link.
+    """
+
+    def test_second_request_invalidates_first_token(self, db, monkeypatch):
+        from api.models import PasswordResetToken
+        from api.routers.password_reset import _hash_reset_token
+
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        _seed_reset_user(db)
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            MagicMock(return_value=True),
+        )
+
+        client = TestClient(app)
+
+        # First /forgot-password — capture token #1.
+        r1 = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        token1 = r1.json()["token"]
+
+        # Second /forgot-password — issues token #2 and stamps token #1.
+        r2 = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        token2 = r2.json()["token"]
+        assert token1 != token2
+
+        db.expire_all()
+        row1 = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token1))
+            .one()
+        )
+        row2 = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token2))
+            .one()
+        )
+        # First is invalidated, second is fresh.
+        assert row1.used_at is not None
+        assert row2.used_at is None
+
+        # Redeeming the now-stale token #1 must 400.
+        stale = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token1, "new_password": "DoesNotMatter!2026"},
+        )
+        assert stale.status_code == 400, stale.text
+
+        # Token #2 still works.
+        ok = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token2, "new_password": "FreshPassword!2026"},
+        )
+        assert ok.status_code == 200, ok.text
+
+
+class TestResetPasswordIsAtomic:
+    """Regression for Codex review on PR #78 — a SELECT-then-update flow
+    leaks a race where two concurrent /reset-password calls with the
+    same token both pass the "unused" check and both change the password
+    (last-write-wins). The handler now uses a single conditional UPDATE
+    that returns rowcount; the loser sees 0 and 400s.
+
+    True multi-thread concurrency is hard to simulate inside a single
+    in-memory SQLite test session, so we exercise the *contract* the
+    atomic UPDATE provides — the second redemption attempt of an
+    already-used token must 400 — which is what the prod multi-worker
+    case ultimately reduces to once one worker has commited.
+    """
+
+    def test_second_redemption_of_used_token_is_rejected(self, db, monkeypatch):
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        _seed_reset_user(db)
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            MagicMock(return_value=True),
+        )
+
+        client = TestClient(app)
+        forgot = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        token = forgot.json()["token"]
+
+        first = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "FirstPassword!2026"},
+        )
+        assert first.status_code == 200, first.text
+
+        # Second submission with the same token: the conditional UPDATE
+        # finds 0 rows matching `used_at IS NULL`, so it rolls back and
+        # 400s without touching the person's password.
+        second = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "SecondPassword!2026"},
+        )
+        assert second.status_code == 400
+
+    def test_expired_token_is_rejected_atomically(self, db, monkeypatch):
+        """The conditional UPDATE includes ``expires_at > now``, so an
+        expired token never claims the row — it 400s like any other
+        invalid token, and ``used_at`` stays NULL on the expired row."""
+        from api.models import PasswordResetToken
+        from api.routers.password_reset import _hash_reset_token
+
+        monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+        _seed_reset_user(db)
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            MagicMock(return_value=True),
+        )
+
+        client = TestClient(app)
+        forgot = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        token = forgot.json()["token"]
+
+        # Force the token to be expired by editing the DB directly.
+        from datetime import timedelta as _td
+
+        from api.timeutils import utcnow as _utcnow
+
+        row = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token))
+            .one()
+        )
+        row.expires_at = _utcnow() - _td(seconds=1)
+        db.commit()
+
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "WontApply!2026"},
+        )
+        assert response.status_code == 400
+
+        # And used_at on the expired row is still NULL — not stamped
+        # by a partial claim.
+        db.expire_all()
+        row_after = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token))
+            .one()
+        )
+        assert row_after.used_at is None
+
+
 class TestSendPasswordResetEmailEscapesUserContent:
     """Regression for Codex review on PR #78 — Person.name flows directly
     into the reset email's HTML body. An unescaped name like

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -261,6 +261,7 @@ class TestResetTokenPersistedToDatabase:
 
     def test_token_row_persisted_after_forgot_password(self, db, monkeypatch):
         from api.models import PasswordResetToken
+        from api.routers.password_reset import _hash_reset_token
 
         monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
         person = _seed_reset_user(db)
@@ -282,8 +283,17 @@ class TestResetTokenPersistedToDatabase:
 
         # Re-query through a fresh expire-on-commit cycle so we're not
         # reading the same identity-mapped object the router commited.
+        # Lookup by the digest (raw bearer token is never stored — see
+        # _hash_reset_token's docstring for rationale).
         db.expire_all()
-        row = db.query(PasswordResetToken).filter(PasswordResetToken.token == token).one()
+        row = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token))
+            .one()
+        )
+        # Confirm the *raw* token is NOT what was stored — defense against
+        # a future regression that accidentally writes the bearer.
+        assert row.token_hash != token
         assert row.person_id == person.id
         assert row.used_at is None
         assert row.expires_at is not None
@@ -295,6 +305,7 @@ class TestResetTokenPersistedToDatabase:
         (it does, because the token is in the DB rather than a per-process
         dict), the multi-worker case works too."""
         from api.models import PasswordResetToken
+        from api.routers.password_reset import _hash_reset_token
         from api.security import verify_password
 
         monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
@@ -337,7 +348,11 @@ class TestResetTokenPersistedToDatabase:
 
         # And the token row exists with used_at stamped.
         db.expire_all()
-        row = db.query(PasswordResetToken).filter(PasswordResetToken.token == token).one()
+        row = (
+            db.query(PasswordResetToken)
+            .filter(PasswordResetToken.token_hash == _hash_reset_token(token))
+            .one()
+        )
         assert row.used_at is not None
 
 

--- a/tests/api/test_password_reset_email.py
+++ b/tests/api/test_password_reset_email.py
@@ -1,10 +1,13 @@
 """Tests for the send_password_reset_email wiring (Sprint 9 PR 9.1).
 
-The forgot-password endpoint now invokes
-``email_service.send_password_reset_email`` after issuing a reset token.
-These tests pin the call shape — they don't actually send any email.
+The forgot-password endpoint now queues
+``email_service.send_password_reset_email`` via FastAPI BackgroundTasks
+after issuing a reset token. These tests pin the call shape AND prove
+that the HTTP response timing does not leak account existence — which
+is the security guarantee the endpoint must keep.
 """
 
+import time
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
@@ -33,7 +36,10 @@ def _seed_reset_user(db):
 class TestForgotPasswordSendsEmail:
     def test_send_password_reset_email_called_with_user_token(self, db, monkeypatch):
         """When the user exists, the email service is called with the freshly
-        issued token, the user's email, and the user's name."""
+        issued token, the user's email, and the user's name. The send happens
+        as a Starlette BackgroundTask AFTER the HTTP response, so we use
+        TestClient (which runs background tasks synchronously after the
+        request returns) and verify the mock was invoked."""
         monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
         _seed_reset_user(db)
 
@@ -103,3 +109,139 @@ class TestSendPasswordResetEmailReturnValue:
         )
         assert response.status_code == 200
         assert mock_send.call_count == 1
+
+    def test_endpoint_succeeds_when_email_send_raises(self, db, monkeypatch):
+        """A throwing email service must not bubble up to the HTTP caller —
+        the wrapper swallows + logs."""
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+
+        def _boom(**kwargs):
+            raise RuntimeError("SendGrid is on fire")
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            _boom,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        assert response.status_code == 200
+
+
+class TestForgotPasswordTimingDoesNotLeakExistence:
+    """Anti-enumeration regression. The slow-email-backend path must not
+    delay /forgot-password's HTTP response, otherwise a probe can compare
+    response timing for known-vs-unknown emails to enumerate registered
+    users.
+
+    Implementation: the email send is queued via Starlette
+    BackgroundTasks, which runs AFTER the response is sent on the wire.
+    We simulate a 2s SendGrid via monkeypatch + assert the response
+    landed within a tight bound, regardless of the slow backend.
+    """
+
+    def test_known_email_response_is_fast_even_with_slow_email_backend(self, db, monkeypatch):
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+
+        def _slow_send(**kwargs):
+            time.sleep(2.0)  # simulate retrying SMTP / SendGrid
+            return True
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            _slow_send,
+        )
+
+        # NOTE: TestClient runs background tasks synchronously on response
+        # close, so call timing here will INCLUDE the 2s. To get a true
+        # network-timing measurement we'd need an async live server. The
+        # next-best regression check: assert that the route's pre-response
+        # work alone is fast — i.e., the slow path is queued, not awaited.
+        # We do this by patching BackgroundTasks.add_task to NOT execute
+        # the queued callable, simulating the "after response close"
+        # boundary. If `add_task` weren't used, the slow send would still
+        # block the in-handler timing here.
+        captured_tasks = []
+        orig_add_task = password_reset_router.BackgroundTasks.add_task
+
+        def _capture_task(self, fn, *args, **kw):
+            captured_tasks.append((fn, args, kw))
+
+        monkeypatch.setattr(password_reset_router.BackgroundTasks, "add_task", _capture_task)
+        try:
+            client = TestClient(app)
+            t0 = time.monotonic()
+            response = client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "reset-email@example.com"},
+            )
+            elapsed = time.monotonic() - t0
+        finally:
+            monkeypatch.setattr(password_reset_router.BackgroundTasks, "add_task", orig_add_task)
+
+        assert response.status_code == 200
+        # 1.0s is generous: the slow backend would force >= 2s if we'd
+        # awaited it inline.
+        assert elapsed < 1.0, f"forgot-password took {elapsed:.2f}s — likely awaiting email"
+        # And the email send WAS queued (just not executed in this test).
+        assert len(captured_tasks) == 1
+        fn, _args, kw = captured_tasks[0]
+        assert fn is password_reset_router._send_reset_email_quiet
+        assert kw["to_email"] == "reset-email@example.com"
+
+    def test_known_and_unknown_email_have_indistinguishable_timing_when_send_is_queued(
+        self, db, monkeypatch
+    ):
+        """Tighter version: with the email send queued (not awaited), a
+        known and an unknown email take comparable time. We patch
+        BackgroundTasks.add_task to a no-op and the email service to a
+        slow function; both calls should be fast and within a few hundred
+        ms of each other."""
+        monkeypatch.delenv("DEBUG_RETURN_RESET_TOKEN", raising=False)
+        _seed_reset_user(db)
+
+        # Neuter the queue so we measure ONLY the synchronous handler time.
+        monkeypatch.setattr(
+            password_reset_router.BackgroundTasks,
+            "add_task",
+            lambda self, *a, **kw: None,
+        )
+
+        def _slow_send(**kwargs):
+            time.sleep(2.0)
+            return True
+
+        monkeypatch.setattr(
+            password_reset_router.email_service,
+            "send_password_reset_email",
+            _slow_send,
+        )
+
+        client = TestClient(app)
+
+        t0 = time.monotonic()
+        r_known = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "reset-email@example.com"},
+        )
+        t_known = time.monotonic() - t0
+        assert r_known.status_code == 200
+
+        t0 = time.monotonic()
+        r_unknown = client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "ghost@example.com"},
+        )
+        t_unknown = time.monotonic() - t0
+        assert r_unknown.status_code == 200
+
+        # Both should be << 2s (i.e., the slow-email-backend never blocks).
+        assert t_known < 0.5, f"known-email path took {t_known:.2f}s"
+        assert t_unknown < 0.5, f"unknown-email path took {t_unknown:.2f}s"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,14 @@ import uuid
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
-# Force a deterministic test database path before any application import.
+# Force deterministic env BEFORE any application import. Module-level so
+# singletons like `EmailService` (created at import time) see the right
+# values when constructed. `TESTING=true` in particular gates email_service
+# off so synchronous BackgroundTasks under FastAPI TestClient don't block
+# on real SMTP retries.
 os.environ.setdefault("DATABASE_URL", "sqlite:////tmp/signupflow_test.db")
 os.environ["TESTING_FORCE_MEMORY"] = "true"
+os.environ["TESTING"] = "true"
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -5110,7 +5110,7 @@
     },
     "/api/v1/auth/forgot-password": {
       "post": {
-        "description": "Request a password reset token.\n\nAlways returns the same generic message regardless of whether the email\nexists. Audits every request. The reset token is held in-memory and is\nNEVER returned in the response in production. Set\n`DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into\nreceiving the token in the JSON body for E2E exercise.\n\nEmail send is queued via ``BackgroundTasks`` so the HTTP response\ntiming is independent of email backend latency \u2014 both for anti-\nenumeration and to prevent slow-SMTP DoS. The reset token is issued\nsynchronously; email delivery is best-effort.",
+        "description": "Request a password reset token.\n\nAlways returns the same generic message regardless of whether the email\nexists. Audits every request. The reset token is persisted in the\n``password_reset_tokens`` table (see model in ``api/models.py``) so it\nsurvives multi-worker deployments \u2014 the legacy in-memory dict broke\nunder the documented default ``WORKERS=4`` because the worker handling\n``POST /reset-password`` may differ from the one that issued the token.\nThe token is NEVER returned in the response in production. Set\n``DEBUG_RETURN_RESET_TOKEN=true`` in dev/test environments to opt into\nreceiving the token in the JSON body for E2E exercise.\n\nEmail send is queued via ``BackgroundTasks`` so the HTTP response\ntiming is independent of email backend latency \u2014 both for anti-\nenumeration and to prevent slow-SMTP DoS. The reset token is issued\nsynchronously; email delivery is best-effort.",
         "operationId": "requestPasswordReset",
         "requestBody": {
           "content": {
@@ -5234,7 +5234,7 @@
     },
     "/api/v1/auth/reset-password": {
       "post": {
-        "description": "Reset password using token.",
+        "description": "Reset password using token.\n\nLooks up the token in the ``password_reset_tokens`` table. Tokens are\none-time-use: a successful reset stamps ``used_at`` so a replay of the\nsame emailed link is rejected with the generic \"invalid or expired\"\nerror.",
         "operationId": "resetPassword",
         "requestBody": {
           "content": {

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -5110,7 +5110,7 @@
     },
     "/api/v1/auth/forgot-password": {
       "post": {
-        "description": "Request a password reset token.\n\nAlways returns the same generic message regardless of whether the email\nexists. Audits every request. The reset token is held in-memory and is\nNEVER returned in the response in production. Set\n`DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into\nreceiving the token in the JSON body for E2E exercise.",
+        "description": "Request a password reset token.\n\nAlways returns the same generic message regardless of whether the email\nexists. Audits every request. The reset token is held in-memory and is\nNEVER returned in the response in production. Set\n`DEBUG_RETURN_RESET_TOKEN=true` in dev/test environments to opt into\nreceiving the token in the JSON body for E2E exercise.\n\nEmail send is queued via ``BackgroundTasks`` so the HTTP response\ntiming is independent of email backend latency \u2014 both for anti-\nenumeration and to prevent slow-SMTP DoS. The reset token is issued\nsynchronously; email delivery is best-effort.",
         "operationId": "requestPasswordReset",
         "requestBody": {
           "content": {

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -5234,7 +5234,7 @@
     },
     "/api/v1/auth/reset-password": {
       "post": {
-        "description": "Reset password using token.\n\nLooks up the token in the ``password_reset_tokens`` table. Tokens are\none-time-use: a successful reset stamps ``used_at`` so a replay of the\nsame emailed link is rejected with the generic \"invalid or expired\"\nerror.",
+        "description": "Reset password using token.\n\nThe token row is *claimed* with a single conditional UPDATE rather\nthan a SELECT-then-update sequence. Two concurrent /reset-password\nsubmissions of the same emailed link otherwise both pass a SELECT\n(``used_at IS NULL``) before either can stamp it, and both proceed\nto change the password \u2014 last-write-wins semantics, not the\none-time-use guarantee the endpoint advertises. The atomic UPDATE\ncloses that race: at most one row transitions from NULL to a\ntimestamp, ``rowcount == 0`` for the loser.",
         "operationId": "resetPassword",
         "requestBody": {
           "content": {


### PR DESCRIPTION
Closes the gap left by Sprint 8.8 (#67) — the mobile forgot/reset password flow shipped without an actual email send because `email_service.send_password_reset_email` didn't exist.

## What's new

- **`api/services/email_service.py`** — new `send_password_reset_email(to_email, name, reset_token, app_url)` mirrors the inline-HTML shape of `send_invitation_email`. Email body includes:
  - **Primary CTA**: a `signupflow://reset-password?token=...` deep link that opens the mobile app at the reset screen.
  - **Web fallback**: `{app_url}/reset-password?token=...` for users opening the email on desktop without the app.
  - Subject "Reset your SignUpFlow password". 1-hour expiry copy.

- **`api/routers/password_reset.py`** — `request_password_reset` now calls the helper after issuing the reset token. Anti-enumeration semantics preserved: the endpoint always returns the generic "if the email exists" message regardless of whether the email send succeeds. `email_service`'s internal `enabled` gate keeps it a no-op when `EMAIL_ENABLED=false`.

## Tests

- **`tests/api/test_password_reset_email.py`** (new) — three scenarios:
  - Known email → `send_password_reset_email` called with correct kwargs (`to_email`, `name`, `reset_token`, `app_url`).
  - Unknown email → `send_password_reset_email` **not** called (no email enumeration leak).
  - Email send returns False → endpoint still 200s (flaky SendGrid must not break reset-token issuance).
- **`tests/api/test_password_reset.py` + `tests/unit/test_password_reset.py`** — all existing reset tests still pass (11/11 across the three files).
- `black --check` + `ruff check` clean.

## What this PR does NOT do

- Does **not** localize the email body (only English; matches `send_invitation_email`'s scope). Localized templates can come later if needed.
- Does **not** flip `EMAIL_ENABLED=true` for production. That's PR 9.2 (live SendGrid wiring + smoke).
- Does **not** add new template files in `api/templates/email/` — uses inline HTML to match `send_invitation_email`. Refactoring all four invitation/reset/assignment/reminder helpers to share a Jinja template directory is a larger project.

Spec: `specs/023-sprint-8-completion/spec.md` Sprint 9 plan, PR 9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)