### PR TITLE
Web: invitation accept page (Sprint 11 PR 11.4)

### DIFF
--- a/tests/web/test_invitation.py
+++ b/tests/web/test_invitation.py
@@ -1,0 +1,106 @@
+"""Sprint 11.4 — invitation accept web flow."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from api.models import Invitation, Person
+from api.timeutils import utcnow
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _seed_invite(
+    db,
+    *,
+    token="invite-tok-123",
+    org_id="web_org",
+    email="newvol@example.com",
+    name="New Vol",
+    roles=None,
+    status="pending",
+    expires_in=timedelta(days=3),
+):
+    admin = seed_person(
+        db,
+        person_id="inv_admin",
+        org_id=org_id,
+        email="invadmin@example.com",
+        roles=["admin"],
+    )
+    inv = Invitation(
+        id=f"inv_{token}",
+        org_id=org_id,
+        email=email,
+        name=name,
+        roles=roles if roles is not None else ["volunteer"],
+        invited_by=admin.id,
+        token=token,
+        status=status,
+        expires_at=utcnow() + expires_in,
+    )
+    db.add(inv)
+    db.commit()
+    return inv
+
+
+def test_invitation_page_renders_for_valid_token(client, db):
+    _seed_invite(db, name="Jamie Park", email="jamie@example.com")
+    resp = client.get("/auth/invitation/invite-tok-123")
+    assert resp.status_code == 200
+    assert "Jamie Park" in resp.text
+    assert "jamie@example.com" in resp.text
+    assert 'name="password"' in resp.text
+
+
+def test_invitation_invalid_token_shows_error(client, db):
+    resp = client.get("/auth/invitation/does-not-exist")
+    assert resp.status_code == 410
+    assert "invalid" in resp.text.lower()
+
+
+def test_invitation_expired_token_shows_error(client, db):
+    _seed_invite(db, token="exp-tok", expires_in=timedelta(days=-1))
+    resp = client.get("/auth/invitation/exp-tok")
+    assert resp.status_code == 410
+    assert "expired" in resp.text.lower()
+
+
+def test_accept_invitation_creates_account_and_authenticates(client, db):
+    _seed_invite(db, token="acc-tok", email="accepter@example.com", roles=["volunteer"])
+    resp = client.post("/auth/invitation/acc-tok", data={"password": "MyNewPass123!"})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/v/schedule"
+    assert SESSION_COOKIE in resp.cookies
+
+    # Account created with the invited email + role.
+    person = db.query(Person).filter(Person.email == "accepter@example.com").first()
+    assert person is not None
+    assert person.roles == ["volunteer"]
+
+    # Session works.
+    token = resp.cookies[SESSION_COOKIE]
+    sched = client.get("/v/schedule", cookies={SESSION_COOKIE: token})
+    assert sched.status_code == 200
+
+
+def test_accept_admin_invitation_lands_on_dashboard(client, db):
+    _seed_invite(db, token="adm-tok", email="newadmin@example.com", roles=["admin"])
+    resp = client.post("/auth/invitation/adm-tok", data={"password": "AdminPass123!"})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/a/dashboard"
+
+
+def test_accept_short_password_rejected(client, db):
+    _seed_invite(db, token="short-tok")
+    resp = client.post("/auth/invitation/short-tok", data={"password": "x"})
+    assert resp.status_code == 400
+    assert "at least 6" in resp.text.lower()
+    assert SESSION_COOKIE not in resp.cookies
+
+
+def test_accept_already_accepted_invitation_errors(client, db):
+    _seed_invite(db, token="used-tok", status="accepted")
+    resp = client.post("/auth/invitation/used-tok", data={"password": "WhateverPass1!"})
+    assert resp.status_code in (400, 410)
+    assert SESSION_COOKIE not in resp.cookies

--- a/web/auth.py
+++ b/web/auth.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from api.database import get_db
 from api.models import Person
 from api.routers.auth import SignupRequest, signup as api_signup
+from api.routers.invitations import accept_invitation, verify_invitation
 from api.routers.organizations import create_organization
 from api.routers.password_reset import (
     PasswordResetConfirm,
@@ -27,6 +28,7 @@ from api.routers.password_reset import (
     request_password_reset,
     reset_password,
 )
+from api.schemas.invitation import InvitationAccept
 from api.schemas.organization import OrganizationCreate
 from api.security import create_access_token, verify_password
 from api.timeutils import utcnow
@@ -260,6 +262,66 @@ def reset_submit(
 
     # Success → bounce to login with a one-shot banner via query flag.
     return RedirectResponse(url="/auth/login?reset=1", status_code=303)
+
+
+@router.get("/auth/invitation/{token}", response_class=HTMLResponse)
+def invitation_form(request: Request, token: str, db: Session = Depends(get_db)):
+    from web.app import templates
+
+    result = verify_invitation(token, db)
+    return templates.TemplateResponse(
+        request,
+        "auth/invitation.html",
+        {
+            "token": token,
+            "valid": result.valid,
+            "invitation": result.invitation,
+            "message": result.message,
+            "error": None,
+        },
+        status_code=200 if result.valid else 410,
+    )
+
+
+@router.post("/auth/invitation/{token}")
+def invitation_submit(
+    request: Request,
+    token: str,
+    password: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    """Accept the invitation, create the account, and land the user
+    authenticated (mirrors api accept_invitation which returns a JWT)."""
+    from web.app import templates
+
+    def _rerender(error: str, code: int):
+        result = verify_invitation(token, db)
+        return templates.TemplateResponse(
+            request,
+            "auth/invitation.html",
+            {
+                "token": token,
+                "valid": result.valid,
+                "invitation": result.invitation,
+                "message": result.message,
+                "error": error,
+            },
+            status_code=code,
+        )
+
+    try:
+        accept = InvitationAccept(password=password, timezone="UTC")
+    except ValidationError:
+        return _rerender("Password must be at least 6 characters.", 400)
+    try:
+        result = accept_invitation(token, accept, db)
+    except HTTPException as exc:
+        return _rerender(str(exc.detail), exc.status_code or 400)
+
+    landing = "/a/dashboard" if "admin" in (result.roles or []) else "/v/schedule"
+    response = RedirectResponse(url=landing, status_code=303)
+    _set_cookie(response, result.token)
+    return response
 
 
 @router.post("/auth/logout")

--- a/web/templates/auth/invitation.html
+++ b/web/templates/auth/invitation.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Accept invitation · SignUpFlow{% endblock %}
+{% block body %}
+<div class="auth-wrap">
+  <div class="brand-mark">S</div>
+  <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
+
+  {% if not valid %}
+  <div class="auth-sub">Invitation</div>
+  <div class="form-error" role="alert">
+    {{ message or "This invitation link is invalid." }}
+  </div>
+  <a class="auth-link" href="/auth/login">Go to sign in</a>
+  {% else %}
+  <div class="auth-sub">You're invited</div>
+  <div class="card">
+    <div class="row-title">{{ invitation.name }}</div>
+    <div class="row-sub">{{ invitation.email }}</div>
+    <div class="spacer-12"></div>
+    <div class="mono-data">
+      {{ (invitation.roles or ['volunteer'])|join(' · ')|upper }}
+    </div>
+  </div>
+  <div class="spacer-12"></div>
+
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% endif %}
+
+  <form method="post" action="/auth/invitation/{{ token }}">
+    <div class="field">
+      <label class="field-label" for="password">Choose a password</label>
+      <input id="password" name="password" type="password"
+             autocomplete="new-password" placeholder="At least 6 characters"
+             minlength="6" required autofocus>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Accept &amp; continue</button>
+  </form>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
`GET/POST /auth/invitation/{token}` reusing `verify_invitation` + `accept_invitation`. Invalid/expired/used → 410 with API message; valid → invitee card (name/email/role) + set-password. Accept creates the account, sets the session cookie from the returned JWT, redirects to the role landing. Completes the Sprint 11 auth surface.

## Test plan
- [x] 7 web tests: valid render, invalid 410, expired 410, accept→account+authed, admin→dashboard, short-pw 400, already-accepted errors
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 35 pass
- [x] **E2E on live server**: real API-created invitation rendered + screenshotted (desktop valid + mobile invalid)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)