### PR TITLE
Android release keystore + signing + signupflow:// deep-link (Sprint 9 PR 9.5)

### DIFF
--- a/mobile/ANDROID_RELEASE.md
+++ b/mobile/ANDROID_RELEASE.md
@@ -1,0 +1,140 @@
+# Android Release Runbook
+
+> Sprint 9 PR 9.5+ — first Android internal release.
+>
+> Counterpart to `mobile/TESTFLIGHT.md` (iOS). The Flutter codebase ships
+> the same Dart UI on both platforms; only the build / signing /
+> distribution pipeline differs.
+
+---
+
+## One-time setup
+
+### 1. Java 17 + Android SDK
+
+Flutter Android builds need JDK 17 and the Android SDK / NDK. Install via
+Homebrew or Android Studio. `flutter doctor` should show Android green.
+
+### 2. Generate the release keystore
+
+```bash
+keytool -genkey -v \
+  -keystore $HOME/keystores/signupflow-android.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -alias upload
+```
+
+The keystore lives **outside** the repo (gitignored). Back it up — the Play
+Console will reject builds signed with a different key once you've published
+to a track. **Losing this file = re-publishing the app under a new package
+ID.**
+
+### 3. Configure `mobile/android/key.properties`
+
+Copy `mobile/android/key.properties.example` to `mobile/android/key.properties`
+(gitignored) and fill in the values from step 2:
+
+```
+storeFile=/Users/you/keystores/signupflow-android.jks
+storePassword=your-store-password
+keyAlias=upload
+keyPassword=your-key-password
+```
+
+If `key.properties` is absent, release builds **fall back to debug signing**
+so dev `flutter run --release` keeps working — the gradle build doesn't fail.
+
+### 4. Application id
+
+Already set in `mobile/android/app/build.gradle.kts`:
+- `applicationId = "app.signupflow.android"`
+- `namespace = "app.signupflow.android"`
+
+This pairs with iOS's `app.signupflow.ios` under the shared `app.signupflow.*`
+prefix. Reserve the package on Google Play Console under that name.
+
+---
+
+## Per-release flow
+
+### Build a signed `.aab`
+
+```bash
+cd mobile
+flutter build appbundle --release
+```
+
+Output: `mobile/build/app/outputs/bundle/release/app-release.aab` (signed
+with the release keystore when `key.properties` exists).
+
+### Smoke-install on a device / emulator
+
+```bash
+flutter build apk --release
+adb install -r mobile/build/app/outputs/flutter-apk/app-release.apk
+```
+
+Then walk the volunteer + admin journeys (mirror the iOS smoke checklist
+in `mobile/TESTFLIGHT.md`).
+
+### Upload to Play Console internal testing
+
+(Sprint 9 PR 9.6 will add a Fastlane lane for this. Until then, manual:)
+
+1. Play Console → SignUpFlow → Internal testing → Create new release.
+2. Upload `app-release.aab`.
+3. Add release notes.
+4. Roll out → Internal testing.
+
+### Deep-link smoke
+
+Verify the `signupflow://` URL scheme registers correctly on a real device:
+
+```bash
+adb shell am start -a android.intent.action.VIEW \
+  -d "signupflow://invitation?token=fake_test_token"
+```
+
+Should open the app at the invitation screen. Same for password reset:
+
+```bash
+adb shell am start -a android.intent.action.VIEW \
+  -d "signupflow://reset-password?token=fake_test_token"
+```
+
+---
+
+## Build history
+
+(populated as releases ship)
+
+| Version code | Sprint | Track | Changelog |
+|--------------|--------|-------|-----------|
+| _none yet_   | 9      | internal | first internal release after Sprint 9 |
+
+---
+
+## Common gotchas
+
+| Symptom | Fix |
+|---------|-----|
+| Gradle: "key.properties not found" but builds fall back to debug | Expected when keystore isn't configured. Add `mobile/android/key.properties` to enable release signing. |
+| Play Console: "Upload failed because you uploaded an APK that is signed with a different signing key" | You used a different keystore than the prior release. Restore the original `signupflow-android.jks` from backup. |
+| Deep link doesn't open the app | Verify `<intent-filter>` with `android:scheme="signupflow"` is present in `mobile/android/app/src/main/AndroidManifest.xml`. |
+| `applicationId` mismatch with Play Console listing | Both must be `app.signupflow.android`. The Play Console listing is created once and immutable. |
+
+---
+
+## Where the agent stops, where you start
+
+**The agent can:**
+- Edit `build.gradle.kts`, `AndroidManifest.xml`, `key.properties.example`.
+- Run `flutter build appbundle --release` (no human input needed).
+- Run `bundle exec fastlane android internal` (Sprint 9 PR 9.6+).
+
+**You do:**
+- Generate + back up the keystore (step 2).
+- Fill in `key.properties` with the keystore secrets (step 3).
+- Create the Play Console listing + add testers (Sprint 9 PR 9.6).
+- Generate the Google Cloud service-account JSON key for the Fastlane upload (PR 9.6).
+- Copy the `app-release.aab` to a real device for smoke testing.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,8 +8,19 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Read release signing config from `mobile/android/key.properties` if present.
+// In dev / CI without the keystore, fall back to debug signing so the
+// `assembleDebug` / `flutter run` paths still work.
+val keystoreProperties = Properties().apply {
+    val keystoreFile = rootProject.file("key.properties")
+    if (keystoreFile.exists()) {
+        load(FileInputStream(keystoreFile))
+    }
+}
+val hasReleaseKeystore = keystoreProperties.getProperty("storeFile") != null
+
 android {
-    namespace = "app.signupflow.signupflow_mobile"
+    namespace = "app.signupflow.android"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,21 +34,39 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "app.signupflow.signupflow_mobile"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        // Aligned to `app.signupflow.android` for Play Console clarity.
+        // (iOS uses `app.signupflow.ios`; both share the `app.signupflow.*`
+        // root the team owns on Apple + Google.)
+        applicationId = "app.signupflow.android"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            create("release") {
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Sign with the release keystore when key.properties is present
+            // (production builds, Fastlane uploads). Otherwise fall back to
+            // debug signing so dev `flutter run --release` keeps working.
+            signingConfig = if (hasReleaseKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
         }
     }
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="signupflow_mobile"
+        android:label="SignUpFlow"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -23,6 +23,15 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <!-- signupflow:// custom-scheme deep links (mirrors iOS Info.plist).
+                 Used by invitation accept (signupflow://invitation?token=...)
+                 and password reset (signupflow://reset-password?token=...). -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="signupflow"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/mobile/android/app/src/main/kotlin/app/signupflow/android/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/app/signupflow/android/MainActivity.kt
@@ -1,4 +1,4 @@
-package app.signupflow.signupflow_mobile
+package app.signupflow.android
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/mobile/android/key.properties.example
+++ b/mobile/android/key.properties.example
@@ -1,0 +1,20 @@
+# Android release-signing credentials.
+#
+# Copy this file to `mobile/android/key.properties` (gitignored) and fill in
+# the values. If `key.properties` is absent, release builds fall back to
+# debug-signing so dev `flutter run --release` still works.
+#
+# Generate a release keystore once with:
+#
+#   keytool -genkey -v \
+#     -keystore $HOME/keystores/signupflow-android.jks \
+#     -keyalg RSA -keysize 2048 -validity 10000 \
+#     -alias upload
+#
+# Then point storeFile at it (absolute or relative to mobile/android/).
+# The aliases / passwords below match the keytool prompts.
+
+storeFile=/Users/you/keystores/signupflow-android.jks
+storePassword=CHANGE_ME
+keyAlias=upload
+keyPassword=CHANGE_ME


### PR DESCRIPTION
Sets up the Android side of the build pipeline so Sprint 9 PR 9.6 can push to Google Play Console internal testing. Mirror of the iOS work in Sprint 7 PR 7.11.

## Build system

- **`mobile/android/app/build.gradle.kts`**:
  - `applicationId` + `namespace` renamed from `app.signupflow.signupflow_mobile` (default Flutter scaffold) to `app.signupflow.android`. Pairs with iOS `app.signupflow.ios` under the shared `app.signupflow.*` prefix.
  - New `signingConfigs` block reads `mobile/android/key.properties` when present.
  - `buildTypes.release.signingConfig` = release config when `key.properties` exists, else falls back to debug signing — so dev `flutter run --release` keeps working without the keystore.
  - `isMinifyEnabled = true` + `isShrinkResources = true` for smaller release bundles.

## AndroidManifest

- **`mobile/android/app/src/main/AndroidManifest.xml`**:
  - Added `<intent-filter>` for the `signupflow://` custom URL scheme so deep links from invitation + reset-password emails open the app (mirrors `mobile/ios/Runner/Info.plist`).
  - App label changed from `signupflow_mobile` (lowercase package) to `SignUpFlow` (proper display name).

## Docs / config

- **`mobile/android/key.properties.example`** (new, committed) — template for the gitignored `key.properties`. The repo's existing `mobile/android/.gitignore` already covers `key.properties`, `*.jks`, `*.keystore`.
- **`mobile/ANDROID_RELEASE.md`** (new) — runbook for keystore setup, per-release flow (`flutter build appbundle --release`), deep-link smoke (`adb shell am start ...`), common gotchas. Counterpart to `mobile/TESTFLIGHT.md`.

## Verification

- `flutter analyze` clean (no Dart-side regressions).
- No new tests yet; this PR is build-system only. PR 9.7 (Android cross-platform smoke) walks the actual UI on a Pixel emulator.
- The signing change is conditional on `key.properties` presence, so CI / dev environments without the keystore continue to use debug signing.

## What this PR does NOT do

- Doesn't create the keystore itself (that's a per-developer action; the runbook documents how).
- Doesn't add a Fastlane Android lane (PR 9.6).
- Doesn't update Sprint 9 plan-tracked memory with the Play Console package name (also PR 9.6).

Spec: `specs/023-sprint-8-completion/spec.md` Sprint 9 plan, PR 9.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)