### PR TITLE
Mobile: dark mode widget audit + segment-toggle remediation (Sprint 10 PR 10.4c)

### DIFF
--- a/mobile/lib/features/admin/solution_review_screen.dart
+++ b/mobile/lib/features/admin/solution_review_screen.dart
@@ -163,27 +163,35 @@ class _Segment extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(3),
       decoration: BoxDecoration(
-        color: BlockColors.line2,
+        color: context.blockColor(
+          light: BlockColors.line2,
+          dark: BlockColors.line2Dark,
+        ),
         borderRadius: BorderRadius.circular(999),
       ),
       child: Row(
         children: [
-          Expanded(child: _seg('ASSIGNMENTS', 'assignments')),
-          Expanded(child: _seg('STATS', 'stats')),
-          Expanded(child: _seg('CONFLICTS', 'conflicts')),
+          Expanded(child: _seg(context, 'ASSIGNMENTS', 'assignments')),
+          Expanded(child: _seg(context, 'STATS', 'stats')),
+          Expanded(child: _seg(context, 'CONFLICTS', 'conflicts')),
         ],
       ),
     );
   }
 
-  Widget _seg(String label, String key) {
+  Widget _seg(BuildContext context, String label, String key) {
     final active = value == key;
     return GestureDetector(
       onTap: () => onChanged(key),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 7),
         decoration: BoxDecoration(
-          color: active ? Colors.white : Colors.transparent,
+          color: active
+              ? context.blockColor(
+                  light: Colors.white,
+                  dark: BlockColors.bgCardDark,
+                )
+              : Colors.transparent,
           borderRadius: BorderRadius.circular(999),
         ),
         alignment: Alignment.center,
@@ -191,7 +199,15 @@ class _Segment extends StatelessWidget {
           label,
           style: BlockType.monoLabel.copyWith(
             fontSize: 11,
-            color: active ? BlockColors.ink1 : BlockColors.ink2,
+            color: active
+                ? context.blockColor(
+                    light: BlockColors.ink1,
+                    dark: BlockColors.ink1Dark,
+                  )
+                : context.blockColor(
+                    light: BlockColors.ink2,
+                    dark: BlockColors.ink2Dark,
+                  ),
           ),
         ),
       ),

--- a/mobile/lib/features/admin/solver_screen.dart
+++ b/mobile/lib/features/admin/solver_screen.dart
@@ -177,26 +177,34 @@ class _ModeSegment extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(3),
       decoration: BoxDecoration(
-        color: BlockColors.line2,
+        color: context.blockColor(
+          light: BlockColors.line2,
+          dark: BlockColors.line2Dark,
+        ),
         borderRadius: BorderRadius.circular(999),
       ),
       child: Row(
         children: [
-          Expanded(child: _seg('STRICT', 'strict')),
-          Expanded(child: _seg('RELAXED', 'relaxed')),
+          Expanded(child: _seg(context, 'STRICT', 'strict')),
+          Expanded(child: _seg(context, 'RELAXED', 'relaxed')),
         ],
       ),
     );
   }
 
