### PR TITLE
Web: forgot + reset password flow (Sprint 11 PR 11.2 + 11.3)

### DIFF
--- a/tests/web/test_password_reset.py
+++ b/tests/web/test_password_reset.py
@@ -1,0 +1,83 @@
+"""Sprint 11.2 + 11.3 — forgot-password + reset-password web flow."""
+
+from __future__ import annotations
+
+from api.models import Person
+from api.security import verify_password
+from tests.web.conftest import seed_person
+
+
+def test_forgot_page_renders(client):
+    resp = client.get("/auth/forgot")
+    assert resp.status_code == 200
+    assert 'name="email"' in resp.text
+    assert "Reset your password" in resp.text
+
+
+def test_forgot_unknown_email_still_shows_sent(client, db):
+    # No user enumeration: unknown email returns the same generic message.
+    resp = client.post("/auth/forgot", data={"email": "nobody@example.com"})
+    assert resp.status_code == 200
+    assert "reset link is on its way" in resp.text.lower()
+
+
+def test_forgot_invalid_email_shows_validation_error(client, db):
+    resp = client.post("/auth/forgot", data={"email": "not-an-email"})
+    assert resp.status_code == 400
+    assert "valid email" in resp.text.lower()
+
+
+def test_reset_page_renders_with_token(client):
+    resp = client.get("/auth/reset/sometoken123")
+    assert resp.status_code == 200
+    assert 'action="/auth/reset/sometoken123"' in resp.text
+    assert 'name="password"' in resp.text
+
+
+def test_reset_invalid_token_shows_error(client, db):
+    seed_person(db, email="reset-bad@example.com")
+    resp = client.post(
+        "/auth/reset/totally-invalid-token",
+        data={"password": "BrandNewPass123!"},
+    )
+    assert resp.status_code in (400, 404)
+    assert "error" in resp.text.lower() or "invalid" in resp.text.lower()
+
+
+def test_reset_short_password_rejected(client, db):
+    resp = client.post("/auth/reset/whatever", data={"password": "short"})
+    assert resp.status_code == 400
+    assert "at least 6" in resp.text.lower()
+
+
+def test_full_reset_flow_changes_password(client, db, monkeypatch):
+    """Real token: API forgot (debug-token on) → web reset → password
+    actually changes and login works with the new one."""
+    monkeypatch.setenv("DEBUG_RETURN_RESET_TOKEN", "true")
+    seed_person(
+        db,
+        person_id="reset_user",
+        email="resetme@example.com",
+        password="OldPass123!",
+    )
+    issued = client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "resetme@example.com"},
+    )
+    assert issued.status_code == 200
+    token = issued.json()["token"]
+
+    resp = client.post(f"/auth/reset/{token}", data={"password": "FreshPass456!"})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login?reset=1"
+
+    person = db.query(Person).filter(Person.id == "reset_user").first()
+    db.refresh(person)
+    assert verify_password("FreshPass456!", person.password_hash)
+    assert not verify_password("OldPass123!", person.password_hash)
+
+
+def test_login_shows_reset_banner(client):
+    resp = client.get("/auth/login?reset=1")
+    assert resp.status_code == 200
+    assert "password updated" in resp.text.lower()

--- a/web/auth.py
+++ b/web/auth.py
@@ -12,7 +12,7 @@ import os
 import re
 import uuid
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -21,6 +21,12 @@ from api.database import get_db
 from api.models import Person
 from api.routers.auth import SignupRequest, signup as api_signup
 from api.routers.organizations import create_organization
+from api.routers.password_reset import (
+    PasswordResetConfirm,
+    PasswordResetRequest,
+    request_password_reset,
+    reset_password,
+)
 from api.schemas.organization import OrganizationCreate
 from api.security import create_access_token, verify_password
 from api.timeutils import utcnow
