### PR TITLE
Web: availability time-off CRUD (Sprint 11 PR 11.8)

### DIFF
--- a/tests/web/test_availability_timeoff.py
+++ b/tests/web/test_availability_timeoff.py
@@ -1,0 +1,84 @@
+"""Sprint 11.8 — availability time-off CRUD."""
+
+from __future__ import annotations
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, email="to@web.test", pid="to_user"):
+    seed_person(db, person_id=pid, email=email)
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_availability_page_renders(client, db):
+    token = _login(client, db)
+    resp = client.get("/v/availability", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Availability" in resp.text
+    assert 'name="start_date"' in resp.text
+    assert "No time-off booked" in resp.text
+
+
+def test_add_timeoff_then_listed(client, db):
+    token = _login(client, db, email="add@web.test", pid="add_user")
+    resp = client.post(
+        "/v/availability/timeoff",
+        data={
+            "start_date": "2026-07-01",
+            "end_date": "2026-07-05",
+            "reason": "Family trip",
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert 'id="timeoff-list"' in resp.text
+    assert "Family trip" in resp.text
+    assert "JUL" in resp.text.upper()
+    assert "No time-off booked" not in resp.text
+
+
+def test_add_timeoff_end_before_start_rejected(client, db):
+    token = _login(client, db, email="bad@web.test", pid="bad_user")
+    resp = client.post(
+        "/v/availability/timeoff",
+        data={"start_date": "2026-07-10", "end_date": "2026-07-01"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "form-error" in resp.text
+    assert "No time-off booked" in resp.text  # nothing was created
+
+
+def test_delete_timeoff(client, db):
+    token = _login(client, db, email="del@web.test", pid="del_user")
+    client.post(
+        "/v/availability/timeoff",
+        data={"start_date": "2026-08-01", "end_date": "2026-08-01"},
+        cookies={SESSION_COOKIE: token},
+    )
+    page = client.get("/v/availability", cookies={SESSION_COOKIE: token})
+    import re
+
+    m = re.search(r"/v/availability/timeoff/(\d+)/delete", page.text)
+    assert m, "delete link not rendered"
+    tid = m.group(1)
+
+    resp = client.post(
+        f"/v/availability/timeoff/{tid}/delete",
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "No time-off booked" in resp.text
+
+
+def test_availability_requires_auth(client):
+    resp = client.get("/v/availability")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+    resp2 = client.post(
+        "/v/availability/timeoff",
+        data={"start_date": "2026-07-01", "end_date": "2026-07-02"},
+    )
+    assert resp2.status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -122,6 +122,50 @@ def volunteer_assignment_detail(
     )
 
 
+def _my_timeoff(db: Session, person: Person) -> list[dict]:
+    """Time-off rows for the caller via the API handler, formatted for
+    display."""
+    from datetime import date as _date
+
+    from api.routers.availability import get_timeoff
+
+    out = []
+    for t in get_timeoff(person.id, db)["timeoff"]:
+        s = _date.fromisoformat(t["start_date"])
+        e = _date.fromisoformat(t["end_date"])
+        out.append(
+            {
+                "id": t["id"],
+                "label": (
+                    s.strftime("%d %b %Y").upper()
+                    if s == e
+                    else f"{s.strftime('%d %b').upper()} – {e.strftime('%d %b %Y').upper()}"
+                ),
+                "reason": t["reason"],
+            }
+        )
+    return out
+
+
+@router.get("/v/availability", response_class=HTMLResponse)
+def volunteer_availability(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "volunteer/availability.html",
+        {
+            "person": person,
+            "active_tab": "availability",
+            "timeoff": _my_timeoff(db, person),
+        },
+    )
+
+
 @router.get("/v/profile", response_class=HTMLResponse)
 def volunteer_profile(request: Request, person: Person = Depends(get_session_user)):
     from web.app import templates

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -20,9 +20,11 @@ from api.routers.assignments import (
     decline_assignment,
     request_swap,
 )
+from api.routers.availability import add_timeoff, delete_timeoff
 from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
+from api.schemas.availability import TimeOffCreate
 from web.deps import get_session_user
-from web.routers.pages import _my_assignment
+from web.routers.pages import _my_assignment, _my_timeoff
 
 router = APIRouter(tags=["web-partials"])
 
@@ -100,3 +102,50 @@ def swap(
     except HTTPException:
         return _gone()
     return _card(request, person, db, assignment_id)
+
+
+# ── Availability: time-off ───────────────────────────────────────────
+
+
+def _timeoff_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/timeoff_list.html",
+        {"timeoff": _my_timeoff(db, person), "error": error},
+    )
+
+
+@router.post("/v/availability/timeoff", response_class=HTMLResponse)
+def timeoff_add(
+    request: Request,
+    start_date: str = Form(...),
+    end_date: str = Form(...),
+    reason: str | None = Form(None),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        payload = TimeOffCreate(start_date=start_date, end_date=end_date, reason=reason or None)
+    except ValueError:
+        return _timeoff_list(request, person, db, error="Enter valid dates.")
+    try:
+        add_timeoff(person.id, payload, db)
+    except HTTPException as exc:
+        return _timeoff_list(request, person, db, error=str(exc.detail))
+    return _timeoff_list(request, person, db)
+
+
+@router.post("/v/availability/timeoff/{timeoff_id}/delete", response_class=HTMLResponse)
+def timeoff_delete(
+    request: Request,
+    timeoff_id: int,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        delete_timeoff(person.id, timeoff_id, db)
+    except HTTPException:
+        pass  # already gone — fall through to a fresh (correct) list
+    return _timeoff_list(request, person, db)

--- a/web/templates/partials/timeoff_list.html
+++ b/web/templates/partials/timeoff_list.html
@@ -1,0 +1,49 @@
+{# Time-off list + add form. Whole block is #timeoff-list so HTMX
+   outerHTML-swaps it after add/delete. #}
+<div id="timeoff-list">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <form hx-post="/v/availability/timeoff"
+        hx-target="#timeoff-list" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="start_date">From</label>
+      <input id="start_date" name="start_date" type="date" required>
+    </div>
+    <div class="field">
+      <label class="field-label" for="end_date">To</label>
+      <input id="end_date" name="end_date" type="date" required>
+    </div>
+    <div class="field">
+      <label class="field-label" for="reason">Reason (optional)</label>
+      <input id="reason" name="reason" type="text" maxlength="200"
+             placeholder="Vacation, travel, …">
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Add time-off</button>
+  </form>
+
+  <div class="mono-label">Your time-off</div>
+  {% if not timeoff %}
+  <div class="empty">No time-off booked.</div>
+  {% else %}
+  <div class="group">
+    {% for t in timeoff %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ t.label }}</div>
+        {% if t.reason %}<div class="row-sub">{{ t.reason }}</div>{% endif %}
+      </div>
+      <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+              hx-post="/v/availability/timeoff/{{ t.id }}/delete"
+              hx-target="#timeoff-list" hx-swap="outerHTML"
+              hx-confirm="Remove this time-off?">
+        Remove
+      </button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>

--- a/web/templates/volunteer/assignment_detail.html
+++ b/web/templates/volunteer/assignment_detail.html
@@ -18,6 +18,7 @@
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
   ('/v/profile', '◍', 'Profile', 'profile'),
 ] %}
 {% include "_nav.html" %}

--- a/web/templates/volunteer/availability.html
+++ b/web/templates/volunteer/availability.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Availability · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav"><span class="nav-back"></span><span class="nav-action"></span></div>
+<div class="page-title">Availability</div>
+<div class="scroll">
+  <div class="row-sub" style="margin:0 4px 8px">
+    Book time-off so the scheduler won't assign you on those days.
+  </div>
+  {% include "partials/timeoff_list.html" %}
+</div>
+{% set tabs = [
+  ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
+  ('/v/profile', '◍', 'Profile', 'profile'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/volunteer/profile.html
+++ b/web/templates/volunteer/profile.html
@@ -34,6 +34,7 @@
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
   ('/v/profile', '◍', 'Profile', 'profile'),
 ] %}
 {% include "_nav.html" %}

--- a/web/templates/volunteer/schedule.html
+++ b/web/templates/volunteer/schedule.html
@@ -29,6 +29,7 @@
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
   ('/v/profile', '◍', 'Profile', 'profile'),
 ] %}
 {% include "_nav.html" %}


### PR DESCRIPTION
## Summary
`/v/availability` — caller's time-off list + add form + per-row remove, all HTMX (`outerHTML`-swap `#timeoff-list`). Reuses `get_timeoff`/`add_timeoff`/`delete_timeoff` with the session user. Invalid/end<start dates → inline error, nothing created. Volunteer nav now 3 tabs (Schedule · Availability · Profile) across all volunteer screens.

## Test plan
- [x] 5 web tests: render+empty, add→listed, end<start rejected, delete→empty, auth-gate
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 55 pass
- [x] **E2E on live server**: seeded volunteer, live add-timeoff, availability page screenshotted (3-tab nav, entry + remove)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)