### PR TITLE
Web: admin dashboard KPIs (Sprint 11 PR 11.12)

### DIFF
--- a/tests/web/test_dashboard.py
+++ b/tests/web/test_dashboard.py
@@ -1,0 +1,69 @@
+"""Sprint 11.12 — admin dashboard KPIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="d_org", email="dadmin@web.test"):
+    seed_person(db, person_id="d_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_dashboard_empty_org_shows_zeros(client, db):
+    token = _admin(client, db)
+    resp = client.get("/a/dashboard", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Dashboard" in resp.text
+    assert "Active volunteers" in resp.text
+    assert "Upcoming events" in resp.text
+    assert "Event coverage" in resp.text
+    # graceful zeros, no crash
+    assert "No assignments in the last 30 days" in resp.text
+    assert "Sign out" in resp.text
+
+
+def test_dashboard_reflects_data(client, db):
+    token = _admin(client, db, org="d_org2", email="dadmin2@web.test")
+    vol = seed_person(db, person_id="d_vol", org_id="d_org2", email="dvol@web.test")
+    db.add(
+        Event(
+            id="d_ev",
+            org_id="d_org2",
+            type="Sunday Service",
+            start_time=datetime(2099, 6, 7, 10, 0),
+            end_time=datetime(2099, 6, 7, 11, 30),
+        )
+    )
+    db.add(Assignment(event_id="d_ev", person_id=vol.id, role="usher", status="confirmed"))
+    db.commit()
+
+    resp = client.get("/a/dashboard", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    # Upcoming event counted; top-volunteer list populated.
+    assert "Sunday Service" not in resp.text  # dashboard shows names, not events
+    assert "Val" not in resp.text or "d_vol" not in resp.text
+    assert "Most active" in resp.text
+    assert "Web User" in resp.text  # seed_person name → appears in top list
+
+
+def test_dashboard_requires_admin(client, db):
+    seed_person(db, person_id="d_volonly", email="dvolonly@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "dvolonly@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/a/dashboard", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+def test_dashboard_requires_auth(client):
+    resp = client.get("/a/dashboard")
+    assert resp.status_code == 303

--- a/tests/web/test_signup.py
+++ b/tests/web/test_signup.py
@@ -30,7 +30,9 @@ def test_signup_creates_org_and_admin_then_redirects(client, db):
     token = resp.cookies[SESSION_COOKIE]
     dash = client.get("/a/dashboard", cookies={SESSION_COOKIE: token})
     assert dash.status_code == 200
-    assert "Sarah Kim" in dash.text
+    # 11.12 replaced the placeholder with the real KPI dashboard.
+    assert "Dashboard" in dash.text
+    assert "Active volunteers" in dash.text
 
 
 def test_signup_duplicate_email_shows_error(client, db):

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -228,12 +228,47 @@ def volunteer_profile(
     )
 
 
+def _dashboard_kpis(db: Session, org_id: str) -> dict:
+    """Roll the three analytics endpoints into the dashboard tiles.
+    All three return graceful zeros for an empty org."""
+    from api.routers.analytics import (
+        get_burnout_risk,
+        get_schedule_health,
+        get_volunteer_stats,
+    )
+
+    # Pass the Query-defaulted args explicitly: a direct (non-FastAPI)
+    # call doesn't resolve Query(...) sentinels to their defaults.
+    vs = get_volunteer_stats(org_id, db, days=30)
+    sh = get_schedule_health(org_id, db)
+    br = get_burnout_risk(org_id, db, threshold=4)
+    latest = sh.get("latest_solution")
+    return {
+        "active_volunteers": vs["active_volunteers"],
+        "total_volunteers": vs["total_volunteers"],
+        "participation_rate": vs["participation_rate"],
+        "upcoming_events": sh["upcoming_events"],
+        "coverage_rate": sh["coverage_rate"],
+        "health_score": (round(latest["health_score"]) if latest else None),
+        "at_risk_count": br["at_risk_count"],
+        "top_volunteers": vs["top_volunteers"][:5],
+    }
+
+
 @router.get("/a/dashboard", response_class=HTMLResponse)
-def admin_dashboard(request: Request, person: Person = Depends(get_session_admin)):
+def admin_dashboard(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
     from web.app import templates
 
     return templates.TemplateResponse(
         request,
         "admin/dashboard.html",
-        {"person": person, "active_tab": "dashboard"},
+        {
+            "person": person,
+            "active_tab": "dashboard",
+            "kpis": _dashboard_kpis(db, person.org_id),
+        },
     )

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -3,19 +3,61 @@
 {% block body %}
 <div class="nav">
   <span class="nav-back"></span>
-  <a class="nav-action" href="/v/profile">Settings</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
 </div>
 <div class="page-title">Dashboard</div>
 <div class="scroll">
-  <div class="empty">
-    Signed in as admin <strong>{{ person.name }}</strong>
-    (org <span class="mono-data">{{ person.org_id }}</span>).<br>
-    KPIs, solver, people &amp; events arrive in Sprint 11.2–11.3.
+  <div class="kpi-grid">
+    <div class="kpi">
+      <div class="kpi-value">{{ kpis.active_volunteers }}<span class="unit">/ {{ kpis.total_volunteers }}</span></div>
+      <div class="kpi-label">Active volunteers</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-value">{{ kpis.upcoming_events }}</div>
+      <div class="kpi-label">Upcoming events</div>
+    </div>
+    <div class="kpi accent">
+      <div class="kpi-value">{{ kpis.coverage_rate }}<span class="unit">%</span></div>
+      <div class="kpi-label">Event coverage</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-value">
+        {% if kpis.health_score is not none %}{{ kpis.health_score }}{% else %}—{% endif %}
+      </div>
+      <div class="kpi-label">Latest health score</div>
+    </div>
   </div>
+
+  <div class="spacer-12"></div>
+  <div class="card">
+    <div class="field-label">Burnout watch</div>
+    <div class="spacer-12" style="height:4px"></div>
+    {% if kpis.at_risk_count == 0 %}
+    <div class="row-sub">No volunteers over the assignment threshold. 🎉</div>
+    {% else %}
+    <div class="row-title">{{ kpis.at_risk_count }} volunteer(s) at risk</div>
+    <div class="row-sub">Serving above the monthly threshold — consider rebalancing.</div>
+    {% endif %}
+  </div>
+
+  <div class="mono-label">Most active</div>
+  {% if not kpis.top_volunteers %}
+  <div class="empty">No assignments in the last 30 days yet.</div>
+  {% else %}
+  <div class="group">
+    {% for v in kpis.top_volunteers %}
+    <div class="row">
+      <div class="row-main"><div class="row-title">{{ v.name }}</div></div>
+      <span class="mono-data">{{ v.assignments }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
 </div>
 {% set tabs = [
-  ('/a/dashboard', '▣', 'Home', 'dashboard'),
-  ('/v/profile', '◍', 'Profile', 'profile'),
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
 ] %}
 {% include "_nav.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
`/a/dashboard` renders real metrics from the 3 analytics endpoints (volunteer-stats / schedule-health / burnout-risk): active/total volunteers, upcoming events, coverage %, latest health score (— if none), burnout-watch card, top-5 most-active. Graceful zeros for an empty org. Admin nav + sign-out.

Note: analytics handlers use `Query()` defaults — passed explicitly (`days=30`, `threshold=4`) since direct calls don't resolve `Query` sentinels.

## Test plan
- [x] 4 web tests: empty→zeros, reflects data, admin-gated, auth-gated
- [x] Fixed stale 11.1 signup assertion (real dashboard shows KPIs not admin name)
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 75 pass
- [x] **E2E on live server**: seeded admin+volunteer+event+assignment, dashboard screenshotted brand-correct (KPI grid, burnout card, most-active)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)