### PR TITLE
Web: profile calendar subscription + token reset (Sprint 11 PR 11.11)

### DIFF
--- a/tests/web/test_profile_calendar.py
+++ b/tests/web/test_profile_calendar.py
@@ -1,0 +1,57 @@
+"""Sprint 11.11 — profile calendar subscription + token reset."""
+
+from __future__ import annotations
+
+import re
+
+from api.models import Person
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, email="cal@web.test", pid="cal_user"):
+    seed_person(db, person_id=pid, email=email)
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_profile_shows_calendar_url(client, db):
+    token = _login(client, db)
+    resp = client.get("/v/profile", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Subscription URL" in resp.text
+    assert "/calendar/feed/" in resp.text
+    assert "Reset link" in resp.text
+    # Token was generated lazily.
+    p = db.query(Person).filter(Person.id == "cal_user").first()
+    assert p.calendar_token
+
+
+def test_calendar_reset_rotates_token(client, db):
+    token = _login(client, db, email="calr@web.test", pid="calr")
+    page = client.get("/v/profile", cookies={SESSION_COOKIE: token})
+    old = re.search(r"/calendar/feed/([A-Za-z0-9_\-]+)", page.text).group(1)
+
+    resp = client.post("/v/profile/calendar/reset", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'id="calendar-section"' in resp.text
+    new = re.search(r"/calendar/feed/([A-Za-z0-9_\-]+)", resp.text).group(1)
+    assert new != old
+    p = db.query(Person).filter(Person.id == "calr").first()
+    db.refresh(p)
+    assert p.calendar_token == new
+
+
+def test_calendar_url_stable_across_loads(client, db):
+    token = _login(client, db, email="cals@web.test", pid="cals")
+    r1 = client.get("/v/profile", cookies={SESSION_COOKIE: token})
+    r2 = client.get("/v/profile", cookies={SESSION_COOKIE: token})
+    t1 = re.search(r"/calendar/feed/([A-Za-z0-9_\-]+)", r1.text).group(1)
+    t2 = re.search(r"/calendar/feed/([A-Za-z0-9_\-]+)", r2.text).group(1)
+    assert t1 == t2  # not regenerated on every view
+
+
+def test_calendar_reset_requires_auth(client):
+    resp = client.post("/v/profile/calendar/reset")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -200,14 +200,31 @@ def volunteer_availability(
     )
 
 
+def _my_calendar(request: Request, db: Session, person: Person) -> dict:
+    """Calendar subscription URL for the caller (token generated lazily
+    by the API handler)."""
+    from api.routers.calendar import get_subscription_url
+
+    resp = get_subscription_url(person.id, person, db, request)
+    return {"https_url": resp.https_url, "webcal_url": resp.webcal_url}
+
+
 @router.get("/v/profile", response_class=HTMLResponse)
-def volunteer_profile(request: Request, person: Person = Depends(get_session_user)):
+def volunteer_profile(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
     from web.app import templates
 
     return templates.TemplateResponse(
         request,
         "volunteer/profile.html",
-        {"person": person, "active_tab": "profile"},
+        {
+            "person": person,
+            "active_tab": "profile",
+            "calendar": _my_calendar(request, db, person),
+        },
     )
 
 

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -35,9 +35,11 @@ from api.schemas.availability import (
     TimeOffCreate,
 )
 from web.deps import get_session_user
+from api.routers.calendar import reset_calendar_token
 from web.routers.pages import (
     RRULE_PRESETS,
     _my_assignment,
+    _my_calendar,
     _my_exceptions,
     _my_rrule,
     _my_timeoff,
@@ -253,3 +255,24 @@ def exception_delete(
     except HTTPException:
         pass  # already gone — return a fresh, correct list
     return _exceptions_list(request, person, db)
+
+
+# ── Profile: calendar subscription ───────────────────────────────────
+
+
+@router.post("/v/profile/calendar/reset", response_class=HTMLResponse)
+def calendar_reset(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    """Rotate the calendar token (invalidates the old subscription URL)
+    and re-render the calendar card with the fresh URL."""
+    from web.app import templates
+
+    reset_calendar_token(person.id, person, db, request)
+    return templates.TemplateResponse(
+        request,
+        "partials/calendar_section.html",
+        {"calendar": _my_calendar(request, db, person)},
+    )

--- a/web/templates/partials/calendar_section.html
+++ b/web/templates/partials/calendar_section.html
@@ -1,0 +1,31 @@
+{# Calendar subscription card. #calendar-section so HTMX outerHTML-
+   swaps it after a token reset. #}
+<div id="calendar-section">
+  <div class="card" x-data="{ copied: false,
+        copy(){ navigator.clipboard
+                 .writeText('{{ calendar.https_url }}')
+                 .then(() => { this.copied = true;
+                               setTimeout(() => this.copied = false, 1500); }); } }">
+    <div class="field-label">Subscription URL</div>
+    <div class="spacer-12" style="height:4px"></div>
+    <div class="mono-data" style="text-transform:none;word-break:break-all">
+      {{ calendar.https_url }}
+    </div>
+    <div class="row-sub" style="margin-top:8px">
+      Add this to Google / Apple / Outlook Calendar to see your shifts.
+    </div>
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-secondary" type="button" @click="copy()">
+        <span x-show="!copied">Copy link</span>
+        <span x-show="copied" x-cloak>Copied ✓</span>
+      </button>
+      <button class="btn btn-destructive" type="button"
+              hx-post="/v/profile/calendar/reset"
+              hx-target="#calendar-section" hx-swap="outerHTML"
+              hx-confirm="Reset the link? Existing calendar subscriptions will stop updating until re-added.">
+        Reset link
+      </button>
+    </div>
+  </div>
+</div>

--- a/web/templates/volunteer/profile.html
+++ b/web/templates/volunteer/profile.html
@@ -27,6 +27,9 @@
     </button>
   </div>
 
+  <div class="mono-label">Calendar</div>
+  {% include "partials/calendar_section.html" %}
+
   <div class="spacer-18"></div>
   <form method="post" action="/auth/logout">
     <button class="btn btn-destructive" type="submit">Sign out</button>


### PR DESCRIPTION
## Summary
Profile Calendar card: personal ICS subscription URL (lazy token via `get_subscription_url`), Alpine copy-to-clipboard, HTMX "Reset link" rotating the token (`reset_calendar_token`) + re-render. Completes the volunteer flow + auth surface.

## Test plan
- [x] 4 web tests: url + lazy token, reset rotates, url stable across loads, reset auth-gated; + login regression
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 71 pass
- [x] **E2E on live server**: profile page screenshotted (account, theme toggle, calendar URL + copy/reset, sign out, 3-tab nav — brand-correct)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)