### PR TITLE
Web: single-date availability exceptions (Sprint 11 PR 11.10)

### DIFF
--- a/tests/web/test_availability_exceptions.py
+++ b/tests/web/test_availability_exceptions.py
@@ -1,0 +1,85 @@
+"""Sprint 11.10 — single-date availability exceptions."""
+
+from __future__ import annotations
+
+import re
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, email="ex@web.test", pid="ex_user"):
+    seed_person(db, person_id=pid, email=email)
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_exceptions_section_empty(client, db):
+    token = _login(client, db)
+    resp = client.get("/v/availability", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Single-date blocks" in resp.text
+    assert "No single-date blocks" in resp.text
+
+
+def test_add_exception_then_listed(client, db):
+    token = _login(client, db, email="exa@web.test", pid="exa")
+    resp = client.post(
+        "/v/availability/exception",
+        data={"exception_date": "2026-09-13"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert 'id="exceptions-section"' in resp.text
+    assert "13 SEP 2026" in resp.text.upper()
+    assert "No single-date blocks" not in resp.text
+
+
+def test_add_exception_idempotent(client, db):
+    token = _login(client, db, email="exi@web.test", pid="exi")
+    for _ in range(2):
+        resp = client.post(
+            "/v/availability/exception",
+            data={"exception_date": "2026-09-20"},
+            cookies={SESSION_COOKIE: token},
+        )
+    assert resp.status_code == 200
+    # Only one row despite two adds.
+    assert resp.text.upper().count("20 SEP 2026") == 1
+
+
+def test_invalid_date_rejected(client, db):
+    token = _login(client, db, email="exb@web.test", pid="exb")
+    resp = client.post(
+        "/v/availability/exception",
+        data={"exception_date": "not-a-date"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "form-error" in resp.text
+    assert "No single-date blocks" in resp.text
+
+
+def test_delete_exception(client, db):
+    token = _login(client, db, email="exd@web.test", pid="exd")
+    client.post(
+        "/v/availability/exception",
+        data={"exception_date": "2026-10-01"},
+        cookies={SESSION_COOKIE: token},
+    )
+    page = client.get("/v/availability", cookies={SESSION_COOKIE: token})
+    m = re.search(r"/v/availability/exception/(\d+)/delete", page.text)
+    assert m
+    resp = client.post(
+        f"/v/availability/exception/{m.group(1)}/delete",
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "No single-date blocks" in resp.text
+
+
+def test_exception_endpoints_require_auth(client):
+    r1 = client.post("/v/availability/exception", data={"exception_date": "2026-09-13"})
+    assert r1.status_code == 303
+    r2 = client.post("/v/availability/exception/1/delete")
+    assert r2.status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -164,6 +164,20 @@ def _my_rrule(db: Session, person: Person) -> str | None:
     return get_rrule(person.id, db).rrule
 
 
+def _my_exceptions(db: Session, person: Person) -> list[dict]:
+    """Single-date blocked exceptions for the caller, formatted."""
+    from api.routers.availability import list_exceptions
+
+    return [
+        {
+            "id": r.id,
+            "date": r.exception_date.isoformat(),
+            "label": r.exception_date.strftime("%a %d %b %Y").upper(),
+        }
+        for r in list_exceptions(person.id, db)
+    ]
+
+
 @router.get("/v/availability", response_class=HTMLResponse)
 def volunteer_availability(
     request: Request,
@@ -181,6 +195,7 @@ def volunteer_availability(
             "timeoff": _my_timeoff(db, person),
             "rrule": _my_rrule(db, person),
             "rrule_presets": RRULE_PRESETS,
+            "exceptions": _my_exceptions(db, person),
         },
     )
 

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -21,15 +21,27 @@ from api.routers.assignments import (
     request_swap,
 )
 from api.routers.availability import (
+    add_exception,
     add_timeoff,
     clear_rrule,
+    delete_exception,
     delete_timeoff,
     set_rrule,
 )
 from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
-from api.schemas.availability import AvailabilityRruleUpdate, TimeOffCreate
+from api.schemas.availability import (
+    AvailabilityExceptionCreate,
+    AvailabilityRruleUpdate,
+    TimeOffCreate,
+)
 from web.deps import get_session_user
-from web.routers.pages import RRULE_PRESETS, _my_assignment, _my_rrule, _my_timeoff
+from web.routers.pages import (
+    RRULE_PRESETS,
+    _my_assignment,
+    _my_exceptions,
+    _my_rrule,
+    _my_timeoff,
+)
 
 router = APIRouter(tags=["web-partials"])
 
@@ -196,3 +208,48 @@ def rrule_clear(
 ):
     clear_rrule(person.id, db)
     return _rrule_section(request, person, db)
+
+
+# ── Availability: single-date exceptions ─────────────────────────────
+
+
+def _exceptions_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/exceptions_list.html",
+        {"exceptions": _my_exceptions(db, person), "error": error},
+    )
+
+
+@router.post("/v/availability/exception", response_class=HTMLResponse)
+def exception_add(
+    request: Request,
+    exception_date: str = Form(...),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        payload = AvailabilityExceptionCreate(exception_date=exception_date)
+    except ValueError:
+        return _exceptions_list(request, person, db, error="Pick a valid date.")
+    add_exception(person.id, payload, db)
+    return _exceptions_list(request, person, db)
+
+
+@router.post(
+    "/v/availability/exception/{exception_id}/delete",
+    response_class=HTMLResponse,
+)
+def exception_delete(
+    request: Request,
+    exception_id: int,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        delete_exception(person.id, exception_id, db)
+    except HTTPException:
+        pass  # already gone — return a fresh, correct list
+    return _exceptions_list(request, person, db)

--- a/web/templates/partials/exceptions_list.html
+++ b/web/templates/partials/exceptions_list.html
@@ -1,0 +1,39 @@
+{# Single-date blocked exceptions + add form. Whole block is
+   #exceptions-section so HTMX outerHTML-swaps after add/delete. #}
+<div id="exceptions-section">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <form hx-post="/v/availability/exception"
+        hx-target="#exceptions-section" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="exception_date">Block a single date</label>
+      <input id="exception_date" name="exception_date" type="date" required>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Block this date</button>
+  </form>
+
+  <div class="mono-label">Blocked dates</div>
+  {% if not exceptions %}
+  <div class="empty">No single-date blocks.</div>
+  {% else %}
+  <div class="group">
+    {% for x in exceptions %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ x.label }}</div>
+      </div>
+      <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+              hx-post="/v/availability/exception/{{ x.id }}/delete"
+              hx-target="#exceptions-section" hx-swap="outerHTML"
+              hx-confirm="Unblock this date?">
+        Remove
+      </button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>

--- a/web/templates/volunteer/availability.html
+++ b/web/templates/volunteer/availability.html
@@ -11,6 +11,9 @@
 
   <div class="mono-label">Recurring availability</div>
   {% include "partials/rrule_section.html" %}
+
+  <div class="mono-label">Single-date blocks</div>
+  {% include "partials/exceptions_list.html" %}
 </div>
 {% set tabs = [
   ('/v/schedule', '▦', 'Schedule', 'schedule'),


### PR DESCRIPTION
## Summary
"Single-date blocks" section on `/v/availability` — block a date, list, remove — HTMX (`outerHTML`-swap `#exceptions-section`). Reuses `list_exceptions`/`add_exception`/`delete_exception` (idempotent). Completes the availability screen (time-off + rrule + single-date blocks).

## Test plan
- [x] 6 web tests: empty, add→listed, idempotent, invalid rejected, delete, auth-gate
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 67 pass
- [x] **E2E on live server**: seeded volunteer, added exception + timeoff, full availability page screenshotted (3 sections cohesive, brand-correct)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)