-  Widget _seg(String label, String key) {
+  Widget _seg(BuildContext context, String label, String key) {
     final active = value == key;
     return GestureDetector(
       onTap: () => onChanged(key),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 7),
         decoration: BoxDecoration(
-          color: active ? Colors.white : Colors.transparent,
+          color: active
+              ? context.blockColor(
+                  light: Colors.white,
+                  dark: BlockColors.bgCardDark,
+                )
+              : Colors.transparent,
           borderRadius: BorderRadius.circular(999),
         ),
         alignment: Alignment.center,
@@ -204,7 +212,15 @@ class _ModeSegment extends StatelessWidget {
           label,
           style: BlockType.monoLabel.copyWith(
             fontSize: 11,
-            color: active ? BlockColors.ink1 : BlockColors.ink2,
+            color: active
+                ? context.blockColor(
+                    light: BlockColors.ink1,
+                    dark: BlockColors.ink1Dark,
+                  )
+                : context.blockColor(
+                    light: BlockColors.ink2,
+                    dark: BlockColors.ink2Dark,
+                  ),
           ),
         ),
       ),

--- a/mobile/lib/theme/colors.dart
+++ b/mobile/lib/theme/colors.dart
@@ -35,4 +35,18 @@ abstract final class BlockColors {
   static const ink3Dark = Color(0xFF71717A);
 
   static const line1Dark = Color(0xFF27272A);
+  // Sits between bgCardDark (#18181B) and line1Dark (#27272A) so the
+  // segment-toggle group background reads as a subtle inset surface in
+  // dark mode the same way `line2` does in light mode.
+  static const line2Dark = Color(0xFF1F1F23);
+}
+
+extension BlockColorsBrightness on BuildContext {
+  /// Pick the brightness-appropriate variant of a paired color token.
+  ///
+  /// Use at call sites instead of hardcoding `Colors.white` or a
+  /// light-only `BlockColors.*` token where the surface should follow
+  /// the active theme.
+  Color blockColor({required Color light, required Color dark}) =>
+      Theme.of(this).brightness == Brightness.dark ? dark : light;
 }

--- a/mobile/lib/theme/components.dart
+++ b/mobile/lib/theme/components.dart
@@ -24,11 +24,28 @@ class BlockButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Outlined buttons (secondary/destructive) need a surface that
+    // tracks the theme — the same hardcoded white that reads as a
+    // "raised pill" on a light background becomes an invisible blob
+    // on dark. Use `bgCardDark` as the dark-mode raised surface.
+    final outlinedBg = context.blockColor(
+      light: Colors.white,
+      dark: BlockColors.bgCardDark,
+    );
+    final outlinedFg = context.blockColor(
+      light: BlockColors.ink1,
+      dark: BlockColors.ink1Dark,
+    );
+    final outlinedBorder = context.blockColor(
+      light: BlockColors.line1,
+      dark: BlockColors.line1Dark,
+    );
     final (bg, fg, border) = switch (kind) {
       BlockButtonKind.primary => (BlockColors.ink1, Colors.white, null),
       BlockButtonKind.go => (BlockColors.accent, Colors.white, null),
-      BlockButtonKind.secondary => (Colors.white, BlockColors.ink1, BlockColors.line1),
-      BlockButtonKind.destructive => (Colors.white, BlockColors.danger, BlockColors.line1),
+      BlockButtonKind.secondary => (outlinedBg, outlinedFg, outlinedBorder),
+      BlockButtonKind.destructive =>
+        (outlinedBg, BlockColors.danger, outlinedBorder),
     };
     return SizedBox(
       width: double.infinity,
@@ -97,8 +114,16 @@ class RoleChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: Colors.white,
-        border: Border.all(color: BlockColors.line1),
+        color: context.blockColor(
+          light: Colors.white,
+          dark: BlockColors.bgCardDark,
+        ),
+        border: Border.all(
+          color: context.blockColor(
+            light: BlockColors.line1,
+            dark: BlockColors.line1Dark,
+          ),
+        ),
         borderRadius: BorderRadius.circular(6),
       ),
       child: Text(
@@ -107,7 +132,10 @@ class RoleChip extends StatelessWidget {
           fontSize: 10,
           fontWeight: FontWeight.w500,
           letterSpacing: 0.6,
-          color: BlockColors.ink2,
+          color: context.blockColor(
+            light: BlockColors.ink2,
+            dark: BlockColors.ink2Dark,
+          ),
         ),
       ),
     );

