### PR TITLE
CI: automate Codex review via openai/codex-action (Sprint 10 PR 10.7)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -78,13 +78,33 @@ jobs:
             - Report P0 / P1 findings only when they would block merge (correctness, security, tenant data leakage, broken contracts).
             - P2 / P3 are nice-to-haves; surface them but don't gate.
             - Be specific: file:line + the issue + a one-line fix proposal.
-            - Verdict line at top: SAFE TO MERGE / NEEDS FIX / NEEDS DISCUSSION.
+            - **First line of your response must be exactly one of:** `Verdict: SAFE TO MERGE` / `Verdict: NEEDS FIX` / `Verdict: NEEDS DISCUSSION`. The CI step below greps this line; anything other than `SAFE TO MERGE` fails the job.
             - Keep the report under 600 words.
 
             PR title + body:
             ----
             ${{ github.event.pull_request.title }}
             ${{ github.event.pull_request.body }}
+
+      - name: Enforce verdict (fail on NEEDS FIX / NEEDS DISCUSSION)
+        env:
+          CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
+        run: |
+          # Parse the first occurrence of `Verdict: <X>` and exit non-zero
+          # unless it's exactly "SAFE TO MERGE". Without this, a blocking
+          # Codex verdict would still mark the check green and could merge
+          # under branch protection / auto-merge gates.
+          verdict_line=$(printf '%s\n' "$CODEX_FINAL_MESSAGE" | grep -m1 -i '^Verdict:' || true)
+          if [ -z "$verdict_line" ]; then
+            echo "::warning::Codex output did not include a 'Verdict:' line; treating as needs-discussion."
+            echo "$CODEX_FINAL_MESSAGE" | head -40
+            exit 1
+          fi
+          echo "Codex verdict: $verdict_line"
+          case "$verdict_line" in
+            *"SAFE TO MERGE"*) exit 0 ;;
+            *) exit 1 ;;
+          esac
 
   post_feedback:
     name: Post Codex feedback as PR comment

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,117 @@
+name: Codex review
+
+# Runs Codex review on every PR push so reviewers (and auto-merge bots
+# acting on the Codex+CI gate) see findings without anyone having to
+# invoke /codex:review locally. Mirrors the local Codex review the
+# CLAUDE.md PR Review Gate previously required to be run manually.
+#
+# Prereq: repo secret OPENAI_API_KEY (https://platform.openai.com/api-keys).
+# Without it, the action fails fast in the precondition step below.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # One Codex review per PR at a time — cancel a previous run if a new
+  # push arrives so we don't review a stale head.
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  precondition:
+    name: Check OPENAI_API_KEY is set
+    runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::warning::OPENAI_API_KEY secret is not configured. Skipping Codex review. Set it under repo settings → Secrets → Actions to enable automatic review."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  codex:
+    name: Run Codex on the PR diff
+    runs-on: ubuntu-latest
+    needs: precondition
+    if: needs.precondition.outputs.configured == 'true'
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Check out the merge ref so Codex reviews the post-merge state,
+          # matching what CI itself tests.
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Pre-fetch base + head refs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Run Codex
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: read-only
+          prompt: |
+            Review the changes introduced by PR #${{ github.event.pull_request.number }} on ${{ github.repository }}.
+
+            Diff range:
+              git log --oneline ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Mirror the local Codex review behaviour the team has used through Sprint 9 + 10:
+
+            - Report P0 / P1 findings only when they would block merge (correctness, security, tenant data leakage, broken contracts).
+            - P2 / P3 are nice-to-haves; surface them but don't gate.
+            - Be specific: file:line + the issue + a one-line fix proposal.
+            - Verdict line at top: SAFE TO MERGE / NEEDS FIX / NEEDS DISCUSSION.
+            - Keep the report under 600 words.
+
+            PR title + body:
+            ----
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.body }}
+
+  post_feedback:
+    name: Post Codex feedback as PR comment
+    runs-on: ubuntu-latest
+    needs: codex
+    if: needs.codex.outputs.final_message != ''
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const body = [
+              '## 🤖 Codex review',
+              '',
+              process.env.CODEX_FINAL_MESSAGE,
+              '',
+              '<sub>Posted by `.github/workflows/codex-review.yml`. To re-run, push a new commit.</sub>',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -101,8 +101,13 @@ jobs:
             exit 1
           fi
           echo "Codex verdict: $verdict_line"
-          case "$verdict_line" in
-            *"SAFE TO MERGE"*) exit 0 ;;
+          # Normalize: strip leading/trailing whitespace, collapse internal
+          # whitespace, uppercase. Exact match prevents a verdict like
+          # "Verdict: NOT SAFE TO MERGE" or "Verdict: UNSAFE TO MERGE" from
+          # passing on substring containment.
+          normalized=$(printf '%s' "$verdict_line" | tr -s '[:space:]' ' ' | awk '{$1=$1; print toupper($0)}')
+          case "$normalized" in
+            "VERDICT: SAFE TO MERGE") exit 0 ;;
             *) exit 1 ;;
           esac
 
