### PR TITLE
Mobile: Solution Review SSE consumer + event_bus publisher wiring (Sprint 10 PR 10.4b)

### DIFF
--- a/api/routers/assignments.py
+++ b/api/routers/assignments.py
@@ -11,7 +11,7 @@ Admins keep their existing entry points in api/routers/events.py
  `GET /events/assignments/all` for org-wide listing).
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -23,6 +23,7 @@ from api.schemas.assignment import (
     AssignmentSwapRequest,
 )
 from api.schemas.common import ListResponse, PaginationParams, get_pagination_params
+from api.services import event_bus
 from api.utils.audit_logger import log_audit_event
 
 router = APIRouter(prefix="/assignments", tags=["assignments"])
@@ -64,10 +65,32 @@ def _audit_status_change(
     )
 
 
+def _publish_assignment_change(
+    background_tasks: BackgroundTasks,
+    assignment: Assignment,
+) -> None:
+    # Manual/admin-created assignments have solution_id=None and don't
+    # belong to a Solution Review stream. Skip them to avoid publishing
+    # under the "solution:None" topic.
+    if assignment.solution_id is None:
+        return
+    background_tasks.add_task(
+        event_bus.publish,
+        f"solution:{assignment.solution_id}",
+        {
+            "type": "assignment.changed",
+            "assignment_id": assignment.id,
+            "solution_id": assignment.solution_id,
+            "status": assignment.status,
+        },
+    )
+
+
 @router.post("/{assignment_id}/accept", response_model=AssignmentResponse)
 def accept_assignment(
     assignment_id: int,
     http_request: Request,
+    background_tasks: BackgroundTasks,
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -84,6 +107,7 @@ def accept_assignment(
         assignment=assignment,
         http_request=http_request,
     )
+    _publish_assignment_change(background_tasks, assignment)
     return assignment
 
 
@@ -92,6 +116,7 @@ def decline_assignment(
     assignment_id: int,
     body: AssignmentDeclineRequest,
     http_request: Request,
+    background_tasks: BackgroundTasks,
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -109,6 +134,7 @@ def decline_assignment(
         http_request=http_request,
         details={"decline_reason": body.decline_reason},
     )
+    _publish_assignment_change(background_tasks, assignment)
     return assignment
 
 
@@ -117,6 +143,7 @@ def request_swap(
     assignment_id: int,
     body: AssignmentSwapRequest,
     http_request: Request,
+    background_tasks: BackgroundTasks,
     current_user: Person = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -134,6 +161,7 @@ def request_swap(
         http_request=http_request,
         details=details,
     )
+    _publish_assignment_change(background_tasks, assignment)
     return assignment
 
 

--- a/api/routers/events.py
+++ b/api/routers/events.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
@@ -19,6 +19,7 @@ from api.models import (
 )
 from api.schemas.common import PaginationParams, get_pagination_params
 from api.schemas.event import EventCreate, EventList, EventResponse, EventUpdate
+from api.services import event_bus
 from api.timeutils import utcnow
 from api.utils.event_helpers import (
     count_people_with_role,
@@ -371,6 +372,7 @@ def validate_event(event_id: str, db: Session = Depends(get_db)) -> dict:
 def manage_assignment(
     event_id: str,
     request: AssignmentRequest,
+    background_tasks: BackgroundTasks,
     current_admin: Person = Depends(get_current_admin_user),
     db: Session = Depends(get_db),
 ):
@@ -406,7 +408,9 @@ def manage_assignment(
                 person=person.name,
             )
 
-        # Create new assignment (solution_id is None for manual assignments)
+        # Create new assignment (solution_id is None for manual assignments).
+        # No event_bus publish here: solution_id is None so there's no
+        # Solution Review stream to notify.
         assignment = Assignment(
             event_id=event_id,
             person_id=request.person_id,
@@ -438,8 +442,22 @@ def manage_assignment(
                 person=person.name,
             )
 
+        # Capture before delete — SQLAlchemy clears attributes post-delete.
+        deleted_solution_id = assignment.solution_id
+        deleted_assignment_id = assignment.id
         db.delete(assignment)
         db.commit()
+        if deleted_solution_id is not None:
+            background_tasks.add_task(
+                event_bus.publish,
+                f"solution:{deleted_solution_id}",
+                {
+                    "type": "assignment.changed",
+                    "assignment_id": deleted_assignment_id,
+                    "solution_id": deleted_solution_id,
+                    "status": "deleted",
+                },
+            )
         return success_response("events.assign.unassigned", person=person.name)
 
     else:

--- a/mobile/lib/features/admin/solution_assignments_stream_provider.dart
+++ b/mobile/lib/features/admin/solution_assignments_stream_provider.dart
@@ -1,0 +1,123 @@
+// Sprint 10 PR 10.4b — mobile SSE consumer for Solution Review live refresh.
+//
+// Subscribes to GET /api/v1/solutions/{id}/assignments/stream and yields one
+// AssignmentChangedEvent per `data:` frame. The screen treats each emission
+// as a refetch signal (it re-invalidates solutionAssignmentsProvider), so the
+// payload only carries enough info to identify which solution changed — the
+// canonical list is fetched via the existing non-stream endpoint.
+//
+// Uses a separate http.Client (not the app's dio) because the dio refresh
+// interceptor in api_client.dart awaits responses and would replay-on-401
+// mid-stream, breaking SSE.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:signupflow_mobile/api/api_client.dart' show defaultApiBaseUrl;
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+
+/// SSE payload from the assignments stream. Minimal on purpose — the
+/// consumer's job is to refetch, not to merge.
+@immutable
+class AssignmentChangedEvent {
+  const AssignmentChangedEvent({
+    required this.type,
+    required this.assignmentId,
+    required this.solutionId,
+    required this.status,
+  });
+
+  factory AssignmentChangedEvent.fromJson(Map<String, dynamic> json) {
+    return AssignmentChangedEvent(
+      type: json['type'] as String,
+      assignmentId: json['assignment_id'] as int,
+      solutionId: json['solution_id'] as int,
+      status: json['status'] as String,
+    );
+  }
+
+  final String type;
+  final int assignmentId;
+  final int solutionId;
+  final String status;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AssignmentChangedEvent &&
+          other.type == type &&
+          other.assignmentId == assignmentId &&
+          other.solutionId == solutionId &&
+          other.status == status;
+
+  @override
+  int get hashCode => Object.hash(type, assignmentId, solutionId, status);
+}
+
+/// Factory hook so tests can swap in a fake http.Client returning a canned
+/// StreamedResponse.
+typedef SseClientFactory = http.Client Function();
+final sseHttpClientFactoryProvider = Provider<SseClientFactory>(
+  (_) => http.Client.new,
+);
+
+final solutionAssignmentsStreamProvider =
+    StreamProvider.family<AssignmentChangedEvent, int>((ref, solutionId) {
+  final storage = ref.read(secureTokenStorageProvider);
+  final client = ref.read(sseHttpClientFactoryProvider)();
+  ref.onDispose(client.close);
+  return _streamSolutionAssignments(
+    client: client,
+    storage: storage,
+    solutionId: solutionId,
+  );
+});
+
+Stream<AssignmentChangedEvent> _streamSolutionAssignments({
+  required http.Client client,
+  required SecureTokenStorage storage,
+  required int solutionId,
+}) async* {
+  final token = await storage.readToken();
+  if (token == null || token.isEmpty) {
+    throw StateError('No access token available for SSE stream');
+  }
+  final uri = Uri.parse(
+    '$defaultApiBaseUrl/api/v1/solutions/$solutionId/assignments/stream',
+  );
+  final request = http.Request('GET', uri)
+    ..headers['Authorization'] = 'Bearer $token'
+    ..headers['Accept'] = 'text/event-stream';
+
+  final response = await client.send(request);
+  if (response.statusCode != 200) {
+    throw http.ClientException(
+      'SSE stream returned ${response.statusCode}',
+      uri,
+    );
+  }
+
+  // W3C SSE format: each event is one-or-more `field: value` lines
+  // followed by a blank line. We only care about `data:` lines, which
+  // for our payloads always contain a single JSON object on one line.
+  final buffer = StringBuffer();
+  await for (final line in response.stream
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())) {
+    if (line.isEmpty) {
+      final raw = buffer.toString();
+      buffer.clear();
+      if (raw.isEmpty) continue;
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      yield AssignmentChangedEvent.fromJson(decoded);
+    } else if (line.startsWith('data:')) {
+      if (buffer.isNotEmpty) buffer.write('\n');
+      buffer.write(line.substring(5).trimLeft());
+    }
+    // Other field types (`event:`, `id:`, `retry:`, `:` comment) are
+    // ignored — the backend only emits `data:` frames.
+  }
+}

--- a/mobile/lib/features/admin/solution_review_screen.dart
+++ b/mobile/lib/features/admin/solution_review_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:signupflow_api/signupflow_api.dart' as api;
 import 'package:signupflow_mobile/features/admin/solution_assignments_provider.dart';
+import 'package:signupflow_mobile/features/admin/solution_assignments_stream_provider.dart';
 import 'package:signupflow_mobile/features/admin/solver_provider.dart';
 import 'package:signupflow_mobile/theme/colors.dart';
 import 'package:signupflow_mobile/theme/components.dart';
@@ -33,6 +34,15 @@ class _SolutionReviewScreenState extends ConsumerState<SolutionReviewScreen> {
         const Center(child: Text('Invalid solution id')),
       );
     }
+    // Sprint 10.4b: each SSE event from the backend is a refetch signal.
+    // Invalidating the FutureProvider re-fires the existing GET /assignments
+    // call, so the UI stays canonical without merging deltas into state.
+    ref.listen<AsyncValue<AssignmentChangedEvent>>(
+      solutionAssignmentsStreamProvider(id),
+      (previous, next) {
+        next.whenData((_) => ref.invalidate(solutionAssignmentsProvider(id)));
+      },
+    );
     final asyncData = ref.watch(solutionDetailProvider(id));
     return _frame(
       asyncData.when(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -435,7 +435,7 @@ packages:
     source: hosted
     version: "4.4.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2    # JWT in iOS Keychain
   go_router: ^14.6.0                # declarative routing + deep links
   google_fonts: ^6.2.1              # Inter + JetBrains Mono per brand-spec
+  http: ^1.2.0                      # SSE consumer for Solution Review (Sprint 10.4b)
   intl: ^0.19.0                     # dates / timezones
   riverpod_annotation: ^2.6.1       # Riverpod codegen annotation
   signupflow_api:                   # generated dart-dio client; run `make mobile-codegen` to refresh

--- a/mobile/test/solution_assignments_stream_provider_test.dart
+++ b/mobile/test/solution_assignments_stream_provider_test.dart
@@ -1,0 +1,164 @@
+// Sprint 10 PR 10.4b — SSE consumer unit tests.
+//
+// Pins the parser + provider contract: each `data:` frame surfaces as
+// an AssignmentChangedEvent; missing or 401-responses go to the error
+// state; the http.Client is closed on provider dispose.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:signupflow_mobile/auth/secure_token_storage.dart';
+import 'package:signupflow_mobile/features/admin/solution_assignments_stream_provider.dart';
+
+class _FakeHttpClient extends http.BaseClient {
+  _FakeHttpClient({required this.respond});
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest req) respond;
+  int closeCount = 0;
+  http.BaseRequest? lastRequest;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    lastRequest = request;
+    return respond(request);
+  }
+
+  @override
+  void close() {
+    closeCount++;
+    super.close();
+  }
+}
+
+Stream<List<int>> _sseFramesFor(List<Map<String, Object?>> events) async* {
+  for (final ev in events) {
+    yield utf8.encode('data: ${jsonEncode(ev)}\n\n');
+  }
+}
+
+ProviderContainer _container({
+  required SecureTokenStorage storage,
+  required _FakeHttpClient fakeClient,
+}) {
+  return ProviderContainer(
+    overrides: [
+      secureTokenStorageProvider.overrideWithValue(storage),
+      sseHttpClientFactoryProvider.overrideWithValue(() => fakeClient),
+    ],
+  );
+}
+
+void main() {
+  test('emits one AssignmentChangedEvent per SSE data frame', () async {
+    final storage = InMemoryTokenStorage();
+    await storage.writeToken('access-jwt');
+
+    final fake = _FakeHttpClient(
+      respond: (_) async => http.StreamedResponse(
+        _sseFramesFor([
+          {
+            'type': 'assignment.changed',
+            'assignment_id': 1,
+            'solution_id': 42,
+            'status': 'confirmed',
+          },
+          {
+            'type': 'assignment.changed',
+            'assignment_id': 2,
+            'solution_id': 42,
+            'status': 'declined',
+          },
+        ]),
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      ),
+    );
+
+    final container = _container(storage: storage, fakeClient: fake);
+    addTearDown(container.dispose);
+
+    final stream = container.read(solutionAssignmentsStreamProvider(42).stream);
+    final events = await stream.take(2).toList();
+
+    expect(events, hasLength(2));
+    expect(
+      events[0],
+      const AssignmentChangedEvent(
+        type: 'assignment.changed',
+        assignmentId: 1,
+        solutionId: 42,
+        status: 'confirmed',
+      ),
+    );
+    expect(
+      events[1],
+      const AssignmentChangedEvent(
+        type: 'assignment.changed',
+        assignmentId: 2,
+        solutionId: 42,
+        status: 'declined',
+      ),
+    );
+    expect(fake.lastRequest!.headers['Authorization'], 'Bearer access-jwt');
+    expect(fake.lastRequest!.headers['Accept'], 'text/event-stream');
+  });
+
+  test('surfaces error when no access token available', () async {
+    final storage = InMemoryTokenStorage();
+    // no writeToken — readToken returns null
+    final fake = _FakeHttpClient(
+      respond: (_) async => http.StreamedResponse(const Stream.empty(), 200),
+    );
+    final container = _container(storage: storage, fakeClient: fake);
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(solutionAssignmentsStreamProvider(7).stream),
+      emitsError(isA<StateError>()),
+    );
+  });
+
+  test('surfaces error when SSE endpoint returns non-200', () async {
+    final storage = InMemoryTokenStorage();
+    await storage.writeToken('access-jwt');
+    final fake = _FakeHttpClient(
+      respond: (_) async => http.StreamedResponse(const Stream.empty(), 401),
+    );
+    final container = _container(storage: storage, fakeClient: fake);
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(solutionAssignmentsStreamProvider(7).stream),
+      emitsError(isA<http.ClientException>()),
+    );
+  });
+
+  test('closes the http client on provider dispose', () async {
+    final storage = InMemoryTokenStorage();
+    await storage.writeToken('access-jwt');
+    final fake = _FakeHttpClient(
+      respond: (_) async => http.StreamedResponse(
+        _sseFramesFor([
+          {
+            'type': 'assignment.changed',
+            'assignment_id': 1,
+            'solution_id': 99,
+            'status': 'confirmed',
+          },
+        ]),
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      ),
+    );
+    final container = _container(storage: storage, fakeClient: fake);
+    final stream = container.read(solutionAssignmentsStreamProvider(99).stream);
+    // Drain so the connect path runs.
+    await stream.first;
+    container.dispose();
+
+    expect(fake.closeCount, greaterThanOrEqualTo(1));
+  });
+}

--- a/tests/api/test_assignments_publishes_events.py
+++ b/tests/api/test_assignments_publishes_events.py
@@ -1,0 +1,329 @@
+"""Sprint 10 PR 10.4b — publisher wiring for assignment mutations.
+
+Each mutation endpoint that touches an Assignment with a non-null
+solution_id must publish to event_bus topic ``"solution:{solution_id}"``
+after the DB commit. Manual (admin-created) assignments without a
+solution_id are silent — they don't belong to any Solution Review
+stream.
+
+Tests pin:
+- POST /assignments/{id}/accept publishes (solution_id != None).
+- POST /assignments/{id}/decline publishes.
+- POST /assignments/{id}/swap-request publishes.
+- POST /events/{id}/assignments action=unassign publishes only when the
+  deleted row had a solution_id (manual admin assignments are silent).
+- POST /events/{id}/assignments action=assign never publishes — it
+  always creates an Assignment with solution_id=None.
+
+Auth: tests/api/conftest.py suppresses the root mock_authentication
+fixture, so we use real JWTs via ``create_access_token``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import pytest
+from httpx import AsyncClient
+
+from api.main import app
+from api.models import Assignment, Event, Organization, Person, Solution
+from api.security import create_access_token
+from api.services import event_bus
+
+
+def _seed(
+    db,
+    *,
+    org_id: str,
+    person_id: str,
+    event_id: str,
+    solution_id: int | None,
+    assignment_status: str = "pending",
+) -> tuple[Assignment, str]:
+    """Seed org/person/event/solution/assignment. Returns (assignment, jwt)."""
+    db.add(Organization(id=org_id, name="Test Org", region="Test"))
+    db.add(
+        Person(
+            id=person_id,
+            org_id=org_id,
+            name="Test Volunteer",
+            email=f"{person_id}@example.com",
+            password_hash="$2b$12$dummy_hash",
+            roles=["admin"],  # admin so unassign tests pass
+        )
+    )
+    db.add(
+        Event(
+            id=event_id,
+            org_id=org_id,
+            type="service",
+            start_time=datetime(2026, 6, 1, 10, 0),
+            end_time=datetime(2026, 6, 1, 11, 0),
+        )
+    )
+    if solution_id is not None:
+        db.add(
+            Solution(
+                id=solution_id,
+                org_id=org_id,
+                hard_violations=0,
+                soft_score=0.0,
+                health_score=1.0,
+            )
+        )
+    assignment = Assignment(
+        solution_id=solution_id,
+        event_id=event_id,
+        person_id=person_id,
+        role="volunteer",
+        status=assignment_status,
+    )
+    db.add(assignment)
+    db.commit()
+    db.refresh(assignment)
+    return assignment, create_access_token({"sub": person_id})
+
+
+async def _spawn_listener(topic: str) -> tuple[asyncio.Task, list[dict]]:
+    """Subscribe to ``topic`` and return (task, received_list).
+
+    The task completes once one event has been collected.
+    """
+    received: list[dict] = []
+    consumer_started = asyncio.Event()
+
+    async def consumer():
+        gen = event_bus.subscribe(topic)
+        consumer_started.set()
+        async for event in gen:
+            received.append(event)
+            return
+
+    task = asyncio.create_task(consumer())
+    await consumer_started.wait()
+    # Yield once so subscribe() registers its queue before any publish.
+    await asyncio.sleep(0)
+    return task, received
+
+
+async def _assert_silent(topic: str, *, settle: float = 0.05) -> None:
+    """Subscribe to ``topic`` and assert nothing arrives within ``settle``."""
+    received: list[dict] = []
+    consumer_started = asyncio.Event()
+
+    async def consumer():
+        gen = event_bus.subscribe(topic)
+        consumer_started.set()
+        async for event in gen:
+            received.append(event)
+            return
+
+    task = asyncio.create_task(consumer())
+    await consumer_started.wait()
+    await asyncio.sleep(0)
+    try:
+        await asyncio.wait_for(task, timeout=settle)
+    except asyncio.TimeoutError:
+        pass
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, StopAsyncIteration):
+        pass
+    assert received == [], f"unexpected event on {topic}: {received}"
+
+
+@pytest.mark.asyncio
+async def test_accept_publishes_event(db):
+    assignment, jwt = _seed(
+        db,
+        org_id="pub_accept",
+        person_id="pub_accept_user",
+        event_id="evt_accept",
+        solution_id=501,
+    )
+    task, received = await _spawn_listener(f"solution:{501}")
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            f"/api/v1/assignments/{assignment.id}/accept",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+    assert resp.status_code == 200, resp.text
+
+    await asyncio.wait_for(task, timeout=1.0)
+    assert received == [
+        {
+            "type": "assignment.changed",
+            "assignment_id": assignment.id,
+            "solution_id": 501,
+            "status": "confirmed",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_decline_publishes_event(db):
+    assignment, jwt = _seed(
+        db,
+        org_id="pub_decline",
+        person_id="pub_decline_user",
+        event_id="evt_decline",
+        solution_id=502,
+    )
+    task, received = await _spawn_listener(f"solution:{502}")
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            f"/api/v1/assignments/{assignment.id}/decline",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"decline_reason": "out of town"},
+        )
+    assert resp.status_code == 200, resp.text
+
+    await asyncio.wait_for(task, timeout=1.0)
+    assert received == [
+        {
+            "type": "assignment.changed",
+            "assignment_id": assignment.id,
+            "solution_id": 502,
+            "status": "declined",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_swap_request_publishes_event(db):
+    assignment, jwt = _seed(
+        db,
+        org_id="pub_swap",
+        person_id="pub_swap_user",
+        event_id="evt_swap",
+        solution_id=503,
+    )
+    task, received = await _spawn_listener(f"solution:{503}")
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            f"/api/v1/assignments/{assignment.id}/swap-request",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"note": "need swap"},
+        )
+    assert resp.status_code == 200, resp.text
+
+    await asyncio.wait_for(task, timeout=1.0)
+    assert received == [
+        {
+            "type": "assignment.changed",
+            "assignment_id": assignment.id,
+            "solution_id": 503,
+            "status": "swap_requested",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_volunteer_self_service_silent_for_manual_assignment(db):
+    """Volunteer accept on a manual (solution_id=None) assignment must
+    not publish — there's no Solution Review stream to feed."""
+    assignment, jwt = _seed(
+        db,
+        org_id="pub_manual",
+        person_id="pub_manual_user",
+        event_id="evt_manual",
+        solution_id=None,
+    )
+
+    # The naive bug would format as "solution:None" — subscribe there to
+    # catch any regression.
+    async def hit():
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            resp = await client.post(
+                f"/api/v1/assignments/{assignment.id}/accept",
+                headers={"Authorization": f"Bearer {jwt}"},
+            )
+        assert resp.status_code == 200, resp.text
+
+    # Run the HTTP call concurrently with a brief subscriber wait.
+    hit_task = asyncio.create_task(hit())
+    await _assert_silent("solution:None", settle=0.1)
+    await hit_task
+
+
+@pytest.mark.asyncio
+async def test_admin_unassign_publishes_when_from_solution(db):
+    """Admin removing a solver-derived assignment must publish so the
+    Solution Review stream invalidates."""
+    assignment, jwt = _seed(
+        db,
+        org_id="pub_unassign",
+        person_id="pub_unassign_admin",
+        event_id="evt_unassign",
+        solution_id=504,
+    )
+    task, received = await _spawn_listener(f"solution:{504}")
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/events/evt_unassign/assignments",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"action": "unassign", "person_id": "pub_unassign_admin"},
+        )
+    assert resp.status_code == 200, resp.text
+
+    await asyncio.wait_for(task, timeout=1.0)
+    assert received == [
+        {
+            "type": "assignment.changed",
+            "assignment_id": assignment.id,
+            "solution_id": 504,
+            "status": "deleted",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_admin_assign_does_not_publish(db):
+    """Admin assign creates with solution_id=None — never publishes."""
+    # Seed without an Assignment; we'll create one via the endpoint.
+    db.add(Organization(id="pub_assign", name="Test Org", region="Test"))
+    db.add(
+        Person(
+            id="pub_assign_admin",
+            org_id="pub_assign",
+            name="Admin",
+            email="admin@pub_assign.test",
+            password_hash="$2b$12$dummy_hash",
+            roles=["admin"],
+        )
+    )
+    db.add(
+        Event(
+            id="evt_admin_assign",
+            org_id="pub_assign",
+            type="service",
+            start_time=datetime(2026, 6, 1, 10, 0),
+            end_time=datetime(2026, 6, 1, 11, 0),
+        )
+    )
+    db.commit()
+    jwt = create_access_token({"sub": "pub_assign_admin"})
+
+    async def hit():
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/events/evt_admin_assign/assignments",
+                headers={"Authorization": f"Bearer {jwt}"},
+                json={
+                    "action": "assign",
+                    "person_id": "pub_assign_admin",
+                    "role": "vol",
+                },
+            )
+        assert resp.status_code == 200, resp.text
+
+    hit_task = asyncio.create_task(hit())
+    await _assert_silent("solution:None", settle=0.1)
+    await hit_task


### PR DESCRIPTION
## Summary

Closes the SSE loop opened in PR #94 (Sprint 10.4): the SSE endpoint now actually emits on real assignment changes, and the admin Solution Review screen consumes the stream so it no longer needs pull-to-refresh.

### Backend — publisher wiring
- \`event_bus.publish(\"solution:{id}\", ...)\` fires via FastAPI \`BackgroundTasks\` after every assignment-mutation \`db.commit()\`:
  - \`api/routers/assignments.py\`: \`accept\`, \`decline\`, \`swap-request\` (volunteer self-service).
  - \`api/routers/events.py\`: \`POST /events/{id}/assignments\` \`unassign\` branch.
- Manual / admin-created assignments (\`solution_id=None\`) stay silent — they don't belong to any Solution Review stream. The \`assign\` branch on \`events.py\` always creates \`solution_id=None\` so it never publishes.
- Payload kept minimal (\`{type, assignment_id, solution_id, status}\`) — the consumer treats each event as a refetch signal.

### Mobile — SSE consumer
- New \`solution_assignments_stream_provider.dart\` connects to \`GET /api/v1/solutions/{id}/assignments/stream\` via a **separate \`http.Client\`** (not the app's dio). Reason: dio's refresh interceptor awaits responses and would replay-on-401 mid-stream, breaking SSE.
- JWT injected manually from \`secureTokenStorageProvider\`. Test hook: \`sseHttpClientFactoryProvider\` lets tests swap in a fake \`http.Client\`.
- \`solution_review_screen.dart\` \`ref.listen\`s the new stream and \`ref.invalidate(solutionAssignmentsProvider(id))\` on each emission. Stream-as-signal, not stream-as-data: the existing \`FutureProvider\` stays the source of truth.

### Tests
- **Backend** (\`tests/api/test_assignments_publishes_events.py\`, 6 tests): one per mutation path + manual-assignment silence checks.
- **Mobile** (\`mobile/test/solution_assignments_stream_provider_test.dart\`, 4 tests): parser round-trip, missing-token error, non-200 error, \`client.close()\` on dispose.
- Full backend regression (300 tests in \`tests/api/\` + \`tests/contract/\`) and full mobile suite (61 tests) green locally.

## Out of scope (10.4c follow-up)
- Dark mode widget audit — sweep custom widgets / screens for hardcoded colors and \`Brightness\` assumptions that bypass the \`BlockColors.*Dark\` variants (Codex P2 deferred from 10.4).

## Out of scope (Sprint 11)
- Multi-worker SSE (Redis pub/sub) — single-process scope per \`api/services/event_bus.py\` docstring; operator runs \`WORKERS=1\` for live updates.

## Test plan

- [x] \`poetry run pytest tests/api/ tests/contract/\` (300 passed)
- [x] \`flutter test\` in \`mobile/\` (61 passed)
- [ ] CI green.
- [ ] Codex local review.
- [ ] Operator smoke: backend up on \`WORKERS=1\`; open Solution Review on device; from a second admin client POST \`/assignments/{id}/accept\`; verify the device's list updates within ~1s without pull-to-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)