--- a/mobile/test/dark_mode_segment_test.dart
+++ b/mobile/test/dark_mode_segment_test.dart
@@ -1,0 +1,162 @@
+// Sprint 10 PR 10.4c — dark-mode regression test for segment toggles.
+//
+// Pins the contract: when the app is rendered under
+// `themeMode: ThemeMode.dark`, the active segment pill in both
+// SolutionReview and Solver must NOT be `Colors.white` — that's the
+// bypass pattern Codex flagged and 10.4c is fixing. If anyone
+// reintroduces the hardcode, these tests fail.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:signupflow_api/signupflow_api.dart' as api;
+import 'package:signupflow_mobile/features/admin/solution_assignments_provider.dart';
+import 'package:signupflow_mobile/features/admin/solution_review_screen.dart';
+import 'package:signupflow_mobile/features/admin/solver_provider.dart';
+import 'package:signupflow_mobile/features/admin/solver_screen.dart';
+import 'package:signupflow_mobile/theme/colors.dart';
+import 'package:signupflow_mobile/theme/theme.dart';
+
+api.SolutionAssignmentsResponse _emptyAssignments(int id) {
+  return (api.SolutionAssignmentsResponseBuilder()
+        ..solutionId = id
+        ..events = ListBuilder<api.SolutionAssignmentEntry>()
+        ..totalAssignments = 0)
+      .build();
+}
+
+api.SolutionResponse _solution() {
+  return (api.SolutionResponseBuilder()
+        ..id = 142
+        ..orgId = 'hcc'
+        ..solveMs = 274
+        ..hardViolations = 0
+        ..softScore = 1.5
+        ..healthScore = 98
+        ..isPublished = false
+        ..assignmentCount = 24
+        ..createdAt = DateTime(2026, 5, 7, 14, 14).toUtc()
+        ..metrics = MapBuilder<String, JsonObject?>())
+      .build();
+}
+
+api.SolutionStatsResponse _stats() {
+  return (api.SolutionStatsResponseBuilder()
+        ..solutionId = 142
+        ..fairness = (api.FairnessStatsBuilder()
+          ..stdev = 0.42
+          ..perPersonCounts = MapBuilder<String, int>({'p1': 1, 'p2': 2})
+          ..histogram = MapBuilder<String, int>({'1': 1, '2': 1}))
+        ..stability = (api.StabilityMetricsBuilder()
+          ..movesFromPublished = 4
+          ..affectedPersons = 2)
+        ..workload = (api.WorkloadStatsBuilder()
+          ..maxEventsPerPerson = 3
+          ..minEventsPerPerson = 1
+          ..medianEventsPerPerson = 2.0
+          ..totalEventsAssigned = 8
+          ..distinctPersonsAssigned = 4))
+      .build();
+}
+
+Color? _activePillColor(WidgetTester tester, String label) {
+  // Each segment renders the label inside a GestureDetector > Container.
+  // Walk up from the label Text to find the Container with the active
+  // pill color (the closest enclosing decorated Container).
+  final container = tester
+      .widgetList<Container>(
+        find.ancestor(
+          of: find.text(label),
+          matching: find.byType(Container),
+        ),
+      )
+      .firstWhere(
+        (c) => c.decoration is BoxDecoration,
+        orElse: Container.new,
+      );
+  final deco = container.decoration as BoxDecoration?;
+  return deco?.color;
+}
+
+void main() {
+  testWidgets(
+    'SolutionReview active segment pill is not Colors.white in dark mode',
+    (tester) async {
+      final data = SolutionDetailData(solution: _solution(), stats: _stats());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            solutionDetailProvider(142).overrideWith((ref) async => data),
+            solutionAssignmentsProvider(142)
+                .overrideWith((ref) async => _emptyAssignments(142)),
+          ],
+          child: MaterialApp(
+            theme: buildBlockMonoTheme(),
+            darkTheme: buildBlockMonoDarkTheme(),
+            themeMode: ThemeMode.dark,
+            home: const SolutionReviewScreen(solutionId: '142'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Default segment is "assignments" — the ASSIGNMENTS label is the
+      // active pill.
+      final activeColor = _activePillColor(tester, 'ASSIGNMENTS');
+      expect(activeColor, isNot(Colors.white),
+          reason: '10.4c regression: active segment pill must follow theme');
+      expect(activeColor, BlockColors.bgCardDark);
+    },
+  );
+
+  testWidgets(
+    'Solver active mode pill is not Colors.white in dark mode',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: buildBlockMonoTheme(),
+            darkTheme: buildBlockMonoDarkTheme(),
+            themeMode: ThemeMode.dark,
+            home: const SolverScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Default mode is 'strict' — STRICT is the active pill.
+      final activeColor = _activePillColor(tester, 'STRICT');
+      expect(activeColor, isNot(Colors.white),
+          reason: '10.4c regression: active mode pill must follow theme');
+      expect(activeColor, BlockColors.bgCardDark);
+    },
+  );
+
+  testWidgets(
+    'SolutionReview active segment pill IS Colors.white in light mode',
+    (tester) async {
+      final data = SolutionDetailData(solution: _solution(), stats: _stats());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            solutionDetailProvider(142).overrideWith((ref) async => data),
+            solutionAssignmentsProvider(142)
+                .overrideWith((ref) async => _emptyAssignments(142)),
+          ],
+          child: MaterialApp(
+            theme: buildBlockMonoTheme(),
+            home: const SolutionReviewScreen(solutionId: '142'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Sanity check that the light-mode look is unchanged.
+      expect(_activePillColor(tester, 'ASSIGNMENTS'), Colors.white);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the Codex P2 deferred from Sprint 10.4: several custom widgets hardcoded \`Colors.white\` in interactive surfaces and became invisible against a dark background.

### New tokens / helper (\`mobile/lib/theme/colors.dart\`)
- \`BlockColors.line2Dark\` (\`#1F1F23\`) — divider between \`bgCardDark\` and \`line1Dark\`, mirroring how \`line2\` sits relative to \`line1\` in light mode.
- \`BlockColorsBrightness\` extension on \`BuildContext\` — call sites use \`context.blockColor(light: ..., dark: ...)\` so the brightness switch is one expression, not a scattered ternary.

### Call sites fixed
- \`components.dart\` \`BlockButton.secondary\` + \`.destructive\` — backgrounds + borders + foregrounds now theme-aware.
- \`components.dart\` \`RoleChip\` — same.
- \`solution_review_screen.dart\` segment toggle — group bg (\`line2\` → \`line2Dark\`), active pill bg (\`white\` → \`bgCardDark\`), label colors (\`ink1/2\` → \`ink1Dark/2Dark\`).
- \`solver_screen.dart\` \`_ModeSegment\` — identical shape to the segment toggle above.

### Regression test
\`mobile/test/dark_mode_segment_test.dart\` — 3 tests pin the contract:
1. Under \`ThemeMode.dark\`, the active SolutionReview segment pill is NOT \`Colors.white\` and IS \`BlockColors.bgCardDark\`.
2. Same for Solver mode pill.
3. Under \`ThemeMode.light\` (sanity), the active pill remains \`Colors.white\`.

If anyone reintroduces a hardcoded \`Colors.white\` in those segment pills, the dark-mode tests fail.

## Out of scope (deferred — 10.4d or just leave)
- \`shell.dart:90\` inbox unread badge text.
- \`brand.dart:28\` brand-mark icon (likely intentional brand invariance).
- \`availability_screen.dart:80,513\` modal sheet backgrounds.
- \`BlockColors.accentSoftDark\` token — \`accentSoft\` cosmetic contrast issue on dark bg (profile calendar card); not interactive-UI invisibility.
- Full visual-snapshot pass across every screen under dark theme.

## Test plan

- [x] \`flutter analyze\` on touched files (no issues).
- [x] \`flutter test\` full suite (64 passed; was 61, +3 new).
- [ ] CI green.
- [ ] Codex local review.
- [ ] Operator smoke: install on simulator, Profile → theme = Dark, navigate to Solution Review + Solver, verify segment toggles remain visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)