@@ -110,7 +115,10 @@ jobs:
     name: Post Codex feedback as PR comment
     runs-on: ubuntu-latest
     needs: codex
-    if: needs.codex.outputs.final_message != ''
+    # always() so feedback gets posted even when the codex job FAILED
+    # (NEEDS FIX / NEEDS DISCUSSION verdict). Without it the PR ends up
+    # with a red check and no explanation of why.
+    if: always() && needs.codex.outputs.final_message != ''
     permissions:
       issues: write
       pull-requests: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,28 +123,30 @@ Pytest markers: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.s
 
 ## PR Workflow With Codex Review
 
-This repository uses local Codex review through `openai/codex-plugin-cc`.
+PR review is run automatically by `openai/codex-action` in CI
+(`.github/workflows/codex-review.yml`). On every PR push, the action
+checks out the merge ref, runs Codex against the diff, and posts the
+verdict as a PR comment.
 
-Before shipping or merging a PR, run Codex review from Claude Code:
+Prereq: the `OPENAI_API_KEY` repo secret must be set. Without it the
+precondition job emits a warning and skips review; the rest of CI
+still runs.
+
+If you need to re-run a review (e.g., after fixing a finding), just
+push another commit — the workflow's concurrency group cancels the
+prior run and starts a fresh review on the new head.
+
+For local iteration before pushing, the legacy
+`openai/codex-plugin-cc` plugin still works:
 
 ```
 git fetch origin main
 /codex:review --base origin/main
 ```
 
-Use the remote ref (`origin/main`), not local `main` — if your checkout
-hasn't fetched recently, reviewing against local `main` runs the
-comparison against a stale base and the verdict won't reflect the diff
-GitHub will actually merge.
-
-For larger changes, prefer background review:
-
-```
-git fetch origin main
-/codex:review --base origin/main --background
-/codex:status
-/codex:result
-```
+Use it when you want a verdict without opening a PR, or when CI is
+unavailable. For routine PR review, lean on the CI action — it runs
+without anyone having to remember.
 
 Do not self-approve by posting `LGTM` markers.
 Do not require or wait for the old GitHub `codex-pr-review-gate` check.


### PR DESCRIPTION
## Summary

Wires `openai/codex-action@v1` into a new `.github/workflows/codex-review.yml`. Every PR push triggers Codex on the diff; verdict posted as a PR comment. Replaces the manual local-Codex review loop with CI automation — no more `node codex-companion.mjs review` per iteration.

- Precondition job verifies `OPENAI_API_KEY` is set; missing → warning, skip (rest of CI unaffected).
- `codex` job runs Codex with `sandbox: read-only` on the merge ref, prompted to mirror the local-review conventions (P0/P1 block merge, P2/P3 don't, verdict + file:line findings, <600 words).
- `post_feedback` posts the verdict as a PR comment.
- Concurrency group cancels prior runs when a new push arrives so we never review a stale head.
- `CLAUDE.md` PR Review Gate section now points at CI as the primary review path; the local plugin remains as a fallback.

## Prereq for the action to actually run

Repo admin must set `OPENAI_API_KEY` in Settings → Secrets and variables → Actions. The workflow is a no-op without it (precondition emits a warning, no CI failure).

## Test plan

- [x] Workflow YAML structure matches the action's documented contract.
- [ ] CI green on this PR (the action attempts to run — if `OPENAI_API_KEY` is set, this PR gets its own self-review).
- [ ] If review fires, the verdict comment appears on this PR.
- [ ] Verify a follow-up PR is reviewed without manual invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)