### PR TITLE
Invitation accept returns real JWT access + refresh pair (Sprint 9 PR 9.4b)

### DIFF
--- a/api/routers/invitations.py
+++ b/api/routers/invitations.py
@@ -23,10 +23,11 @@ from api.schemas.invitation import (
     InvitationResponse,
     InvitationVerify,
 )
+from api.security import create_access_token, create_refresh_token
 from api.timeutils import utcnow
 from api.utils.db_helpers import check_email_exists
 from api.utils.rate_limit_middleware import rate_limit
-from api.utils.security import generate_auth_token, generate_invitation_token, hash_password
+from api.utils.security import generate_invitation_token, hash_password
 
 router = APIRouter(prefix="/invitations", tags=["invitations"])
 
@@ -246,6 +247,7 @@ def accept_invitation(
         timezone=request.timezone,
         status="active",
         invited_by=invitation.invited_by,
+        password_changed_at=utcnow(),
         extra_data={},
     )
 
@@ -258,8 +260,23 @@ def accept_invitation(
     db.commit()
     db.refresh(person)
 
-    # Generate auth token for immediate login
-    auth_token = generate_auth_token()
+    # Mint real JWT access + refresh tokens (same shape as /auth/login
+    # and /auth/signup). The refresh token carries org_id + rtv so it
+    # works with /auth/refresh's atomic conditional UPDATE.
+    pwd_iat = (
+        person.password_changed_at.timestamp()
+        if person.password_changed_at is not None
+        else utcnow().timestamp()
+    )
+    access_token = create_access_token(data={"sub": person.id, "pwd_iat": pwd_iat})
+    refresh_token = create_refresh_token(
+        data={
+            "sub": person.id,
+            "org_id": person.org_id,
+            "pwd_iat": pwd_iat,
+            "rtv": person.refresh_token_version or 0,
+        }
+    )
 
     return InvitationAcceptResponse(
         person_id=person.id,
@@ -268,7 +285,8 @@ def accept_invitation(
         email=person.email,
         roles=person.roles or [],
         timezone=person.timezone,
-        token=auth_token,
+        token=access_token,
+        refresh_token=refresh_token,
         message="Account created successfully. You are now logged in.",
     )
 

--- a/api/schemas/invitation.py
+++ b/api/schemas/invitation.py
@@ -54,7 +54,12 @@ class InvitationAccept(BaseModel):
 
 
 class InvitationAcceptResponse(BaseModel):
-    """Schema for invitation acceptance response."""
+    """Schema for invitation acceptance response.
+
+    Returns a JWT access token + refresh token pair so the mobile client
+    can use ``token`` as a Bearer immediately and call ``/auth/refresh``
+    when it expires (mirrors login/signup since Sprint 9 PR 9.3).
+    """
 
     person_id: str
     org_id: str
@@ -62,5 +67,10 @@ class InvitationAcceptResponse(BaseModel):
     email: str
     roles: list[str]
     timezone: str
-    token: str  # Auth token for immediate login
+    token: str  # JWT access token (Authorization: Bearer ...)
+    refresh_token: str = Field(
+        default="",
+        description="Refresh token (long-lived). Use POST /auth/refresh "
+        "to exchange for a fresh access+refresh token pair.",
+    )
     message: str

--- a/mobile/api_client/doc/InvitationAcceptResponse.md
+++ b/mobile/api_client/doc/InvitationAcceptResponse.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **name** | **String** |  | 
 **orgId** | **String** |  | 
 **personId** | **String** |  | 
+**refreshToken** | **String** | Refresh token (long-lived). Use POST /auth/refresh to exchange for a fresh access+refresh token pair. | [optional] [default to '']
 **roles** | **BuiltList&lt;String&gt;** |  | 
 **timezone** | **String** |  | 
 **token** | **String** |  | 

--- a/mobile/api_client/lib/src/model/invitation_accept_response.dart
+++ b/mobile/api_client/lib/src/model/invitation_accept_response.dart
@@ -9,7 +9,7 @@ import 'package:built_value/serializer.dart';
 
 part 'invitation_accept_response.g.dart';
 
-/// Schema for invitation acceptance response.
+/// Schema for invitation acceptance response.  Returns a JWT access token + refresh token pair so the mobile client can use ``token`` as a Bearer immediately and call ``/auth/refresh`` when it expires (mirrors login/signup since Sprint 9 PR 9.3).
 ///
 /// Properties:
 /// * [email] 
@@ -17,6 +17,7 @@ part 'invitation_accept_response.g.dart';
 /// * [name] 
 /// * [orgId] 
 /// * [personId] 
+/// * [refreshToken] - Refresh token (long-lived). Use POST /auth/refresh to exchange for a fresh access+refresh token pair.
 /// * [roles] 
 /// * [timezone] 
 /// * [token] 
@@ -37,6 +38,10 @@ abstract class InvitationAcceptResponse implements Built<InvitationAcceptRespons
   @BuiltValueField(wireName: r'person_id')
   String get personId;
 
+  /// Refresh token (long-lived). Use POST /auth/refresh to exchange for a fresh access+refresh token pair.
+  @BuiltValueField(wireName: r'refresh_token')
+  String? get refreshToken;
+
   @BuiltValueField(wireName: r'roles')
   BuiltList<String> get roles;
 
@@ -51,7 +56,8 @@ abstract class InvitationAcceptResponse implements Built<InvitationAcceptRespons
   factory InvitationAcceptResponse([void updates(InvitationAcceptResponseBuilder b)]) = _$InvitationAcceptResponse;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(InvitationAcceptResponseBuilder b) => b;
+  static void _defaults(InvitationAcceptResponseBuilder b) => b
+      ..refreshToken = '';
 
   @BuiltValueSerializer(custom: true)
   static Serializer<InvitationAcceptResponse> get serializer => _$InvitationAcceptResponseSerializer();
@@ -94,6 +100,13 @@ class _$InvitationAcceptResponseSerializer implements PrimitiveSerializer<Invita
       object.personId,
       specifiedType: const FullType(String),
     );
+    if (object.refreshToken != null) {
+      yield r'refresh_token';
+      yield serializers.serialize(
+        object.refreshToken,
+        specifiedType: const FullType(String),
+      );
+    }
     yield r'roles';
     yield serializers.serialize(
       object.roles,
@@ -166,6 +179,13 @@ class _$InvitationAcceptResponseSerializer implements PrimitiveSerializer<Invita
             specifiedType: const FullType(String),
           ) as String;
           result.personId = valueDes;
+          break;
+        case r'refresh_token':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.refreshToken = valueDes;
           break;
         case r'roles':
           final valueDes = serializers.deserialize(

--- a/mobile/api_client/lib/src/model/invitation_accept_response.g.dart
+++ b/mobile/api_client/lib/src/model/invitation_accept_response.g.dart
@@ -18,6 +18,8 @@ class _$InvitationAcceptResponse extends InvitationAcceptResponse {
   @override
   final String personId;
   @override
+  final String? refreshToken;
+  @override
   final BuiltList<String> roles;
   @override
   final String timezone;
@@ -34,6 +36,7 @@ class _$InvitationAcceptResponse extends InvitationAcceptResponse {
       required this.name,
       required this.orgId,
       required this.personId,
+      this.refreshToken,
       required this.roles,
       required this.timezone,
       required this.token})
@@ -56,6 +59,7 @@ class _$InvitationAcceptResponse extends InvitationAcceptResponse {
         name == other.name &&
         orgId == other.orgId &&
         personId == other.personId &&
+        refreshToken == other.refreshToken &&
         roles == other.roles &&
         timezone == other.timezone &&
         token == other.token;
@@ -69,6 +73,7 @@ class _$InvitationAcceptResponse extends InvitationAcceptResponse {
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, orgId.hashCode);
     _$hash = $jc(_$hash, personId.hashCode);
+    _$hash = $jc(_$hash, refreshToken.hashCode);
     _$hash = $jc(_$hash, roles.hashCode);
     _$hash = $jc(_$hash, timezone.hashCode);
     _$hash = $jc(_$hash, token.hashCode);
@@ -84,6 +89,7 @@ class _$InvitationAcceptResponse extends InvitationAcceptResponse {
           ..add('name', name)
           ..add('orgId', orgId)
           ..add('personId', personId)
+          ..add('refreshToken', refreshToken)
           ..add('roles', roles)
           ..add('timezone', timezone)
           ..add('token', token))
@@ -116,6 +122,10 @@ class InvitationAcceptResponseBuilder
   String? get personId => _$this._personId;
   set personId(String? personId) => _$this._personId = personId;
 
+  String? _refreshToken;
+  String? get refreshToken => _$this._refreshToken;
+  set refreshToken(String? refreshToken) => _$this._refreshToken = refreshToken;
+
   ListBuilder<String>? _roles;
   ListBuilder<String> get roles => _$this._roles ??= ListBuilder<String>();
   set roles(ListBuilder<String>? roles) => _$this._roles = roles;
@@ -140,6 +150,7 @@ class InvitationAcceptResponseBuilder
       _name = $v.name;
       _orgId = $v.orgId;
       _personId = $v.personId;
+      _refreshToken = $v.refreshToken;
       _roles = $v.roles.toBuilder();
       _timezone = $v.timezone;
       _token = $v.token;
@@ -176,6 +187,7 @@ class InvitationAcceptResponseBuilder
                 orgId, r'InvitationAcceptResponse', 'orgId'),
             personId: BuiltValueNullFieldError.checkNotNull(
                 personId, r'InvitationAcceptResponse', 'personId'),
+            refreshToken: refreshToken,
             roles: roles.build(),
             timezone: BuiltValueNullFieldError.checkNotNull(
                 timezone, r'InvitationAcceptResponse', 'timezone'),

--- a/mobile/lib/auth/invitation_repository.dart
+++ b/mobile/lib/auth/invitation_repository.dart
@@ -85,6 +85,13 @@ class InvitationRepository {
         throw const InvitationFailure('Server returned an empty token.');
       }
       await _storage.writeToken(data.token);
+      // Persist the refresh token (Sprint 9 PR 9.4b makes invitation accept
+      // mint real JWT pairs like login/signup). Pre-9.4b backends omit the
+      // field; treat null/empty as "no refresh — fall back to re-login".
+      final refreshToken = data.refreshToken;
+      if (refreshToken != null && refreshToken.isNotEmpty) {
+        await _storage.writeRefreshToken(refreshToken);
+      }
       return AuthState(
         role: LoginRepository.resolveRole(data.roles.toList()),
         token: data.token,

--- a/tests/api/test_invitation_accept_jwt.py
+++ b/tests/api/test_invitation_accept_jwt.py
@@ -1,0 +1,127 @@
+"""Tests that POST /invitations/{token}/accept now returns real JWT
+access + refresh tokens (Sprint 9 PR 9.4b).
+
+The legacy implementation returned an opaque random token from
+``generate_auth_token()``, which couldn't be used as a Bearer for
+authenticated API calls. The new implementation mints the same
+access+refresh JWT pair as /auth/login and /auth/signup, so the
+mobile app can sign the user in directly after accepting.
+"""
+
+import time
+
+import pytest
+from jose import jwt
+
+from api.models import Invitation, Organization
+from api.security import (
+    ALGORITHM,
+    SECRET_KEY,
+    TOKEN_TYPE_ACCESS,
+    TOKEN_TYPE_REFRESH,
+)
+from api.timeutils import utcnow
+
+
+def _seed_pending_invitation(
+    db,
+    *,
+    org_id: str,
+    email: str,
+    name: str = "Invited Volunteer",
+    roles: list[str] | None = None,
+) -> Invitation:
+    if not db.query(Organization).filter(Organization.id == org_id).first():
+        db.add(Organization(id=org_id, name=f"Org {org_id}", region="Test"))
+    inv = Invitation(
+        id=f"inv_{int(time.time())}_{email.replace('@', '_').replace('.', '_')}",
+        org_id=org_id,
+        email=email,
+        name=name,
+        roles=roles or ["volunteer"],
+        invited_by="test_admin_id",
+        token=f"token_{int(time.time())}_{email.split('@')[0]}",
+        status="pending",
+        expires_at=utcnow().replace(year=utcnow().year + 1),
+    )
+    db.add(inv)
+    db.commit()
+    return inv
+
+
+@pytest.mark.no_mock_auth
+class TestInvitationAcceptReturnsJwts:
+    def test_accept_returns_access_token_jwt(self, client, db):
+        inv = _seed_pending_invitation(db, org_id="inv_jwt_org_1", email="invitee1@example.com")
+        resp = client.post(
+            f"/api/v1/invitations/{inv.token}/accept",
+            json={"password": "InviteePass1!", "timezone": "UTC"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+
+        # Token is a real JWT with type:"access".
+        assert body["token"]
+        payload = jwt.decode(body["token"], SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["type"] == TOKEN_TYPE_ACCESS
+        assert payload["sub"].startswith("person_invitee1_")
+        assert "pwd_iat" in payload
+        assert "exp" in payload
+
+    def test_accept_returns_refresh_token_with_org_and_rtv(self, client, db):
+        inv = _seed_pending_invitation(db, org_id="inv_jwt_org_2", email="invitee2@example.com")
+        resp = client.post(
+            f"/api/v1/invitations/{inv.token}/accept",
+            json={"password": "InviteePass1!", "timezone": "UTC"},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+
+        # refresh_token is present, non-empty, and decodes as a refresh JWT
+        # carrying the same org_id + rtv claims as login/signup tokens.
+        assert body["refresh_token"]
+        payload = jwt.decode(body["refresh_token"], SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["type"] == TOKEN_TYPE_REFRESH
+        assert payload["org_id"] == "inv_jwt_org_2"
+        assert payload["rtv"] == 0
+        assert "pwd_iat" in payload
+
+    def test_returned_access_token_authenticates_against_a_real_endpoint(self, client, db):
+        """The token is actually usable as a Bearer (regression for the
+        legacy opaque-token bug)."""
+        inv = _seed_pending_invitation(db, org_id="inv_jwt_org_3", email="invitee3@example.com")
+        resp = client.post(
+            f"/api/v1/invitations/{inv.token}/accept",
+            json={"password": "InviteePass1!", "timezone": "UTC"},
+        )
+        assert resp.status_code == 201
+        access = resp.json()["token"]
+
+        # Use the token to hit /people/me — an authenticated endpoint.
+        me = client.get(
+            "/api/v1/people/me",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert me.status_code == 200, me.text
+        assert me.json()["email"] == "invitee3@example.com"
+
+    def test_returned_refresh_token_works_against_auth_refresh(self, client, db):
+        """Round-trip: accept invitation → use refresh_token at
+        /auth/refresh → get a new access+refresh pair."""
+        inv = _seed_pending_invitation(db, org_id="inv_jwt_org_4", email="invitee4@example.com")
+        accept = client.post(
+            f"/api/v1/invitations/{inv.token}/accept",
+            json={"password": "InviteePass1!", "timezone": "UTC"},
+        )
+        assert accept.status_code == 201
+        refresh_token = accept.json()["refresh_token"]
+
+        time.sleep(1)  # so the new tokens have a different iat/exp
+        rotate = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": refresh_token},
+        )
+        assert rotate.status_code == 200, rotate.text
+        new = rotate.json()
+        assert new["token"] and new["token"] != accept.json()["token"]
+        assert new["refresh_token"] and new["refresh_token"] != refresh_token

--- a/tests/contract/openapi.snapshot.json
+++ b/tests/contract/openapi.snapshot.json
@@ -1593,7 +1593,7 @@
         "type": "object"
       },
       "InvitationAcceptResponse": {
-        "description": "Schema for invitation acceptance response.",
+        "description": "Schema for invitation acceptance response.\n\nReturns a JWT access token + refresh token pair so the mobile client\ncan use ``token`` as a Bearer immediately and call ``/auth/refresh``\nwhen it expires (mirrors login/signup since Sprint 9 PR 9.3).",
         "properties": {
           "email": {
             "title": "Email",
@@ -1613,6 +1613,12 @@
           },
           "person_id": {
             "title": "Person Id",
+            "type": "string"
+          },
+          "refresh_token": {
+            "default": "",
+            "description": "Refresh token (long-lived). Use POST /auth/refresh to exchange for a fresh access+refresh token pair.",
+            "title": "Refresh Token",
             "type": "string"
           },
           "roles": {


### PR DESCRIPTION
Closes the gap noted in #82's PR description.

The legacy `accept_invitation` handler returned `generate_auth_token()` — a random opaque token from `api/utils/security.py` that was **never a JWT**. As a result:
- Mobile couldn't use it as a Bearer for authenticated API calls (the legacy flow effectively forced a separate `/auth/login` round-trip after accepting).
- No refresh-token semantics → accepted users would have to re-login every 24h regardless of #79's `/auth/refresh`.

Now `/invitations/{token}/accept` mints the same JWT access + refresh pair as `/auth/login` and `/auth/signup` (Sprint 9 PR 9.3 / #79 shape). Mobile signs the user in directly from invitation acceptance, and the dio refresh interceptor (#82) keeps them signed in beyond 24h.

## Backend

- **`api/schemas/invitation.py`** — `InvitationAcceptResponse` now has a `refresh_token` field (defaults to `""` for backwards compat).
- **`api/routers/invitations.py`**:
  - Imports `create_access_token` + `create_refresh_token` from `api.security` (replaces the `generate_auth_token` call).
  - On accept, sets `person.password_changed_at = utcnow()` so the JWT's `pwd_iat` claim has a valid baseline (mirrors signup).
  - Mints access JWT `{sub, pwd_iat}` + refresh JWT `{sub, org_id, pwd_iat, rtv}` — same shape `/auth/refresh` expects.
- **`tests/contract/openapi.snapshot.json`** refreshed.

## Mobile

- **`mobile/api_client/`** regenerated to surface the new `refreshToken` field on `InvitationAcceptResponse`.
- **`mobile/lib/auth/secure_token_storage.dart`** — pulled in the `writeRefreshToken`/`clearAll` helpers from #82 so this branch is self-contained until #82 lands. (Once #82 is merged, the cherry-picked content is identical; rebase is a no-op.)
- **`mobile/lib/auth/invitation_repository.dart`** — persists `data.refreshToken` on successful accept (handles null/empty for pre-9.4b backends).

## Tests (4 new in `tests/api/test_invitation_accept_jwt.py`)

- Access token decodes as `type:"access"`.
- Refresh token decodes as `type:"refresh"` with `org_id` + `rtv` claims.
- **The returned access token actually authenticates against `/people/me`** — regression test for the legacy opaque-token bug.
- Round-trip: accept invitation → use `refresh_token` at `/auth/refresh` → new pair rotates correctly.

4/4 new pass. `flutter analyze` clean. `flutter test` 44/44 green. black + ruff clean.

## Behavior change for existing clients

`accept_invitation` now returns a JWT in the `token` field instead of an opaque random string. **This is a fix, not a regression**: the legacy token couldn't be used as a Bearer at all (you'd have called `/auth/login` after — which is what `tests/api/conftest.py::accept_invitation` already documented with the comment "NOTE: returned token is NOT a JWT — must call login() after"). Any client that was treating the legacy field as opaque (e.g., the test conftest) continues to work; clients that try to use it as a Bearer now succeed where they previously got 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)