### PR TITLE
docs(claude.md): switch PR review to local Codex via openai/codex-plugin-cc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,66 +119,59 @@ Pytest markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.s
 
 1. **Run tests after every code change.** After any edit to code or tests, run `make test-unit` (or `make test-unit-fast` during iteration). The change is not "done" until local tests pass. Run `make test-all` before pushing a PR.
 2. **Commit and let CI run.** After local tests pass, commit and push. Do not declare a change shippable based on local results alone — wait for CI on the branch.
-3. **Merge only when CI is green and the GitHub-enforced review gate has passed** (see next section).
+3. **Merge only when CI is green and Codex local review reports no blocking issues** (see next section).
 
-## GitHub-Enforced PR Review Gate
+## PR Workflow With Codex Review
 
-I am the builder/coding agent for this repository.
+This repository uses local Codex review through `openai/codex-plugin-cc`.
 
-I may write code, push branches, open PRs, respond to PR feedback, resolve merge
-conflicts, and merge my PR only after GitHub branch protection passes.
+Before shipping or merging a PR, run Codex review from Claude Code:
 
-Do not merge before the review gate passes.
+```
+/codex:review --base main
+```
 
-A PR may merge only when all of these are true:
-1. The PR is not draft.
+For larger changes, prefer background review:
+
+```
+/codex:review --base main --background
+/codex:status
+/codex:result
+```
+
+Do not self-approve by posting `LGTM` markers.
+Do not require or wait for the old GitHub `codex-pr-review-gate` check.
+
+A PR may merge only when:
+1. CI is green.
 2. GitHub says the PR is mergeable.
-3. Required CI checks are green.
-4. The required `codex-pr-review-gate` check is green for the current head SHA.
-5. There are no merge conflicts.
-6. There is no newer blocking review feedback.
+3. Codex local review reports no blocking issues.
+4. There are no unresolved review comments or merge conflicts.
 
-The `codex-pr-review-gate` check is the source of truth for independent AI
-review approval. Do not bypass it by reading old LGTM comments directly.
-
-Do not post `LGTM` yourself.
-Do not post or edit `<!-- codex-pr-review: ... -->` markers yourself.
-Do not treat an old approval as valid after pushing a new commit.
-
-If review feedback says `Not LGTM yet`:
-1. Treat it as blocking.
-2. Fix the issue.
+If Codex review reports blockers:
+1. Keep the PR open.
+2. Fix the issues.
 3. Run relevant local checks.
 4. Push a follow-up commit.
-5. Reply on the PR with what changed.
-6. Wait for CI and `codex-pr-review-gate` again.
+5. Run Codex review again.
 
 If the PR has merge conflicts:
 1. Update the branch against the latest base branch.
 2. Resolve conflicts carefully.
-3. Preserve requested changes and current base behavior when possible.
-4. Run relevant local checks.
-5. Commit and push the resolution.
-6. Wait for CI and `codex-pr-review-gate` again.
+3. Run relevant local checks.
+4. Push the resolution.
+5. Run Codex review again.
 
-Before merging, re-fetch PR state:
+If CI passes and Codex review passes:
+- Merge the PR using the repository's normal merge method.
+- Do not manually close the PR as the success path.
 
-```bash
-gh pr view <PR> --json number,url,isDraft,headRefName,headRefOid,mergeStateStatus,statusCheckRollup,comments,reviews
-gh pr checks <PR>
-```
+If GitHub blocks the merge:
+- Report the exact blocker.
+- Leave the PR open.
 
-Merge only if GitHub reports the PR is mergeable and all required checks,
-including `codex-pr-review-gate`, are passing for the current head SHA.
-
-Use the repository's normal merge method. If unclear, prefer:
-
-```bash
-gh pr merge <PR> --squash --delete-branch
-```
-
-If GitHub blocks the merge, report the exact blocker and leave the PR unmerged.
-Do not work around branch protection.
+Only close without merging if the work is abandoned, duplicated, or superseded,
+and leave a PR comment explaining why.
 
 ## Common Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,112 +119,66 @@ Pytest markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.s
 
 1. **Run tests after every code change.** After any edit to code or tests, run `make test-unit` (or `make test-unit-fast` during iteration). The change is not "done" until local tests pass. Run `make test-all` before pushing a PR.
 2. **Commit and let CI run.** After local tests pass, commit and push. Do not declare a change shippable based on local results alone — wait for CI on the branch.
-3. **Merge only when CI is green and the review gate has passed** (see next section).
+3. **Merge only when CI is green and the GitHub-enforced review gate has passed** (see next section).
 
-## PR Review Gate
+## GitHub-Enforced PR Review Gate
 
-You may write code, push branches, open PRs, respond to PR feedback, resolve
-merge conflicts, and merge your PR after the review gate passes.
+I am the builder/coding agent for this repository.
+
+I may write code, push branches, open PRs, respond to PR feedback, resolve merge
+conflicts, and merge my PR only after GitHub branch protection passes.
 
 Do not merge before the review gate passes.
 
-After opening or updating a PR:
-1. Push the branch.
-2. Wait for CI to finish.
-3. Wait for independent review.
-4. Treat "Not LGTM yet" as blocking feedback.
-
-A PR is mergeable only when all of these are true:
+A PR may merge only when all of these are true:
 1. The PR is not draft.
-2. CI/checks are green: no failing, cancelled, or pending required checks.
-3. An independent reviewer comment says:
+2. GitHub says the PR is mergeable.
+3. Required CI checks are green.
+4. The required `codex-pr-review-gate` check is green for the current head SHA.
+5. There are no merge conflicts.
+6. There is no newer blocking review feedback.
 
