### PR TITLE
Web: volunteer assignment detail (Sprint 11 PR 11.6)

### DIFF
--- a/tests/web/test_assignment_detail.py
+++ b/tests/web/test_assignment_detail.py
@@ -1,0 +1,85 @@
+"""Sprint 11.6 — volunteer assignment detail."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, email):
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _seed(
+    db, person, *, eid="ev_d", etype="Sunday Service", role="usher", status="confirmed", reason=None
+):
+    db.add(
+        Event(
+            id=eid,
+            org_id=person.org_id,
+            type=etype,
+            start_time=datetime(2026, 6, 7, 10, 0),
+            end_time=datetime(2026, 6, 7, 11, 30),
+        )
+    )
+    a = Assignment(
+        event_id=eid,
+        person_id=person.id,
+        role=role,
+        status=status,
+        decline_reason=reason,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def test_detail_renders_for_owned_assignment(client, db):
+    p = seed_person(db, person_id="d_owner", email="d_owner@web.test")
+    a = _seed(db, p, etype="Sunday Service", role="usher")
+    token = _login(client, db, "d_owner@web.test")
+    resp = client.get(f"/v/schedule/{a.id}", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Sunday Service" in resp.text
+    assert "10:00" in resp.text and "11:30" in resp.text
+    assert "usher" in resp.text
+    assert "confirmed" in resp.text
+    assert 'href="/v/schedule"' in resp.text  # back nav
+
+
+def test_detail_shows_decline_reason(client, db):
+    p = seed_person(db, person_id="d_decl", email="d_decl@web.test")
+    a = _seed(db, p, status="declined", reason="Out of town that weekend")
+    token = _login(client, db, "d_decl@web.test")
+    resp = client.get(f"/v/schedule/{a.id}", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Out of town that weekend" in resp.text
+
+
+def test_detail_404_for_unknown_id(client, db):
+    seed_person(db, person_id="d_404", email="d_404@web.test")
+    token = _login(client, db, "d_404@web.test")
+    resp = client.get("/v/schedule/999999", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 404
+    assert "isn't on your schedule" in resp.text
+
+
+def test_detail_404_for_other_users_assignment(client, db):
+    seed_person(db, person_id="d_me", email="d_me@web.test")
+    other = seed_person(db, person_id="d_other", email="d_other@web.test")
+    a = _seed(db, other, eid="ev_other", etype="Not Mine")
+    token = _login(client, db, "d_me@web.test")
+    resp = client.get(f"/v/schedule/{a.id}", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 404
+    assert "Not Mine" not in resp.text
+
+
+def test_detail_requires_auth(client):
+    resp = client.get("/v/schedule/1")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -15,8 +15,23 @@ from web.deps import get_session_admin, get_session_user
 router = APIRouter(tags=["web-pages"])
 
 
+def _row_dict(a: Assignment, e: Event) -> dict:
+    start, end = e.start_time, e.end_time
+    return {
+        "id": a.id,
+        "event_type": e.type,
+        "date_label": start.strftime("%a %d %b %Y").upper() if start else "",
+        "time_label": (
+            f"{start.strftime('%H:%M')}–{end.strftime('%H:%M')}" if start and end else ""
+        ),
+        "role": a.role,
+        "status": (a.status or "pending").lower(),
+        "decline_reason": a.decline_reason,
+    }
+
+
 def _my_schedule_rows(db: Session, person: Person) -> list[dict]:
-    """Assignment ⋈ Event for the caller, newest first. Enriched with
+    """Assignment ⋈ Event for the caller, by event start. Enriched with
     event type + times — richer than the bare /api/v1/assignments/me
     shape, which omits event details the schedule list needs."""
     rows = (
@@ -29,22 +44,22 @@ def _my_schedule_rows(db: Session, person: Person) -> list[dict]:
         .order_by(Event.start_time.asc())
         .all()
     )
-    out = []
-    for a, e in rows:
-        start, end = e.start_time, e.end_time
-        out.append(
-            {
-                "id": a.id,
-                "event_type": e.type,
-                "date_label": start.strftime("%a %d %b %Y").upper() if start else "",
-                "time_label": (
-                    f"{start.strftime('%H:%M')}–{end.strftime('%H:%M')}" if start and end else ""
-                ),
-                "role": a.role,
-                "status": (a.status or "pending").lower(),
-            }
+    return [_row_dict(a, e) for a, e in rows]
+
+
+def _my_assignment(db: Session, person: Person, aid: int) -> dict | None:
+    """Single Assignment ⋈ Event owned by the caller, or None (404)."""
+    row = (
+        db.query(Assignment, Event)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(
+            Assignment.id == aid,
+            Assignment.person_id == person.id,
+            Event.org_id == person.org_id,
         )
-    return out
+        .first()
+    )
+    return _row_dict(*row) if row else None
 
 
 @router.get("/")
@@ -80,6 +95,30 @@ def volunteer_schedule(
             "active_tab": "schedule",
             "rows": _my_schedule_rows(db, person),
         },
+    )
+
+
+@router.get("/v/schedule/{assignment_id}", response_class=HTMLResponse)
+def volunteer_assignment_detail(
+    request: Request,
+    assignment_id: int,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    row = _my_assignment(db, person, assignment_id)
+    if row is None:
+        return templates.TemplateResponse(
+            request,
+            "volunteer/assignment_detail.html",
+            {"person": person, "active_tab": "schedule", "row": None},
+            status_code=404,
+        )
+    return templates.TemplateResponse(
+        request,
+        "volunteer/assignment_detail.html",
+        {"person": person, "active_tab": "schedule", "row": row},
     )
 
 

--- a/web/templates/volunteer/assignment_detail.html
+++ b/web/templates/volunteer/assignment_detail.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Assignment · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/v/schedule">‹ Schedule</a>
+  <span class="nav-title-inline">Assignment</span>
+  <span class="nav-action"></span>
+</div>
+<div class="scroll">
+  {% if row is none %}
+  <div class="empty">
+    This assignment isn't on your schedule.<br>
+    It may have been reassigned or the schedule republished.
+  </div>
+  {% else %}
+  <div class="card">
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
+      {% if row.time_label %}<span class="time-chip">{{ row.time_label }}</span>{% endif %}
+      {% if row.role %}<span class="role-chip">{{ row.role }}</span>{% endif %}
+      <span class="status-text {{ row.status }}">{{ row.status }}</span>
+    </div>
+    <div class="page-title" style="padding:0;font-size:24px">{{ row.event_type }}</div>
+    <div class="row-sub" style="margin-top:6px">{{ row.date_label }}</div>
+    {% if row.decline_reason %}
+    <div class="spacer-12"></div>
+    <div class="mono-label" style="margin:0 0 4px">Decline reason</div>
+    <div class="row-sub">{{ row.decline_reason }}</div>
+    {% endif %}
+    <div class="spacer-18"></div>
+    <div class="row-sub">
+      Respond to this assignment from the actions below
+      <span class="mono-data">(Sprint 11.7)</span>.
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/profile', '◍', 'Profile', 'profile'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}


### PR DESCRIPTION
## Summary
`GET /v/schedule/{id}` — single `Assignment ⋈ Event` scoped to the caller (404 for unknown / other-user). Full card: chips, status, event title, date, decline-reason when present, back nav. Shared `_row_dict` keeps list + detail consistent. Actions = 11.7.

## Test plan
- [x] 5 web tests: owned render, decline-reason, 404 unknown, 404 other-user, auth-gate
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 44 pass
- [x] **E2E on live server**: seeded assignment, detail page screenshotted (brand-correct)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)