### PR TITLE
Web: recurring availability (rrule) editor (Sprint 11 PR 11.9)

### DIFF
--- a/tests/web/test_availability_rrule.py
+++ b/tests/web/test_availability_rrule.py
@@ -1,0 +1,77 @@
+"""Sprint 11.9 — recurring availability (rrule) editor."""
+
+from __future__ import annotations
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, email="rr@web.test", pid="rr_user"):
+    seed_person(db, person_id=pid, email=email)
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_availability_shows_rrule_section_empty(client, db):
+    token = _login(client, db)
+    resp = client.get("/v/availability", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Recurring availability" in resp.text
+    assert "No recurring rule" in resp.text
+    assert "Every Sunday" in resp.text  # preset rendered
+
+
+def test_set_rrule_via_custom_then_shown(client, db):
+    token = _login(client, db, email="rrset@web.test", pid="rrset")
+    resp = client.post(
+        "/v/availability/rrule",
+        data={"rrule": "FREQ=WEEKLY;BYDAY=MO"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert 'id="rrule-section"' in resp.text
+    assert "FREQ=WEEKLY;BYDAY=MO" in resp.text
+    assert "Clear recurring rule" in resp.text
+
+
+def test_set_rrule_via_preset(client, db):
+    token = _login(client, db, email="rrp@web.test", pid="rrp")
+    resp = client.post(
+        "/v/availability/rrule",
+        data={"rrule": "FREQ=WEEKLY;BYDAY=SU"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "FREQ=WEEKLY;BYDAY=SU" in resp.text
+
+
+def test_empty_rrule_rejected(client, db):
+    token = _login(client, db, email="rre@web.test", pid="rre")
+    resp = client.post(
+        "/v/availability/rrule",
+        data={"rrule": "   "},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "form-error" in resp.text
+    assert "No recurring rule" in resp.text  # nothing saved
+
+
+def test_clear_rrule(client, db):
+    token = _login(client, db, email="rrc@web.test", pid="rrc")
+    client.post(
+        "/v/availability/rrule",
+        data={"rrule": "FREQ=WEEKLY;BYDAY=FR"},
+        cookies={SESSION_COOKIE: token},
+    )
+    resp = client.post("/v/availability/rrule/clear", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "No recurring rule" in resp.text
+    assert "FREQ=WEEKLY;BYDAY=FR" not in resp.text.replace('placeholder="FREQ=WEEKLY;BYDAY=SU"', "")
+
+
+def test_rrule_endpoints_require_auth(client):
+    r1 = client.post("/v/availability/rrule", data={"rrule": "FREQ=DAILY"})
+    assert r1.status_code == 303
+    r2 = client.post("/v/availability/rrule/clear")
+    assert r2.status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -147,6 +147,23 @@ def _my_timeoff(db: Session, person: Person) -> list[dict]:
     return out
 
 
+# Preset recurring patterns. label → RRULE; the editor also accepts a
+# custom expression. Mirrors the mobile kRrulePresets intent.
+RRULE_PRESETS = [
+    ("Every Sunday", "FREQ=WEEKLY;BYDAY=SU"),
+    ("Every Saturday", "FREQ=WEEKLY;BYDAY=SA"),
+    ("Weekdays", "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"),
+    ("Every other week", "FREQ=WEEKLY;INTERVAL=2"),
+    ("Monthly (1st)", "FREQ=MONTHLY;BYMONTHDAY=1"),
+]
+
+
+def _my_rrule(db: Session, person: Person) -> str | None:
+    from api.routers.availability import get_rrule
+
+    return get_rrule(person.id, db).rrule
+
+
 @router.get("/v/availability", response_class=HTMLResponse)
 def volunteer_availability(
     request: Request,
@@ -162,6 +179,8 @@ def volunteer_availability(
             "person": person,
             "active_tab": "availability",
             "timeoff": _my_timeoff(db, person),
+            "rrule": _my_rrule(db, person),
+            "rrule_presets": RRULE_PRESETS,
         },
     )
 

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -20,11 +20,16 @@ from api.routers.assignments import (
     decline_assignment,
     request_swap,
 )
-from api.routers.availability import add_timeoff, delete_timeoff
+from api.routers.availability import (
+    add_timeoff,
+    clear_rrule,
+    delete_timeoff,
+    set_rrule,
+)
 from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
-from api.schemas.availability import TimeOffCreate
+from api.schemas.availability import AvailabilityRruleUpdate, TimeOffCreate
 from web.deps import get_session_user
-from web.routers.pages import _my_assignment, _my_timeoff
+from web.routers.pages import RRULE_PRESETS, _my_assignment, _my_rrule, _my_timeoff
 
 router = APIRouter(tags=["web-partials"])
 
@@ -149,3 +154,45 @@ def timeoff_delete(
     except HTTPException:
         pass  # already gone — fall through to a fresh (correct) list
     return _timeoff_list(request, person, db)
+
+
+# ── Availability: recurring rrule ────────────────────────────────────
+
+
+def _rrule_section(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/rrule_section.html",
+        {
+            "rrule": _my_rrule(db, person),
+            "rrule_presets": RRULE_PRESETS,
+            "error": error,
+        },
+    )
+
+
+@router.post("/v/availability/rrule", response_class=HTMLResponse)
+def rrule_set(
+    request: Request,
+    rrule: str = Form(...),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        payload = AvailabilityRruleUpdate(rrule=rrule.strip())
+    except ValueError:
+        return _rrule_section(request, person, db, error="Enter a recurrence rule.")
+    set_rrule(person.id, payload, db)
+    return _rrule_section(request, person, db)
+
+
+@router.post("/v/availability/rrule/clear", response_class=HTMLResponse)
+def rrule_clear(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    clear_rrule(person.id, db)
+    return _rrule_section(request, person, db)

--- a/web/templates/partials/rrule_section.html
+++ b/web/templates/partials/rrule_section.html
@@ -1,0 +1,50 @@
+{# Recurring-availability editor. Whole block is #rrule-section so HTMX
+   outerHTML-swaps it after set/clear. #}
+<div id="rrule-section">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <div class="card">
+    <div class="field-label">Current recurring rule</div>
+    <div class="spacer-12" style="height:4px"></div>
+    {% if rrule %}
+    <div class="mono-data" style="text-transform:none">{{ rrule }}</div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-destructive" type="button"
+            hx-post="/v/availability/rrule/clear"
+            hx-target="#rrule-section" hx-swap="outerHTML">
+      Clear recurring rule
+    </button>
+    {% else %}
+    <div class="row-sub">No recurring rule — you're considered available
+      unless you book time-off.</div>
+    {% endif %}
+  </div>
+
+  <div class="mono-label">Quick presets</div>
+  <div class="btn-row cols-2">
+    {% for label, expr in rrule_presets %}
+    <button class="btn btn-secondary" type="button"
+            hx-post="/v/availability/rrule"
+            hx-vals='{"rrule": "{{ expr }}"}'
+            hx-target="#rrule-section" hx-swap="outerHTML">
+      {{ label }}
+    </button>
+    {% endfor %}
+  </div>
+
+  <div class="mono-label">Custom rule</div>
+  <form hx-post="/v/availability/rrule"
+        hx-target="#rrule-section" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="rrule">iCalendar RRULE</label>
+      <input id="rrule" name="rrule" type="text" required
+             placeholder="FREQ=WEEKLY;BYDAY=SU"
+             value="{{ rrule or '' }}">
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Save rule</button>
+  </form>
+</div>

--- a/web/templates/volunteer/availability.html
+++ b/web/templates/volunteer/availability.html
@@ -8,6 +8,9 @@
     Book time-off so the scheduler won't assign you on those days.
   </div>
   {% include "partials/timeoff_list.html" %}
+
+  <div class="mono-label">Recurring availability</div>
+  {% include "partials/rrule_section.html" %}
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),


### PR DESCRIPTION
## Summary
"Recurring availability" section on `/v/availability`: current rule, 5 quick presets, custom iCalendar RRULE input, clear — all HTMX (`outerHTML`-swap `#rrule-section`). Reuses `get_rrule`/`set_rrule`/`clear_rrule`. Empty rule → inline error.

## Test plan
- [x] 6 web tests: empty section, set custom, set preset, empty rejected, clear, auth-gate
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 61 pass
- [x] **E2E on live server**: set `FREQ=WEEKLY;BYDAY=SU`, screenshotted (current rule + presets + custom + clear). Confirmed `;` round-trips correctly (earlier curl-only truncation was a harness artifact, not an app bug — browsers/HTMX url-encode; unit tests prove the full rule persists)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)