### PR TITLE
Mobile: Flutter integration_test/ scaffold + first on-device test (Sprint 10 PR 10.2)

### DIFF
--- a/mobile/SMOKE.md
+++ b/mobile/SMOKE.md
@@ -211,6 +211,19 @@ Issues filed:
 
 ---
 
+## Automated subset
+
+Portions of this runbook are starting to land as Flutter integration
+tests under `mobile/integration_test/` (run via
+`mobile/scripts/run_integration_tests.sh`). The first one is the
+cold-launch → login → authenticated landing flow. Future PRs (10.3
+mobile-concurrency) add deep-link routing verification. Everything
+else here remains manual until the integration_test/ harness grows
+to cover it.
+
+CI does NOT run integration tests (device-dependent); operator
+invokes them locally before/after the manual smoke walk.
+
 ## Related
 
 - `mobile/TESTFLIGHT.md` — iOS-specific upload + signing details.

--- a/mobile/integration_test/login_flow_test.dart
+++ b/mobile/integration_test/login_flow_test.dart
@@ -61,15 +61,16 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // The unauthenticated app lands on /login. We expect at least the
-    // email + password fields to be visible.
-    expect(find.byType(TextField), findsAtLeastNWidgets(2));
+    // The unauthenticated app lands on /login. LoginScreen wraps its
+    // inputs in a custom `_Field` widget — TextField hint text is the
+    // stable selector (label is a separate sibling Text in uppercase,
+    // not a TextField decoration). Hints come from
+    // mobile/lib/features/auth/login_screen.dart:88,95.
+    final textFields = find.byType(TextField);
+    expect(textFields, findsAtLeastNWidgets(2));
 
-    // Find the email and password inputs by their decoration label (the
-    // login screen labels them; if those labels change this test fails
-    // fast, which is the point of an end-to-end smoke).
-    final emailField = find.widgetWithText(TextField, 'Email');
-    final passwordField = find.widgetWithText(TextField, 'Password');
+    final emailField = find.widgetWithText(TextField, 'you@church.org');
+    final passwordField = find.widgetWithText(TextField, '•••••••');
     expect(emailField, findsOneWidget);
     expect(passwordField, findsOneWidget);
 
