### PR TITLE
Web: accept / decline / swap HTMX actions (Sprint 11 PR 11.7)

### DIFF
--- a/tests/web/test_assignment_actions.py
+++ b/tests/web/test_assignment_actions.py
@@ -1,0 +1,114 @@
+"""Sprint 11.7 — accept / decline / swap HTMX actions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _setup(client, db, *, person_id, email, status="pending"):
+    p = seed_person(db, person_id=person_id, email=email)
+    db.add(
+        Event(
+            id=f"ev_{person_id}",
+            org_id=p.org_id,
+            type="Sunday Service",
+            start_time=datetime(2026, 6, 7, 10, 0),
+            end_time=datetime(2026, 6, 7, 11, 30),
+        )
+    )
+    a = Assignment(
+        event_id=f"ev_{person_id}",
+        person_id=p.id,
+        role="usher",
+        status=status,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    login = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return a, login.cookies[SESSION_COOKIE]
+
+
+def test_accept_updates_status_and_returns_card(client, db):
+    a, token = _setup(client, db, person_id="a_acc", email="a_acc@web.test")
+    resp = client.post(f"/v/schedule/{a.id}/accept", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'id="assignment-card"' in resp.text
+    assert "confirmed" in resp.text
+    db.refresh(a)
+    assert a.status == "confirmed"
+
+
+def test_decline_requires_reason_and_persists_it(client, db):
+    a, token = _setup(client, db, person_id="a_dec", email="a_dec@web.test")
+    resp = client.post(
+        f"/v/schedule/{a.id}/decline",
+        data={"decline_reason": "Away that weekend"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "declined" in resp.text
+    assert "Away that weekend" in resp.text
+    db.refresh(a)
+    assert a.status == "declined"
+    assert a.decline_reason == "Away that weekend"
+
+
+def test_decline_without_reason_is_rejected(client, db):
+    a, token = _setup(client, db, person_id="a_dec2", email="a_dec2@web.test")
+    resp = client.post(
+        f"/v/schedule/{a.id}/decline",
+        data={"decline_reason": ""},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code in (400, 422)
+    db.refresh(a)
+    assert a.status == "pending"
+
+
+def test_swap_request_updates_status(client, db):
+    a, token = _setup(client, db, person_id="a_sw", email="a_sw@web.test")
+    resp = client.post(
+        f"/v/schedule/{a.id}/swap-request",
+        data={"note": "Can someone cover?"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    db.refresh(a)
+    assert a.status == "swap_requested"
+
+
+def test_action_on_other_users_assignment_is_gone(client, db):
+    other = seed_person(db, person_id="a_other", email="a_other@web.test")
+    db.add(
+        Event(
+            id="ev_other_act",
+            org_id=other.org_id,
+            type="Theirs",
+            start_time=datetime(2026, 6, 7, 10, 0),
+            end_time=datetime(2026, 6, 7, 11, 30),
+        )
+    )
+    a = Assignment(event_id="ev_other_act", person_id=other.id, role="x", status="pending")
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+
+    seed_person(db, person_id="a_me", email="a_me@web.test")
+    login = client.post("/auth/login", data={"email": "a_me@web.test", "password": "WebPass123!"})
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.post(f"/v/schedule/{a.id}/accept", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 404
+    assert "isn't on your schedule" in resp.text
+    db.refresh(a)
+    assert a.status == "pending"
+
+
+def test_actions_require_auth(client):
+    resp = client.post("/v/schedule/1/accept")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"

--- a/web/app.py
+++ b/web/app.py
@@ -19,11 +19,13 @@ templates = Jinja2Templates(directory=str(_WEB_DIR / "templates"))
 # elsewhere to avoid circular imports with `templates`.
 from web import auth as _auth  # noqa: E402
 from web.routers import pages as _pages  # noqa: E402
+from web.routers import partials as _partials  # noqa: E402
 from web.deps import _RedirectToLogin  # noqa: E402
 
 router = APIRouter()
 router.include_router(_auth.router)
 router.include_router(_pages.router)
+router.include_router(_partials.router)
 
 
 def mount_web(app: FastAPI) -> None:

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -1,0 +1,102 @@
+"""HTMX fragment endpoints — return HTML partials, not full pages.
+
+Assignment actions reuse the API handlers in api/routers/assignments.py
+directly (same _load_own_assignment ownership check, same event_bus
+publish). The web session user is passed as `current_user`; a throwaway
+BackgroundTasks collects the publish side-effect. On success we re-render
+the assignment card partial so HTMX swaps the fresh status in place.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from api.database import get_db
+from api.models import Person
+from api.routers.assignments import (
+    accept_assignment,
+    decline_assignment,
+    request_swap,
+)
+from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
+from web.deps import get_session_user
+from web.routers.pages import _my_assignment
+
+router = APIRouter(tags=["web-partials"])
+
+
+def _gone() -> HTMLResponse:
+    return HTMLResponse(
+        '<div id="assignment-card" class="empty">'
+        "This assignment isn't on your schedule anymore.</div>",
+        status_code=404,
+    )
+
+
+def _card(request: Request, person: Person, db: Session, aid: int):
+    from web.app import templates
+
+    row = _my_assignment(db, person, aid)
+    if row is None:
+        return _gone()
+    return templates.TemplateResponse(request, "partials/assignment_detail_card.html", {"row": row})
+
+
+@router.post("/v/schedule/{assignment_id}/accept", response_class=HTMLResponse)
+def accept(
+    request: Request,
+    assignment_id: int,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        accept_assignment(assignment_id, request, BackgroundTasks(), person, db)
+    except HTTPException:
+        return _gone()
+    return _card(request, person, db, assignment_id)
+
+
+@router.post("/v/schedule/{assignment_id}/decline", response_class=HTMLResponse)
+def decline(
+    request: Request,
+    assignment_id: int,
+    decline_reason: str = Form(...),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        decline_assignment(
+            assignment_id,
+            AssignmentDeclineRequest(decline_reason=decline_reason),
+            request,
+            BackgroundTasks(),
+            person,
+            db,
+        )
+    except HTTPException:
+        return _gone()
+    return _card(request, person, db, assignment_id)
+
+
+@router.post("/v/schedule/{assignment_id}/swap-request", response_class=HTMLResponse)
+def swap(
+    request: Request,
+    assignment_id: int,
+    note: str | None = Form(None),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        request_swap(
+            assignment_id,
+            AssignmentSwapRequest(note=note),
+            request,
+            BackgroundTasks(),
+            person,
+            db,
+        )
+    except HTTPException:
+        return _gone()
+    return _card(request, person, db, assignment_id)

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -405,3 +405,5 @@ a { color: var(--accent); text-decoration: none; }
 }
 .spacer-12 { height: 12px; }
 .spacer-18 { height: 18px; }
+[x-cloak] { display: none !important; }
+.htmx-request.btn, .htmx-request .btn { opacity: 0.6; pointer-events: none; }

--- a/web/templates/partials/assignment_detail_card.html
+++ b/web/templates/partials/assignment_detail_card.html
@@ -1,0 +1,58 @@
+{# Assignment detail card + response actions. Rendered both inside the
+   full detail page and returned standalone by the HTMX action POSTs
+   (outerHTML-swapped into #assignment-card). #}
+<div id="assignment-card" x-data="{ declining: false }">
+  <div class="card">
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
+      {% if row.time_label %}<span class="time-chip">{{ row.time_label }}</span>{% endif %}
+      {% if row.role %}<span class="role-chip">{{ row.role }}</span>{% endif %}
+      <span class="status-text {{ row.status }}">{{ row.status }}</span>
+    </div>
+    <div class="page-title" style="padding:0;font-size:24px">{{ row.event_type }}</div>
+    <div class="row-sub" style="margin-top:6px">{{ row.date_label }}</div>
+    {% if row.decline_reason %}
+    <div class="spacer-12"></div>
+    <div class="mono-label" style="margin:0 0 4px">Decline reason</div>
+    <div class="row-sub">{{ row.decline_reason }}</div>
+    {% endif %}
+  </div>
+
+  <div class="spacer-18"></div>
+  <div class="mono-label" style="margin-top:0">Your response</div>
+
+  <div class="btn-row cols-2">
+    <button class="btn btn-go" type="button"
+            hx-post="/v/schedule/{{ row.id }}/accept"
+            hx-target="#assignment-card" hx-swap="outerHTML">
+      Accept
+    </button>
+    <button class="btn btn-secondary" type="button"
+            hx-post="/v/schedule/{{ row.id }}/swap-request"
+            hx-target="#assignment-card" hx-swap="outerHTML">
+      Request swap
+    </button>
+  </div>
+  <div class="spacer-12"></div>
+
+  <button class="btn btn-destructive" type="button"
+          x-show="!declining" @click="declining = true">
+    Decline
+  </button>
+
+  <form x-show="declining" x-cloak
+        hx-post="/v/schedule/{{ row.id }}/decline"
+        hx-target="#assignment-card" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="decline_reason">Reason</label>
+      <input id="decline_reason" name="decline_reason" type="text"
+             required minlength="1" maxlength="500"
+             placeholder="Briefly, why can't you make it?">
+    </div>
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-secondary" type="button"
+              @click="declining = false">Cancel</button>
+      <button class="btn btn-destructive" type="submit">Confirm decline</button>
+    </div>
+  </form>
+</div>

--- a/web/templates/volunteer/assignment_detail.html
+++ b/web/templates/volunteer/assignment_detail.html
@@ -13,25 +13,7 @@
     It may have been reassigned or the schedule republished.
   </div>
   {% else %}
-  <div class="card">
-    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
-      {% if row.time_label %}<span class="time-chip">{{ row.time_label }}</span>{% endif %}
-      {% if row.role %}<span class="role-chip">{{ row.role }}</span>{% endif %}
-      <span class="status-text {{ row.status }}">{{ row.status }}</span>
-    </div>
-    <div class="page-title" style="padding:0;font-size:24px">{{ row.event_type }}</div>
-    <div class="row-sub" style="margin-top:6px">{{ row.date_label }}</div>
-    {% if row.decline_reason %}
-    <div class="spacer-12"></div>
-    <div class="mono-label" style="margin:0 0 4px">Decline reason</div>
-    <div class="row-sub">{{ row.decline_reason }}</div>
-    {% endif %}
-    <div class="spacer-18"></div>
-    <div class="row-sub">
-      Respond to this assignment from the actions below
-      <span class="mono-data">(Sprint 11.7)</span>.
-    </div>
-  </div>
+  {% include "partials/assignment_detail_card.html" %}
   {% endif %}
 </div>
 {% set tabs = [


### PR DESCRIPTION
## Summary
New `web/routers/partials.py` HTMX endpoints reuse `api/routers/assignments.py` handlers directly (same ownership check + event_bus publish). Success → re-rendered assignment-card partial swapped in place; deleted/not-yours → 404 fragment. Card extracted to a shared partial. Accept/swap one-click; decline = Alpine inline reason form (required, x-cloak no-flash).

## Test plan
- [x] 6 web tests: accept→confirmed+card, decline persists reason, empty-reason rejected, swap→swap_requested, other-user 404, auth-gate
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 50 pass
- [x] **E2E on live server**: detail renders 3 action buttons; live `POST /accept` returns swapped card w/ `confirmed`; screenshotted

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)