### PR TITLE
Mobile: theme-aware modal sheet backgrounds (Sprint 10 PR 10.4d)

### DIFF
--- a/mobile/lib/features/admin/people_screen.dart
+++ b/mobile/lib/features/admin/people_screen.dart
@@ -110,7 +110,10 @@ class _PeopleScreenState extends ConsumerState<PeopleScreen> {
     final ok = await showModalBottomSheet<bool>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: BlockColors.bgCard,
+      backgroundColor: context.blockColor(
+        light: BlockColors.bgCard,
+        dark: BlockColors.bgCardDark,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),

--- a/mobile/lib/features/volunteer/assignment_detail_screen.dart
+++ b/mobile/lib/features/volunteer/assignment_detail_screen.dart
@@ -280,7 +280,10 @@ class _Body extends ConsumerWidget {
     final ctrl = TextEditingController();
     return showModalBottomSheet<String?>(
       context: context,
-      backgroundColor: BlockColors.bgCard,
+      backgroundColor: context.blockColor(
+        light: BlockColors.bgCard,
+        dark: BlockColors.bgCardDark,
+      ),
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/mobile/lib/features/volunteer/availability_screen.dart
+++ b/mobile/lib/features/volunteer/availability_screen.dart
@@ -77,7 +77,10 @@ class AvailabilityScreen extends ConsumerWidget {
     final result = await showModalBottomSheet<bool>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: BlockColors.bgCard,
+      backgroundColor: context.blockColor(
+        light: BlockColors.bgCard,
+        dark: BlockColors.bgCardDark,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -510,7 +513,10 @@ class _RruleCard extends ConsumerWidget {
     final picked = await showModalBottomSheet<String?>(
       context: context,
       isScrollControlled: true,
-      backgroundColor: BlockColors.bgCard,
+      backgroundColor: context.blockColor(
+        light: BlockColors.bgCard,
+        dark: BlockColors.bgCardDark,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),


### PR DESCRIPTION
## Summary

10.4c fixed the segment toggles + outlined buttons; the remaining bypass was \`showModalBottomSheet(backgroundColor: BlockColors.bgCard)\` — four call sites that render a white sheet over the dark scaffold in dark mode.

Each swapped for \`context.blockColor(light: BlockColors.bgCard, dark: BlockColors.bgCardDark)\` (the helper added in 10.4c).

### Files
- \`mobile/lib/features/volunteer/availability_screen.dart\` (×2 — add-availability sheet, rrule-picker sheet)
- \`mobile/lib/features/admin/people_screen.dart\` (invite sheet)
- \`mobile/lib/features/volunteer/assignment_detail_screen.dart\` (swap/decline reason sheet)

## Test plan

- [x] \`flutter analyze\` on touched files (no issues).
- [x] \`flutter test\` full suite (64 passed).
- [ ] CI green.
- [ ] Codex local review.
- [ ] Operator smoke: open each sheet on a real device with Profile → theme = Dark, verify the sheet bg matches the scaffold rather than flashing white.

## Out of scope (no longer 10.4 follow-ups — likely WONTFIX)

- \`mobile/lib/features/admin/shell.dart:90\` — inbox unread badge: white text on the \`danger\` red badge background. Works in both themes; not breakage.
- \`mobile/lib/theme/brand.dart:28\` — brand-mark 'S' icon: always white on accent. Intentional brand identity.
- \`accentSoft\` dark variant — cosmetic contrast issue on profile calendar card; non-interactive, low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)