### PR TITLE
Android Fastlane lane + Play Console upload (Sprint 9 PR 9.6)

### DIFF
--- a/mobile/ANDROID_RELEASE.md
+++ b/mobile/ANDROID_RELEASE.md
@@ -53,38 +53,74 @@ Already set in `mobile/android/app/build.gradle.kts`:
 This pairs with iOS's `app.signupflow.ios` under the shared `app.signupflow.*`
 prefix. Reserve the package on Google Play Console under that name.
 
+### 5. Create the Play Console app listing
+
+(One-time, owner-side. The Fastlane lane uploads to an existing app
+listing; it doesn't create it.)
+
+1. Go to Play Console → **Create app**.
+2. App name: **SignUpFlow** · Default language: English (United States).
+3. App or game: App · Free or paid: Free.
+4. Package name: `app.signupflow.android` (must match `applicationId`).
+5. Open **Internal testing** → create a new track → add the owner's
+   Google account to the testers list.
+6. Upload at least one `.aab` manually the first time (any signed build
+   works) so Play Console finalizes the package + signing-key
+   association. Future uploads can go through the Fastlane lane.
+
+### 6. Generate a service-account JSON key for Fastlane uploads
+
+The Fastlane Android lane needs a Google Cloud service account with
+Play Console permissions:
+
+1. Google Cloud Console → IAM & Admin → Service Accounts → **Create**.
+   Name: `signupflow-fastlane`. Skip optional permissions.
+2. On the new service account → **Keys** → Add key → JSON. Save the
+   downloaded file as `~/play-store-key.json` (gitignored by default).
+3. Play Console → Setup → API access → link the same Google Cloud
+   project, then grant the service account **Release Manager** role on
+   the SignUpFlow app.
+
+The path can be overridden via env var:
+```bash
+export GOOGLE_PLAY_JSON_KEY_PATH="$HOME/.signupflow/play-store-key.json"
+```
+
+`mobile/fastlane/Appfile` reads from `GOOGLE_PLAY_JSON_KEY_PATH` first,
+falls back to `~/play-store-key.json`.
+
 ---
 
 ## Per-release flow
 
-### Build a signed `.aab`
+### Recommended: Fastlane internal lane
 
 ```bash
 cd mobile
-flutter build appbundle --release
+bundle exec fastlane android internal
 ```
 
-Output: `mobile/build/app/outputs/bundle/release/app-release.aab` (signed
-with the release keystore when `key.properties` exists).
+What this does:
+1. `flutter build appbundle --release --build-number=<git-rev-count>` →
+   produces a signed `.aab` (release keystore from `key.properties`).
+2. `upload_to_play_store(track: "internal", release_status: "draft", ...)` →
+   uploads to the Play Console internal testing track as a draft.
 
-### Smoke-install on a device / emulator
+The `release_status: "draft"` setting means the upload doesn't auto-roll
+out; you finalize it manually in Play Console after smoke-testing the
+build. Flip to `"completed"` in `Fastfile` if/when you want auto-roll-out
+on every push.
+
+### Smoke-install before publishing
 
 ```bash
-flutter build apk --release
+bundle exec fastlane android build_only   # build .aab without uploading
+flutter build apk --release                # or apk for adb install
 adb install -r mobile/build/app/outputs/flutter-apk/app-release.apk
 ```
 
 Then walk the volunteer + admin journeys (mirror the iOS smoke checklist
 in `mobile/TESTFLIGHT.md`).
-
-### Upload to Play Console internal testing
-
-(Sprint 9 PR 9.6 will add a Fastlane lane for this. Until then, manual:)
-
-1. Play Console → SignUpFlow → Internal testing → Create new release.
-2. Upload `app-release.aab`.
-3. Add release notes.
-4. Roll out → Internal testing.
 
 ### Deep-link smoke
 

--- a/mobile/fastlane/Appfile
+++ b/mobile/fastlane/Appfile
@@ -1,16 +1,27 @@
-# Apple identifiers — these are public (Team ID + bundle ID appear on App Store).
-# Apple ID password / app-specific password / API key are NOT here — they live
-# in env vars (see TESTFLIGHT.md).
+# Apple + Google identifiers — these are public (Team ID, bundle ID, and
+# package name appear on App Store / Play Store). Auth credentials are NOT
+# here — they live in env vars (see TESTFLIGHT.md and ANDROID_RELEASE.md).
 
-app_identifier("app.signupflow.ios")
-team_id("T32FW7PZ3S")
+for_platform :ios do
+  app_identifier("app.signupflow.ios")
+  team_id("T32FW7PZ3S")
 
-# Apple ID is read from env var to avoid embedding it in version control.
-# Set APPLE_ID before running fastlane. Example:
-#   export APPLE_ID="you@example.com"
-apple_id(ENV["APPLE_ID"])
+  # Apple ID is read from env var to avoid embedding it in version control.
+  # Set APPLE_ID before running fastlane. Example:
+  #   export APPLE_ID="you@example.com"
+  apple_id(ENV["APPLE_ID"])
 
-# Note: do NOT set `itc_team_id` here — `6767228040` is the per-app
-# numeric Apple ID (referenced as the App Store Connect "Apple ID" on the
-# app's page), not the team's numeric ID. With only one ASC team
-# (`Qiang Wu` at T32FW7PZ3S), pilot picks the team automatically.
+  # Note: do NOT set `itc_team_id` here — `6767228040` is the per-app
+  # numeric Apple ID (referenced as the App Store Connect "Apple ID" on the
+  # app's page), not the team's numeric ID. With only one ASC team
+  # (`Qiang Wu` at T32FW7PZ3S), pilot picks the team automatically.
+end
+
+# Google Play identifiers — package name is public (appears in the
+# Play Store URL). The service-account JSON key authenticates uploads;
+# its path is read from GOOGLE_PLAY_JSON_KEY_PATH or defaults to
+# ~/play-store-key.json (see ANDROID_RELEASE.md for setup).
+for_platform :android do
+  package_name("app.signupflow.android")
+  json_key_file(ENV["GOOGLE_PLAY_JSON_KEY_PATH"] || File.expand_path("~/play-store-key.json"))
+end

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -93,3 +93,65 @@ platform :ios do
     UI.success("✅ ipa built at build/ios/ipa/signupflow_mobile.ipa")
   end
 end
+
+platform :android do
+  desc "Build the Flutter Android app bundle and upload to Play Console internal track"
+  lane :internal do |options|
+    flutter_root = File.expand_path("..", __dir__)
+
+    # `flutter` may live outside the default PATH (same situation as iOS).
+    flutter_bin = `which flutter`.strip
+    UI.user_error!("flutter not on PATH — install or `export PATH=/path/to/flutter/bin:$PATH`") if flutter_bin.empty?
+    flutter_dir = File.dirname(flutter_bin)
+
+    # 1. Bump the build number — same git-rev-count strategy as iOS so the
+    # two platforms move together.
+    build_number = sh("git rev-list --count HEAD").strip
+    UI.message("Using version code: #{build_number}")
+
+    # 2. Build the signed .aab. The release keystore is read from
+    # mobile/android/key.properties (gitignored); see ANDROID_RELEASE.md.
+    # Without that file, gradle falls back to debug signing — Play Console
+    # will reject the upload, which is the correct failure mode.
+    Bundler.with_clean_env do
+      ENV["PATH"] = "#{flutter_dir}:#{ENV['PATH']}"
+      sh(
+        "cd #{flutter_root} && flutter build appbundle " \
+        "--release " \
+        "--build-number=#{build_number}"
+      )
+    end
+
+    aab_path = "#{flutter_root}/build/app/outputs/bundle/release/app-release.aab"
+    UI.user_error!("aab not found at #{aab_path}") unless File.exist?(aab_path)
+
+    # 3. Upload to Play Console internal testing track. Authenticates via
+    # the service-account JSON key referenced in Appfile (env var
+    # GOOGLE_PLAY_JSON_KEY_PATH or the default /Users/tomwu/play-store-key.json).
+    upload_to_play_store(
+      track: "internal",
+      aab: aab_path,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      release_status: "draft",
+      changes_not_sent_for_review: true,
+    )
+
+    UI.success("✅ Uploaded version code #{build_number} to Play Console internal track")
+  end
+
+  desc "Local-only: build the .aab without uploading (smoke test the build)"
+  lane :build_only do
+    flutter_root = File.expand_path("..", __dir__)
+    flutter_bin = `which flutter`.strip
+    UI.user_error!("flutter not on PATH") if flutter_bin.empty?
+    flutter_dir = File.dirname(flutter_bin)
+    Bundler.with_clean_env do
+      ENV["PATH"] = "#{flutter_dir}:#{ENV['PATH']}"
+      sh("cd #{flutter_root} && flutter build appbundle --release")
+    end
+    UI.success("✅ aab built at build/app/outputs/bundle/release/app-release.aab")
+  end
+end


### PR DESCRIPTION
Adds the Android counterpart to the iOS `:beta` lane: build a signed `.aab` via `flutter build appbundle`, then upload to Play Console internal testing track via `upload_to_play_store`. Mirrors the iOS fastlane shape — `Bundler.with_clean_env` wrapper, captured flutter dir to survive the env strip, git-rev-count build number.

## Fastlane

### `mobile/fastlane/Appfile`
- iOS config moved into `for_platform :ios do ... end` block (no behavior change).
- New `for_platform :android do ... end` block:
  - `package_name("app.signupflow.android")`
  - `json_key_file(ENV["GOOGLE_PLAY_JSON_KEY_PATH"] || ~/play-store-key.json)`

### `mobile/fastlane/Fastfile`
- New `platform :android do` block with two lanes:
  - **`:internal`** — full upload pipeline: `flutter build appbundle --release --build-number=<git-rev-count>` → `upload_to_play_store(track: "internal", release_status: "draft", ...)`. Uses `skip_upload_apk/metadata/images/screenshots` + `changes_not_sent_for_review` so we control the listing manually in Play Console.
  - **`:build_only`** — local build, no upload, mirrors the iOS `:build_only`.

`release_status: "draft"` means the upload doesn't auto-roll-out; you finalize in Play Console after smoke-testing. Flip to `"completed"` if/when you want auto-roll on every push.

## Docs

`mobile/ANDROID_RELEASE.md` extended with:
- **Step 5: Create the Play Console app listing** — one-time owner-side, documents the first-manual-upload requirement to finalize package + signing-key association.
- **Step 6: Generate a Google Cloud service-account JSON key** — `Release Manager` role on the SignUpFlow app, save to `~/play-store-key.json` (gitignored), env override `GOOGLE_PLAY_JSON_KEY_PATH`.
- Per-release flow rewrites the manual upload section to use `bundle exec fastlane android internal` + the new `build_only` smoke option.

Updated project memory (`ios_flutter_dev_coords.md`) with the Play Console package name + service-account key path so future agent runs have the coordinates.

## What this PR does NOT do

- Doesn't run the actual upload — needs the service-account JSON key + Play Console listing first; both are **owner-side actions** (documented in steps 5 + 6 of the runbook).
- Doesn't change the iOS `:beta` lane. Additive only.
- Doesn't modify branch protection / CI config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)