### PR TITLE
Email pipeline: SendGrid wiring docs + smoke runbook + one-shot send (Sprint 9 PR 9.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,15 @@ RATE_LIMITING_ENABLED=true
 # keeps password-reset and other email-bearing endpoints from queuing real
 # SMTP requests against deployments that lack credentials.
 EMAIL_ENABLED=false
+
+# SendGrid HTTP API key — production email backend.
+# Read by EmailService at api/services/email_service.py:97; if set, the
+# service auto-selects the SendGrid backend (use_sendgrid=True). Leave
+# blank for dev/staging — those should use the SMTP backend pointed at
+# the Mailtrap sandbox (see MAILTRAP_* vars below). See
+# docs/saas/SMOKE_TESTING_EMAIL.md for the end-to-end smoke runbook.
+SENDGRID_API_KEY=
+
 SMS_ENABLED=true
 SESSION_TTL_HOURS=24
 

--- a/docs/saas/SMOKE_TESTING_EMAIL.md
+++ b/docs/saas/SMOKE_TESTING_EMAIL.md
@@ -1,0 +1,184 @@
+# Email Smoke Testing — Runbook
+
+End-to-end verification that the email pipeline (`api/services/email_service.py`)
+actually delivers a message to a real inbox, after credentials have been
+configured in `.env`. Use this when:
+
+- Wiring a new environment for the first time (dev, staging, prod).
+- After rotating the SendGrid API key or Mailtrap credentials.
+- After any change to `EmailService` itself (sanity check that the send
+  path still works against a live backend, not just unit-test mocks).
+
+The pipeline has two backends:
+
+| Backend  | When                | Vars                                    |
+|----------|---------------------|-----------------------------------------|
+| SMTP     | dev / staging / CI  | `MAILTRAP_SMTP_*` (Mailtrap sandbox)    |
+| SendGrid | production          | `SENDGRID_API_KEY` (auto-selects)       |
+
+Selection is automatic in `EmailService.__init__`: if `SENDGRID_API_KEY` is
+set, the SendGrid backend is used; otherwise SMTP. `EMAIL_ENABLED=true` is
+required either way — without it, every send is a no-op (with a `WARNING`
+log line). See `specs/001-email-notifications/spec.md:105` for the design.
+
+---
+
+## Prerequisites
+
+Run the existing prerequisite check first:
+
+```bash
+./scripts/validate_email_system.sh
+```
+
+It verifies Python 3.10+, Poetry, and Redis (the broker for the Celery
+notification worker — not strictly needed for the synchronous smoke send,
+but required for the full notification path). Fix anything it flags before
+continuing.
+
+---
+
+## Path A — Mailtrap sandbox (dev / staging / CI)
+
+Mailtrap captures every send to a virtual inbox you can view in the
+browser. Nothing leaves their network — safe to use without any domain
+authentication.
+
+### 1. Get credentials
+
+1. Sign up / log in at <https://mailtrap.io/>.
+2. Navigate to **Email Testing → Inboxes → SMTP Settings**.
+3. Copy `Username` and `Password`. The host (`sandbox.smtp.mailtrap.io`)
+   and port (`2525`) are already set as defaults in `.env.example`.
+
+### 2. Configure `.env`
+
+```bash
+cp .env.example .env  # if you haven't already
+```
+
+Edit `.env`:
+
+```ini
+EMAIL_ENABLED=true
+MAILTRAP_SMTP_USER=<paste from step 1>
+MAILTRAP_SMTP_PASSWORD=<paste from step 1>
+SENDGRID_API_KEY=        # leave blank — forces SMTP backend
+```
+
+### 3. Run the smoke send
+
+```bash
+poetry run python scripts/email_smoke.py --to your-mailtrap-inbox@example.com
+```
+
+(The `--to` address is the envelope recipient. Mailtrap captures it
+regardless — anything you put here ends up in your sandbox inbox, not in
+that real mailbox.)
+
+### 4. Verify
+
+- Script prints `backend: smtp`, a non-empty message ID, and exits 0.
+- Open your Mailtrap inbox in the browser. The message appears within
+  ~30s with subject `[smoke] SignUpFlow email pipeline test — <ISO ts>`.
+- Click into it; the body should render the smoke payload HTML cleanly.
+
+If you don't see the message:
+
+- Check the script output for an exception. SMTP auth errors mean the
+  Mailtrap user/password is wrong.
+- Check `MAILTRAP_SMTP_HOST` and `MAILTRAP_SMTP_PORT` weren't overridden
+  in `.env` — the sandbox host is required, the bulk host won't work
+  without a paid plan.
+
+---
+
+## Path B — SendGrid (production)
+
+This actually sends a real email to a real inbox. Only run against an
+environment whose `EMAIL_FROM` belongs to a domain you've authenticated
+with SendGrid (SPF + DKIM). Sending from an unverified domain triggers a
+403 from SendGrid and the message never leaves the API.
+
+### 1. Generate an API key
+
+1. <https://app.sendgrid.com/settings/api_keys> → **Create API Key**.
+2. Choose **Restricted Access**, grant **Mail Send: Full**, deny
+   everything else.
+3. Copy the key (it's shown once — store it in your password manager).
+
+### 2. Authenticate the sender domain
+
+1. <https://app.sendgrid.com/settings/sender_auth> → **Authenticate Your
+   Domain**.
+2. Add the SPF and DKIM records SendGrid generates to your DNS. Wait for
+   them to propagate (usually < 1 hour, sometimes longer).
+3. Confirm `EMAIL_FROM` in `.env` matches a mailbox on the authenticated
+   domain (default `noreply@signupflow.io` from `api/core/config.py:38`).
+
+### 3. Configure `.env`
+
+```ini
+EMAIL_ENABLED=true
+EMAIL_FROM=noreply@yourdomain.com  # must match an authenticated domain
+SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxx
+```
+
+`MAILTRAP_*` vars are ignored once `SENDGRID_API_KEY` is set — the SMTP
+client is never constructed.
+
+### 4. Run the smoke send
+
+```bash
+poetry run python scripts/email_smoke.py --to your-personal-inbox@example.com
+```
+
+### 5. Verify
+
+- Script prints `backend: sendgrid`, a non-empty `X-Message-Id`
+  (`sendgrid-msg-<22 hex chars>`), exit 0.
+- Watch the SendGrid Activity Feed
+  (<https://app.sendgrid.com/email_activity>) — the smoke message
+  appears within ~5s with status `Delivered`.
+- Check the recipient inbox (give it a minute, especially first send to
+  a domain).
+
+---
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Script prints `email service disabled — set EMAIL_ENABLED=true` and exits 0 | `EMAIL_ENABLED=false` in `.env` (or unset — default is now `false` per #78) | Set `EMAIL_ENABLED=true`. The no-op log lives at `api/services/email_service.py:191-193`. |
+| Script refuses with `won't run under TESTING=true` and exits 1 | `TESTING=true` in your shell or `.env` | Unset `TESTING`. The smoke is for live envs only; CI uses mocked email. |
+| `backend: sendgrid` + 401 in the exception | API key invalid, expired, or revoked | Regenerate the key (Path B step 1). The 401 surfaces from `sendgrid.SendGridAPIClient.send` and is logged at `email_service.py:295`. |
+| `backend: sendgrid` + 403 in the exception | `EMAIL_FROM` is not an authenticated SendGrid sender | Either authenticate the domain (Path B step 2) or change `EMAIL_FROM` to a verified address. |
+| `backend: smtp` + auth error | Mailtrap user/password wrong, or you used a non-sandbox host without a paid plan | Re-paste from Mailtrap dashboard; confirm `MAILTRAP_SMTP_HOST=sandbox.smtp.mailtrap.io`. |
+| Script succeeds but message never appears in recipient inbox | SendGrid Activity Feed shows `Delivered` → it's at the recipient end (spam folder, deferred, blocked). Activity Feed shows `Bounced` / `Dropped` → recipient address invalid or blocklisted. | Inspect the Activity Feed entry; SendGrid surfaces the SMTP response code there. |
+
+---
+
+## Rollback
+
+If a live send goes wrong (wrong recipients, content issue, etc.) and you
+need to immediately stop further sends:
+
+1. `EMAIL_ENABLED=false` in the deployed `.env` and restart the API
+   process. Every subsequent send becomes a no-op.
+2. If the leak was via the SendGrid key (e.g., committed to git, exposed
+   in a screenshot): revoke the key in the SendGrid dashboard
+   (<https://app.sendgrid.com/settings/api_keys>) — this invalidates it
+   immediately, even before the env var is rotated. Then generate a
+   replacement and redeploy.
+
+---
+
+## Related
+
+- `docs/saas/EMAIL_INTEGRATION_PLAN.md` — design doc for the email
+  pipeline (templates, notification model, future webhook).
+- `specs/001-email-notifications/spec.md` — original spec, including the
+  Mailtrap-for-staging / SendGrid-for-prod split.
+- `scripts/validate_email_system.sh` — prerequisite checks (Python,
+  Poetry, Redis).
+- `api/services/email_service.py` — the implementation under test here.

--- a/scripts/email_smoke.py
+++ b/scripts/email_smoke.py
@@ -1,0 +1,97 @@
+"""One-shot live email send for smoke testing the EmailService pipeline.
+
+Usage:
+    poetry run python scripts/email_smoke.py --to recipient@example.com
+
+Reads credentials from .env (loaded automatically by api.main / dotenv).
+Picks SendGrid if SENDGRID_API_KEY is set, otherwise falls back to SMTP
+(Mailtrap sandbox in dev/staging). Refuses to run under TESTING=true so
+it can't be invoked from CI by accident.
+
+See docs/saas/SMOKE_TESTING_EMAIL.md for the full runbook (credential
+setup, verification, failure modes, rollback).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--to",
+        required=True,
+        help="Recipient email address. For Mailtrap sandbox, this is captured "
+        "regardless of the address — anything goes to your sandbox inbox.",
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    if os.getenv("TESTING", "").lower() == "true":
+        print(
+            "won't run under TESTING=true — this script issues real sends. "
+            "Unset TESTING in your shell / .env first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Import after load_dotenv so EmailService picks up the configured env.
+    from api.services.email_service import EmailService
+
+    service = EmailService()
+
+    backend = "sendgrid" if (service.use_sendgrid and service.sendgrid_client) else "smtp"
+    print(f"backend: {backend}")
+    print(f"enabled: {service.enabled}")
+
+    if not service.enabled:
+        print(
+            "email service disabled — set EMAIL_ENABLED=true in .env "
+            "to dispatch a real send. No message was queued."
+        )
+        return 0
+
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    subject = f"[smoke] SignUpFlow email pipeline test — {timestamp}"
+    html = (
+        "<p>This is a smoke-test message from "
+        "<code>scripts/email_smoke.py</code>.</p>"
+        f"<p>Timestamp: {timestamp}<br>Backend: {backend}</p>"
+        "<p>If you're reading this, the email pipeline is wired correctly "
+        "for the current environment. Safe to delete.</p>"
+    )
+
+    try:
+        message_id = service.send_email(
+            to_email=args.to,
+            subject=subject,
+            html_content=html,
+        )
+    except Exception as exc:  # surface the backend exception verbatim
+        print(f"send failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    if not message_id:
+        # send_email returns None when the service is disabled mid-flight,
+        # or when the backend swallowed an error. The retry loop logs detail.
+        print(
+            "send returned no message ID. Check the EmailService log for "
+            "the backend's error (api/services/email_service.py).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"message_id: {message_id}")
+    print(f"sent to: {args.to}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The SendGrid send code path in `EmailService` is already complete (#78);
what was missing was the operator-facing surface to flip it on and verify
a real email lands. Adds three additive artifacts, no behavioral changes:

- **`.env.example`** — documents `SENDGRID_API_KEY` (was a gap: read by `email_service.py:97` but undocumented). Comment explains the auto-select rule and points at the new runbook.
- **`docs/saas/SMOKE_TESTING_EMAIL.md`** — end-to-end runbook. Path A (Mailtrap sandbox for dev/staging/CI) + Path B (real SendGrid for prod, with SPF/DKIM + Activity Feed verification). Failure-mode table + rollback.
- **`scripts/email_smoke.py`** — thin wrapper that builds an `EmailService` and dispatches one labeled message (`[smoke] SignUpFlow email pipeline test — <ISO ts>`). Prints backend + message ID, exit 0/1. Refuses under `TESTING=true`.

Per `specs/001-email-notifications/spec.md:105`: Mailtrap for dev/staging/CI, SendGrid for prod.

Out of scope (deferred):
- `POST /webhooks/sendgrid` event handler (per `EMAIL_INTEGRATION_PLAN.md:401`).
- Real prod deployment of `EMAIL_ENABLED=true` against `api.signupflow.io` — operator action.
- DNS / SPF+DKIM record creation — operator action, doc only.

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open(...))'` — script syntax ok.
- [ ] CI green (no behavioral changes; the script isn't invoked by `make test` or any workflow).
- [ ] Codex local review pass.
- [ ] Manual smoke against Mailtrap sandbox (operator step):
  - [ ] `cp .env.example .env`, fill in `MAILTRAP_SMTP_USER` / `MAILTRAP_SMTP_PASSWORD`, set `EMAIL_ENABLED=true`.
  - [ ] `poetry run python scripts/email_smoke.py --to anything@example.com` — expect `backend: smtp` + non-empty message ID + exit 0.
  - [ ] Message visible in Mailtrap inbox within 30s.
- [ ] Manual smoke against SendGrid (operator step, post-domain-auth):
  - [ ] `SENDGRID_API_KEY=SG.xxx`, `EMAIL_FROM=noreply@<authenticated-domain>`, `EMAIL_ENABLED=true`.
  - [ ] `poetry run python scripts/email_smoke.py --to <real-inbox>` — expect `backend: sendgrid` + `sendgrid-msg-...` ID.
  - [ ] Message visible in SendGrid Activity Feed (`Delivered`) + recipient inbox.
- [ ] Disabled-path verification: same command with `EMAIL_ENABLED=false` — expect `email service disabled` + exit 0, no send.
- [ ] CI guard verification: same command with `TESTING=true` — expect refusal + exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)