### PR TITLE
Web: signup page — create org + first admin (Sprint 11 PR 11.1)

### DIFF
--- a/tests/web/test_signup.py
+++ b/tests/web/test_signup.py
@@ -1,0 +1,84 @@
+"""Sprint 11.1 — web signup (create org + first admin)."""
+
+from __future__ import annotations
+
+from web.deps import SESSION_COOKIE
+
+
+def test_signup_page_renders(client):
+    resp = client.get("/auth/signup")
+    assert resp.status_code == 200
+    assert 'name="org_name"' in resp.text
+    assert "Create your organization" in resp.text
+
+
+def test_signup_creates_org_and_admin_then_redirects(client, db):
+    resp = client.post(
+        "/auth/signup",
+        data={
+            "org_name": "Hope Community Church",
+            "name": "Sarah Kim",
+            "email": "sarah@hopechurch.org",
+            "password": "StrongPass123!",
+        },
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/a/dashboard"
+    assert SESSION_COOKIE in resp.cookies
+
+    # The session works: dashboard loads as admin.
+    token = resp.cookies[SESSION_COOKIE]
+    dash = client.get("/a/dashboard", cookies={SESSION_COOKIE: token})
+    assert dash.status_code == 200
+    assert "Sarah Kim" in dash.text
+
+
+def test_signup_duplicate_email_shows_error(client, db):
+    payload = {
+        "org_name": "First Org",
+        "name": "Admin One",
+        "email": "dup@example.com",
+        "password": "StrongPass123!",
+    }
+    first = client.post("/auth/signup", data=payload)
+    assert first.status_code == 303
+
+    # Second signup, different org name but same email → API signup
+    # raises 409; web surfaces it inline, no cookie.
+    payload2 = dict(payload, org_name="Second Org")
+    resp = client.post("/auth/signup", data=payload2)
+    assert resp.status_code == 409
+    assert "already registered" in resp.text.lower()
+    assert SESSION_COOKIE not in resp.cookies
+
+
+def test_signup_short_password_rejected(client, db):
+    resp = client.post(
+        "/auth/signup",
+        data={
+            "org_name": "Tiny Pw Org",
+            "name": "Pw User",
+            "email": "pw@example.com",
+            "password": "short",
+        },
+    )
+    # SignupRequest enforces min_length=6 → pydantic ValidationError →
+    # surfaced as a form error, not a 500.
+    assert resp.status_code in (400, 422)
+    assert SESSION_COOKIE not in resp.cookies
+
+
+def test_signup_redirects_when_already_authenticated(client, db):
+    login = client.post(
+        "/auth/signup",
+        data={
+            "org_name": "Already Org",
+            "name": "Already In",
+            "email": "already@example.com",
+            "password": "StrongPass123!",
+        },
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/auth/signup", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/a/dashboard"

--- a/web/auth.py
+++ b/web/auth.py
@@ -9,13 +9,19 @@ redirect the browser to the role-appropriate landing page.
 from __future__ import annotations
 
 import os
+import re
+import uuid
 
-from fastapi import APIRouter, Depends, Form, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from api.database import get_db
 from api.models import Person
+from api.routers.auth import SignupRequest, signup as api_signup
+from api.routers.organizations import create_organization
+from api.schemas.organization import OrganizationCreate
 from api.security import create_access_token, verify_password
 from api.timeutils import utcnow
 from web.deps import SESSION_COOKIE, get_optional_session_user
@@ -40,8 +46,7 @@ def _landing_for(person: Person) -> str:
     return "/a/dashboard" if "admin" in (person.roles or []) else "/v/schedule"
 
 
-def set_session_cookie(response, person: Person) -> None:
-    token = create_access_token(data={"sub": person.id, "pwd_iat": _pwd_iat_for(person)})
+def _set_cookie(response, token: str) -> None:
     response.set_cookie(
         key=SESSION_COOKIE,
         value=token,
@@ -51,6 +56,19 @@ def set_session_cookie(response, person: Person) -> None:
         samesite="lax",
         path="/",
     )
+
+
+def set_session_cookie(response, person: Person) -> None:
+    _set_cookie(
+        response,
+        create_access_token(data={"sub": person.id, "pwd_iat": _pwd_iat_for(person)}),
+    )
+
+
+def _slugify(name: str) -> str:
+    """org name → url-safe id. Mirrors the mobile create-org slug rule."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug or "org"
 
 
 @router.get("/auth/login", response_class=HTMLResponse)
@@ -94,6 +112,67 @@ def login_submit(
 
     response = RedirectResponse(url=_landing_for(person), status_code=303)
     set_session_cookie(response, person)
+    return response
+
+
+@router.get("/auth/signup", response_class=HTMLResponse)
+def signup_form(
+    request: Request,
+    person: Person | None = Depends(get_optional_session_user),
+):
+    if person is not None:
+        return RedirectResponse(url=_landing_for(person), status_code=303)
+    from web.app import templates
+
+    return templates.TemplateResponse(request, "auth/signup.html", {"error": None, "form": {}})
+
+
+@router.post("/auth/signup")
+def signup_submit(
+    request: Request,
+    org_name: str = Form(...),
+    name: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    """Create an organization and its first user (auto-admin). Reuses the
+    API's create_organization + signup so all validation/limits apply."""
+    from web.app import templates
+
+    form = {"org_name": org_name, "name": name, "email": email}
+
+    def _err(msg: str, code: int = 400):
+        return templates.TemplateResponse(
+            request,
+            "auth/signup.html",
+            {"error": msg, "form": form},
+            status_code=code,
+        )
+
+    org_id = f"{_slugify(org_name)}-{uuid.uuid4().hex[:6]}"
+
+    # Validate the signup payload BEFORE creating the org, so a bad
+    # password (pydantic min_length) can't leave an orphan organization.
+    try:
+        signup_req = SignupRequest(org_id=org_id, name=name, email=email, password=password)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        field = first.get("loc", ["field"])[-1]
+        return _err(f"{field}: {first.get('msg', 'invalid value')}", code=400)
+
+    try:
+        create_organization(OrganizationCreate(id=org_id, name=org_name), db)
+    except HTTPException as exc:
+        return _err(f"Could not create organization: {exc.detail}")
+
+    try:
+        auth = api_signup(signup_req, db)
+    except HTTPException as exc:
+        return _err(str(exc.detail), code=exc.status_code or 400)
+
+    response = RedirectResponse(url="/a/dashboard", status_code=303)
+    _set_cookie(response, auth.token)
     return response
 
 

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -26,5 +26,6 @@
   </form>
 
   <a class="auth-link" href="/auth/forgot">Forgot password?</a>
+  <a class="auth-link" href="/auth/signup">Create a new organization</a>
 </div>
 {% endblock %}

--- a/web/templates/auth/signup.html
+++ b/web/templates/auth/signup.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}Create organization · SignUpFlow{% endblock %}
+{% block body %}
+<div class="auth-wrap">
+  <div class="brand-mark">S</div>
+  <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
+  <div class="auth-sub">Create your organization</div>
+
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% endif %}
+
+  <form method="post" action="/auth/signup">
+    <div class="field">
+      <label class="field-label" for="org_name">Organization name</label>
+      <input id="org_name" name="org_name" type="text"
+             placeholder="Hope Community Church" required autofocus
+             value="{{ form.org_name or '' }}">
+    </div>
+    <div class="field">
+      <label class="field-label" for="name">Your name</label>
+      <input id="name" name="name" type="text" autocomplete="name"
+             placeholder="Sarah Kim" required value="{{ form.name or '' }}">
+    </div>
+    <div class="field">
+      <label class="field-label" for="email">Email</label>
+      <input id="email" name="email" type="email" autocomplete="email"
+             placeholder="you@church.org" required value="{{ form.email or '' }}">
+    </div>
+    <div class="field">
+      <label class="field-label" for="password">Password</label>
+      <input id="password" name="password" type="password"
+             autocomplete="new-password" placeholder="At least 6 characters"
+             minlength="6" required>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Create organization</button>
+  </form>
+
+  <div class="auth-sub" style="margin-top:14px;text-transform:none;letter-spacing:0">
+    The first account is the admin.
+  </div>
+  <a class="auth-link" href="/auth/login">Already have an account? Sign in</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
`GET/POST /auth/signup` — creates an organization + its first user (auto-admin) by reusing `create_organization` + `signup` from the API routers directly. Validates the signup payload **before** creating the org (no orphan org on bad password). Sets the session cookie, redirects to `/a/dashboard`. Login page now links to it.

## Test plan
- [x] 5 web tests: render, create→redirect→authed dashboard, duplicate-email 409 inline, short-password rejected, already-authed redirect
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 20 pass (contract + openapi guards intact)
- [x] **E2E on live server**: signup page renders brand-correct (desktop+mobile screenshots); `curl` POST → 303 → httpOnly cookie → `/a/dashboard` renders as admin

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)