@@ -77,11 +78,12 @@ void main() {
     await tester.enterText(passwordField, 'irrelevant-fake-pw');
     await tester.pumpAndSettle();
 
-    // Tap the primary login button. The label is the same in both
-    // light and dark themes; if the label changes update this string.
-    final loginButton = find.widgetWithText(ElevatedButton, 'Log in');
-    expect(loginButton, findsOneWidget);
-    await tester.tap(loginButton);
+    // The sign-in CTA is a custom BlockButton, not a Material
+    // ElevatedButton. find.text matches the rendered label inside it;
+    // the tap walks up to the gesture target.
+    final loginButtonLabel = find.text('Sign in');
+    expect(loginButtonLabel, findsOneWidget);
+    await tester.tap(loginButtonLabel);
     await tester.pumpAndSettle();
 
     // After successful sign-in, the auth state's token must be set.

--- a/mobile/integration_test/login_flow_test.dart
+++ b/mobile/integration_test/login_flow_test.dart
@@ -78,10 +78,11 @@ void main() {
     await tester.enterText(passwordField, 'irrelevant-fake-pw');
     await tester.pumpAndSettle();
 
-    // The sign-in CTA is a custom BlockButton, not a Material
-    // ElevatedButton. find.text matches the rendered label inside it;
-    // the tap walks up to the gesture target.
-    final loginButtonLabel = find.text('Sign in');
+    // BlockButton renders label.toUpperCase() so the widget tree shows
+    // "SIGN IN" even though the constructor arg is "Sign in" — match the
+    // rendered text. find.text matches the inner Text inside the
+    // BlockButton; tester.tap walks up to the gesture target.
+    final loginButtonLabel = find.text('SIGN IN');
     expect(loginButtonLabel, findsOneWidget);
     await tester.tap(loginButtonLabel);
     await tester.pumpAndSettle();

--- a/mobile/integration_test/login_flow_test.dart
+++ b/mobile/integration_test/login_flow_test.dart
@@ -1,0 +1,97 @@
+// Sprint 10 PR 10.2 — first integration test (on-device end-to-end).
+//
+// Drives the app from cold launch through the login screen to the
+// authenticated landing. Uses InMemoryTokenStorage (from
+// mobile/lib/auth/secure_token_storage.dart) and a fake LoginRepository
+// (same pattern as mobile/test/auth_test.dart) so the test doesn't need
+// a live backend.
+//
+// Run via:
+//   flutter test integration_test/login_flow_test.dart
+//   ... or use mobile/scripts/run_integration_tests.sh to pick a
+//   simulator / emulator automatically.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:signupflow_mobile/app.dart';
+import 'package:signupflow_mobile/auth/auth_provider.dart';
+import 'package:signupflow_mobile/auth/login_repository.dart';
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+class _FakeLoginRepo implements LoginRepository {
+  _FakeLoginRepo({this.role = AuthRole.volunteer});
+  AuthRole role;
+
+  @override
+  Future<AuthState> signIn(String email, String password) async {
+    // Echo a token shaped like the real backend's so any consumer that
+    // checks length / structure doesn't trip.
+    return AuthState(
+      role: role,
+      token: 'integration-test-access-$email',
+      email: email,
+      name: 'Test User',
+    );
+  }
+
+  @override
+  Future<void> signOut() async {
+    // No-op for the integration test — the storage override handles state.
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Cold launch → /login → enter creds → land authenticated',
+      (tester) async {
+    final storage = InMemoryTokenStorage();
+    final repo = _FakeLoginRepo();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          loginRepositoryProvider.overrideWithValue(repo),
+          secureTokenStorageProvider.overrideWithValue(storage),
+        ],
+        child: const SignUpFlowApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The unauthenticated app lands on /login. We expect at least the
+    // email + password fields to be visible.
+    expect(find.byType(TextField), findsAtLeastNWidgets(2));
+
+    // Find the email and password inputs by their decoration label (the
+    // login screen labels them; if those labels change this test fails
+    // fast, which is the point of an end-to-end smoke).
+    final emailField = find.widgetWithText(TextField, 'Email');
+    final passwordField = find.widgetWithText(TextField, 'Password');
+    expect(emailField, findsOneWidget);
+    expect(passwordField, findsOneWidget);
+
+    await tester.enterText(emailField, 'volunteer@example.com');
+    await tester.enterText(passwordField, 'irrelevant-fake-pw');
+    await tester.pumpAndSettle();
+
+    // Tap the primary login button. The label is the same in both
+    // light and dark themes; if the label changes update this string.
+    final loginButton = find.widgetWithText(ElevatedButton, 'Log in');
+    expect(loginButton, findsOneWidget);
+    await tester.tap(loginButton);
+    await tester.pumpAndSettle();
+
+    // After successful sign-in, the auth state's token must be set.
+    // We don't assert exact landing screen here because the volunteer's
+    // home screen depends on backend data we're not stubbing; the auth
+    // state mutation is the smoke.
+    final ctx = tester.element(find.byType(SignUpFlowApp));
+    final container = ProviderScope.containerOf(ctx);
+    final auth = container.read(authProvider);
+    expect(auth.role, AuthRole.volunteer);
+    expect(auth.token, 'integration-test-access-volunteer@example.com');
+  });
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -294,6 +294,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -376,6 +381,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -448,6 +458,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -680,6 +695,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -844,6 +867,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -940,6 +971,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -28,6 +28,12 @@ dev_dependencies:
   custom_lint: ^0.7.0
   flutter_test:
     sdk: flutter
+  # On-device end-to-end tests. Lives at mobile/integration_test/ and runs
+  # via `flutter test integration_test/` against an iOS simulator or Android
+  # emulator. CI doesn't run these (device-dependent); they're operator-
+  # invoked. See mobile/scripts/run_integration_tests.sh for the harness.
+  integration_test:
+    sdk: flutter
   riverpod_generator: ^2.6.4
   riverpod_lint: ^2.6.4
   very_good_analysis: ^7.0.0

--- a/mobile/scripts/run_integration_tests.sh
+++ b/mobile/scripts/run_integration_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# run_integration_tests.sh — invoke Flutter integration_test/ on whichever
+# device target is available. Tries iOS simulator first (faster startup on
+# macOS), falls back to Android emulator if `flutter devices` reports one.
+#
+# This is operator-invoked. CI does NOT run integration tests (device-
+# dependent + slow). Local smoke only.
+#
+# Usage:
+#   ./mobile/scripts/run_integration_tests.sh                 # default test glob
+#   ./mobile/scripts/run_integration_tests.sh integration_test/foo_test.dart
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+MOBILE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$MOBILE_DIR"
+
+TEST_TARGET="${1:-integration_test/}"
+
+echo "==> Resolving Flutter device target"
+DEVICES_JSON=$(flutter devices --machine 2>/dev/null || echo "[]")
+
+# Pick an iOS simulator if present; else first Android device; else bail.
+TARGET_DEVICE=$(printf '%s' "$DEVICES_JSON" | python3 -c '
+import json, sys
+devs = json.load(sys.stdin)
+ios = [d for d in devs if d.get("platformType") == "ios" and d.get("emulator")]
+android = [d for d in devs if d.get("platformType") == "android"]
+pick = (ios + android)[:1]
+print(pick[0]["id"] if pick else "")
+')
+
+if [ -z "$TARGET_DEVICE" ]; then
+  echo "ERROR: no iOS simulator or Android emulator/device available." >&2
+  echo "Start one first:" >&2
+  echo "  - iOS:     open -a Simulator" >&2
+  echo "  - Android: emulator -avd <name>  (list with: emulator -list-avds)" >&2
+  exit 1
+fi
+
+echo "==> Running integration tests on device: $TARGET_DEVICE"
+echo "    Target: $TEST_TARGET"
+exec flutter test "$TEST_TARGET" -d "$TARGET_DEVICE"

--- a/mobile/scripts/run_integration_tests.sh
+++ b/mobile/scripts/run_integration_tests.sh
@@ -22,11 +22,19 @@ echo "==> Resolving Flutter device target"
 DEVICES_JSON=$(flutter devices --machine 2>/dev/null || echo "[]")
 
 # Pick an iOS simulator if present; else first Android device; else bail.
+# `flutter devices --machine` emits `targetPlatform` (e.g. "ios",
+# "android-arm64", "android-x64") + `emulator` (bool). platformType is
+# NOT in the device listing's JSON shape.
 TARGET_DEVICE=$(printf '%s' "$DEVICES_JSON" | python3 -c '
 import json, sys
 devs = json.load(sys.stdin)
-ios = [d for d in devs if d.get("platformType") == "ios" and d.get("emulator")]
-android = [d for d in devs if d.get("platformType") == "android"]
+def is_ios_sim(d):
+    return d.get("targetPlatform") == "ios" and d.get("emulator")
+def is_android(d):
+    tp = d.get("targetPlatform") or ""
+    return tp.startswith("android")
+ios = [d for d in devs if is_ios_sim(d)]
+android = [d for d in devs if is_android(d)]
 pick = (ios + android)[:1]
 print(pick[0]["id"] if pick else "")
 ')


### PR DESCRIPTION
## Summary

Pure infrastructure addition. Adds the Flutter `integration_test/` harness so future PRs (10.3 mobile concurrency + deep-link verification) have somewhere to put device-end-to-end tests.

- `mobile/pubspec.yaml`: adds `integration_test: { sdk: flutter }` to dev_dependencies.
- `mobile/integration_test/login_flow_test.dart`: first test — cold launch → /login → enter creds → assert authenticated. Uses `InMemoryTokenStorage` + a fake `LoginRepository` (same pattern as `mobile/test/auth_test.dart`) so no live backend needed.
- `mobile/scripts/run_integration_tests.sh`: operator harness; resolves an iOS simulator or Android emulator via `flutter devices --machine` and runs the suite.
- `mobile/SMOKE.md`: new "Automated subset" section cross-links to the harness.

CI impact: **none**. Integration tests are device-dependent and not wired into `make test` or any GitHub Actions workflow. Operator-invoked only.

## Test plan

- [x] Pubspec syntax: well-formed YAML.
- [x] Dart syntax: file parses (relies on review + CI's Dart analyzer if any).
- [ ] CI green (no backend impact expected — backend tests unaffected).
- [ ] Codex local review pass.
- [ ] Operator runs `mobile/scripts/run_integration_tests.sh` on a real device to confirm the first test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)