@@ -81,7 +87,18 @@ def login_form(
         return RedirectResponse(url=_landing_for(person), status_code=303)
     from web.app import templates
 
-    return templates.TemplateResponse(request, "auth/login.html", {"error": None})
+    return templates.TemplateResponse(
+        request,
+        "auth/login.html",
+        {
+            "error": None,
+            "notice": (
+                "Password updated — sign in with your new password."
+                if request.query_params.get("reset") == "1"
+                else None
+            ),
+        },
+    )
 
 
 @router.post("/auth/login")
@@ -174,6 +191,75 @@ def signup_submit(
     response = RedirectResponse(url="/a/dashboard", status_code=303)
     _set_cookie(response, auth.token)
     return response
+
+
+@router.get("/auth/forgot", response_class=HTMLResponse)
+def forgot_form(request: Request):
+    from web.app import templates
+
+    return templates.TemplateResponse(request, "auth/forgot.html", {"sent": False, "error": None})
+
+
+@router.post("/auth/forgot")
+def forgot_submit(
+    request: Request,
+    email: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    """Always renders the same 'if it exists, a link was sent' message —
+    no user enumeration (mirrors the API's generic response)."""
+    from web.app import templates
+
+    try:
+        req = PasswordResetRequest(email=email)
+    except ValidationError:
+        return templates.TemplateResponse(
+            request,
+            "auth/forgot.html",
+            {"sent": False, "error": "Enter a valid email address."},
+            status_code=400,
+        )
+    # Reuse the API handler; a throwaway BackgroundTasks collects the
+    # (best-effort) email send. Generic response regardless of outcome.
+    request_password_reset(req, request, BackgroundTasks(), db)
+    return templates.TemplateResponse(request, "auth/forgot.html", {"sent": True, "error": None})
+
+
+@router.get("/auth/reset/{token}", response_class=HTMLResponse)
+def reset_form(request: Request, token: str):
+    from web.app import templates
+
+    return templates.TemplateResponse(request, "auth/reset.html", {"token": token, "error": None})
+
+
+@router.post("/auth/reset/{token}")
+def reset_submit(
+    request: Request,
+    token: str,
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    def _err(msg: str, code: int = 400):
+        return templates.TemplateResponse(
+            request,
+            "auth/reset.html",
+            {"token": token, "error": msg},
+            status_code=code,
+        )
+
+    try:
+        confirm = PasswordResetConfirm(token=token, new_password=password)
+    except ValidationError:
+        return _err("Password must be at least 6 characters.")
+    try:
+        reset_password(confirm, db)
+    except HTTPException as exc:
+        return _err(str(exc.detail), code=exc.status_code or 400)
+
+    # Success → bounce to login with a one-shot banner via query flag.
+    return RedirectResponse(url="/auth/login?reset=1", status_code=303)
 
 
 @router.post("/auth/logout")

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -388,6 +388,15 @@ a { color: var(--accent); text-decoration: none; }
   padding: 10px 12px;
   font-size: 13px;
 }
+.form-notice {
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  border: 1px solid var(--success);
+  color: var(--success);
+  border-radius: var(--r-chip);
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.45;
+}
 
 /* ─── Misc ──────────────────────────────────────────────────────────── */
 .empty {

--- a/web/templates/auth/forgot.html
+++ b/web/templates/auth/forgot.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block title %}Forgot password · SignUpFlow{% endblock %}
+{% block body %}
+<div class="auth-wrap">
+  <div class="brand-mark">S</div>
+  <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
+  <div class="auth-sub">Reset your password</div>
+
+  {% if sent %}
+  <div class="form-notice" role="status">
+    If an account exists for that email, a reset link is on its way.
+    Check your inbox.
+  </div>
+  <a class="auth-link" href="/auth/login">Back to sign in</a>
+  {% else %}
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% endif %}
+  <form method="post" action="/auth/forgot">
+    <div class="field">
+      <label class="field-label" for="email">Email</label>
+      <input id="email" name="email" type="email" autocomplete="email"
+             placeholder="you@church.org" required autofocus>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Send reset link</button>
+  </form>
+  <a class="auth-link" href="/auth/login">Back to sign in</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -6,6 +6,9 @@
   <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
   <div class="auth-sub">Volunteer scheduling</div>
 
+  {% if notice %}
+  <div class="form-notice" role="status">{{ notice }}</div>
+  {% endif %}
   {% if error %}
   <div class="form-error" role="alert">{{ error }}</div>
   {% endif %}

--- a/web/templates/auth/reset.html
+++ b/web/templates/auth/reset.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Set new password · SignUpFlow{% endblock %}
+{% block body %}
+<div class="auth-wrap">
+  <div class="brand-mark">S</div>
+  <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
+  <div class="auth-sub">Choose a new password</div>
+
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% endif %}
+
+  <form method="post" action="/auth/reset/{{ token }}">
+    <div class="field">
+      <label class="field-label" for="password">New password</label>
+      <input id="password" name="password" type="password"
+             autocomplete="new-password" placeholder="At least 6 characters"
+             minlength="6" required autofocus>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Update password</button>
+  </form>
+  <a class="auth-link" href="/auth/login">Back to sign in</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
Bundled — forgot→reset is one coherent journey (a reset link is meaningless without the request).

- `GET/POST /auth/forgot` reuses `request_password_reset`; generic no-enumeration message; invalid email → inline 400.
- `GET/POST /auth/reset/{token}` reuses `reset_password`; invalid/expired token + short password → inline error; success → `303 /auth/login?reset=1`.
- Login shows a green success banner on `?reset=1` (new `.form-notice`, dark-mode aware).

## Test plan
- [x] 8 web tests incl. full real-token flow (API debug-token → web reset → password actually changes; old rejected; no-enumeration; banner)
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 28 pass
- [x] **E2E on live server**: forgot + reset pages + reset-success banner screenshotted (desktop)

Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)