### PR TITLE
Web: volunteer schedule list with real data (Sprint 11 PR 11.5)

### DIFF
--- a/tests/web/test_login_flow.py
+++ b/tests/web/test_login_flow.py
@@ -66,8 +66,10 @@ def test_authenticated_session_can_load_schedule(client, db):
     token = login.cookies[SESSION_COOKIE]
     resp = client.get("/v/schedule", cookies={SESSION_COOKIE: token})
     assert resp.status_code == 200
+    # 11.5 replaced the placeholder with the real schedule page; a fresh
+    # user with no assignments sees the empty state.
     assert "Schedule" in resp.text
-    assert "Web User" in resp.text
+    assert "No assignments yet" in resp.text
 
 
 def test_volunteer_cannot_load_admin_dashboard(client, db):

--- a/tests/web/test_schedule.py
+++ b/tests/web/test_schedule.py
@@ -1,0 +1,86 @@
+"""Sprint 11.5 — volunteer schedule list (real data)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, **kw):
+    seed_person(db, **kw)
+    email = kw.get("email", "user@web.test")
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _seed_assignment(
+    db, person, *, eid="evt1", etype="Sunday Service", role="usher", status="confirmed"
+):
+    db.add(
+        Event(
+            id=eid,
+            org_id=person.org_id,
+            type=etype,
+            start_time=datetime(2026, 6, 7, 10, 0),
+            end_time=datetime(2026, 6, 7, 11, 30),
+        )
+    )
+    db.add(
+        Assignment(
+            event_id=eid,
+            person_id=person.id,
+            role=role,
+            status=status,
+        )
+    )
+    db.commit()
+
+
+def test_schedule_empty_state(client, db):
+    token = _login(client, db, person_id="p_empty", email="empty@web.test")
+    resp = client.get("/v/schedule", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "No assignments yet" in resp.text
+
+
+def test_schedule_lists_assignment_with_event_details(client, db):
+    person = seed_person(db, person_id="p_sched", email="sched@web.test")
+    _seed_assignment(db, person, etype="Sunday Service", role="usher")
+    login = client.post(
+        "/auth/login",
+        data={"email": "sched@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+
+    resp = client.get("/v/schedule", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Sunday Service" in resp.text
+    assert "10:00" in resp.text and "11:30" in resp.text
+    assert "usher" in resp.text
+    assert "confirmed" in resp.text
+    # Row links to the (future) detail page.
+    assert "/v/schedule/" in resp.text
+
+
+def test_schedule_requires_auth(client):
+    resp = client.get("/v/schedule")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+def test_schedule_scoped_to_caller(client, db):
+    seed_person(db, person_id="me_sched", email="me@web.test")
+    other = seed_person(db, person_id="other_sched", email="other@web.test")
+    _seed_assignment(db, other, eid="evt_other", etype="Not Mine")
+    login = client.post(
+        "/auth/login",
+        data={"email": "me@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/v/schedule", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Not Mine" not in resp.text
+    assert "No assignments yet" in resp.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -6,11 +6,45 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
 
-from api.models import Person
+from api.database import get_db
+from api.models import Assignment, Event, Person
 from web.deps import get_session_admin, get_session_user
 
 router = APIRouter(tags=["web-pages"])
+
+
+def _my_schedule_rows(db: Session, person: Person) -> list[dict]:
+    """Assignment ⋈ Event for the caller, newest first. Enriched with
+    event type + times — richer than the bare /api/v1/assignments/me
+    shape, which omits event details the schedule list needs."""
+    rows = (
+        db.query(Assignment, Event)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(
+            Assignment.person_id == person.id,
+            Event.org_id == person.org_id,
+        )
+        .order_by(Event.start_time.asc())
+        .all()
+    )
+    out = []
+    for a, e in rows:
+        start, end = e.start_time, e.end_time
+        out.append(
+            {
+                "id": a.id,
+                "event_type": e.type,
+                "date_label": start.strftime("%a %d %b %Y").upper() if start else "",
+                "time_label": (
+                    f"{start.strftime('%H:%M')}–{end.strftime('%H:%M')}" if start and end else ""
+                ),
+                "role": a.role,
+                "status": (a.status or "pending").lower(),
+            }
+        )
+    return out
 
 
 @router.get("/")
@@ -31,13 +65,21 @@ def root(request: Request):
 
 
 @router.get("/v/schedule", response_class=HTMLResponse)
-def volunteer_schedule(request: Request, person: Person = Depends(get_session_user)):
+def volunteer_schedule(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
     from web.app import templates
 
     return templates.TemplateResponse(
         request,
         "volunteer/schedule.html",
-        {"person": person, "active_tab": "schedule"},
+        {
+            "person": person,
+            "active_tab": "schedule",
+            "rows": _my_schedule_rows(db, person),
+        },
     )
 
 

--- a/web/templates/volunteer/schedule.html
+++ b/web/templates/volunteer/schedule.html
@@ -1,17 +1,31 @@
 {% extends "base.html" %}
 {% block title %}Schedule · SignUpFlow{% endblock %}
 {% block body %}
-<div class="nav">
-  <span class="nav-back"></span>
-  <span class="nav-action"></span>
-</div>
+<div class="nav"><span class="nav-back"></span><span class="nav-action"></span></div>
 <div class="page-title">Schedule</div>
 <div class="scroll">
+  {% if not rows %}
   <div class="empty">
-    Signed in as <strong>{{ person.name }}</strong>.<br>
-    Your upcoming assignments will appear here.<br>
-    <span class="mono-data">(Sprint 11.1)</span>
+    No assignments yet.<br>
+    When an admin publishes a schedule with you on it,
+    your shifts show up here.
   </div>
+  {% else %}
+  {% for r in rows %}
+  <a class="row" href="/v/schedule/{{ r.id }}">
+    <div class="row-main">
+      <div class="row-title">{{ r.event_type }}</div>
+      <div class="row-sub">{{ r.date_label }}</div>
+      <div style="margin-top:6px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+        {% if r.time_label %}<span class="time-chip">{{ r.time_label }}</span>{% endif %}
+        {% if r.role %}<span class="role-chip">{{ r.role }}</span>{% endif %}
+        <span class="status-text {{ r.status }}">{{ r.status }}</span>
+      </div>
+    </div>
+    <span class="chev">›</span>
+  </a>
+  {% endfor %}
+  {% endif %}
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),


### PR DESCRIPTION
## Summary
`/v/schedule` queries `Assignment ⋈ Event` for the session user (org-scoped, ordered by start), rendering event type / date / time-chip / role-chip / color-coded status; empty state otherwise. Rows link to `/v/schedule/{id}` (detail = 11.6). Direct DB read — richer than `/api/v1/assignments/me` which omits event details.

## Test plan
- [x] 5 web tests: empty state, populated w/ event details, auth-gate, caller-scoping; fixed stale 11.0 login-flow assertion
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 39 pass
- [x] **E2E on live server**: seeded 2 real assignments, populated schedule screenshotted (chips + status colors + tab nav, brand-correct)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)