-```
-LGTM
-<!-- codex-pr-review: <head_sha> -->
-```
+The `codex-pr-review-gate` check is the source of truth for independent AI
+review approval. Do not bypass it by reading old LGTM comments directly.
 
-4. The `<head_sha>` marker exactly matches the current PR head SHA.
-5. No newer comment, review, or review thread after that LGTM contains blocking
-   feedback.
-6. No new commit was pushed after the LGTM marker.
-7. GitHub reports the PR can merge cleanly, with no merge conflicts.
+Do not post `LGTM` yourself.
+Do not post or edit `<!-- codex-pr-review: ... -->` markers yourself.
+Do not treat an old approval as valid after pushing a new commit.
 
-Important rules:
-- Do not post LGTM yourself.
-- Do not treat an LGTM for an older commit as valid.
-- If you push a new commit, the prior LGTM is stale; wait for review again.
-- If the reviewer comments "Not LGTM yet", fix the issue, run relevant checks,
-  push a follow-up commit, reply on the PR with what changed, and wait for
-  review again.
-- Keep review and fix discussion visible on the PR.
+If review feedback says `Not LGTM yet`:
+1. Treat it as blocking.
+2. Fix the issue.
+3. Run relevant local checks.
+4. Push a follow-up commit.
+5. Reply on the PR with what changed.
+6. Wait for CI and `codex-pr-review-gate` again.
 
-### Merge conflict responsibility
-
-You are responsible for keeping your PR mergeable.
-
-Before waiting for review, before merging, and after any base branch update,
-check whether the PR has merge conflicts or is behind the base branch.
-
-Use commands such as:
-
-```bash
-git fetch origin
-gh pr view --json number,url,headRefName,baseRefName,headRefOid,mergeStateStatus,statusCheckRollup
-gh pr checks
-```
-
-If the PR has merge conflicts, a dirty merge state, or GitHub reports it cannot
-be merged cleanly:
-1. Do not ask the reviewer to fix it.
-2. Update your branch against the latest base branch using the repo's normal
-   workflow. If no workflow is specified, prefer:
-
-   ```bash
-   git fetch origin
-   git checkout <pr-branch>
-   git merge origin/<base-branch>
-   ```
-
-3. Resolve conflicts carefully. Preserve both the requested branch changes and
-   the current base branch behavior unless the conflict makes that impossible.
+If the PR has merge conflicts:
+1. Update the branch against the latest base branch.
+2. Resolve conflicts carefully.
+3. Preserve requested changes and current base behavior when possible.
 4. Run relevant local checks.
-5. Commit the conflict resolution.
-6. Push the branch.
-7. Reply on the PR with a short summary of the conflict resolution.
-8. Wait for CI and independent review again.
+5. Commit and push the resolution.
+6. Wait for CI and `codex-pr-review-gate` again.
 
-### Before merging
-
-Re-fetch PR state immediately:
-- current head SHA
-- CI/check status
-- comments
-- reviews
-- review threads if available
-- draft state
-- mergeability / merge conflict state
-
-Use GitHub CLI when available, for example:
+Before merging, re-fetch PR state:
 
 ```bash
-gh pr view --json number,url,isDraft,headRefName,headRefOid,mergeStateStatus,statusCheckRollup,comments,reviews
-gh pr checks
-gh pr merge
+gh pr view <PR> --json number,url,isDraft,headRefName,headRefOid,mergeStateStatus,statusCheckRollup,comments,reviews
+gh pr checks <PR>
 ```
 
-Only merge if the fresh state still satisfies the gate.
+Merge only if GitHub reports the PR is mergeable and all required checks,
+including `codex-pr-review-gate`, are passing for the current head SHA.
 
-If the gate passes, merge the PR. Use the repository's normal merge method if it
-is clear from repo policy or branch protection. Otherwise prefer squash merge:
+Use the repository's normal merge method. If unclear, prefer:
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge <PR> --squash --delete-branch
 ```
 
 If GitHub blocks the merge, report the exact blocker and leave the PR unmerged.
-If CI is pending, review is missing, LGTM is stale, merge conflicts exist, or
-blocking feedback exists, do not merge; report what is still needed.
+Do not work around branch protection.
 
 ## Common Gotchas
 


### PR DESCRIPTION
Replaces the (never-deployed) `codex-pr-review-gate` GitHub Action approach with **local Codex review** via `openai/codex-plugin-cc`. Drops the comment-marker polling logic; keeps the review fully agent-side.

## What changed

- **Section renamed**: `## GitHub-Enforced PR Review Gate` → `## PR Workflow With Codex Review`.
- **Merge criteria**:
  1. CI green
  2. GitHub mergeable
  3. Codex local review passes
  4. No unresolved comments / merge conflicts
- **Documents the slash commands**: `/codex:review --base main` for sync review; `/codex:review --base main --background` + `/codex:status` + `/codex:result` for larger changes.
- **Explicit prohibitions**: don't post `LGTM` yourself; don't require or wait for the old `codex-pr-review-gate` GitHub check.
- `## PR rules` bullet 3 now references the new section name.

## What this PR does NOT do

- **No branch-protection changes** — `main` is not currently protected on this repo (per `gh api repos/.../branches/main/protection` returning 404), and rulesets are empty. There is nothing to remove.
- **No workflow deletion** — `.github/workflows/codex-pr-review-gate.yml` was never created; only `ci.yml` exists.
- **No required-check change** — `Lint, type-check, and test` (the `ci.yml` job) remains the lone CI check. The Codex review is local-only by design.

## Background

The earlier version of this branch documented a server-enforced AI review gate (looking up a required `codex-pr-review-gate` check). The owner has since asked to switch to local-only Codex review through `openai/codex-plugin-cc` to avoid maintaining a GitHub Action. Branch force-pushed; the prior content is in this PR's force-push history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)