### PR TITLE
Web: admin people list + live search (Sprint 11 PR 11.13)

### DIFF
--- a/tests/web/test_people.py
+++ b/tests/web/test_people.py
@@ -1,0 +1,77 @@
+"""Sprint 11.13 — admin people list + search."""
+
+from __future__ import annotations
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="p_org", email="padmin@web.test"):
+    seed_person(db, person_id="p_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_people_lists_org_members(client, db):
+    token = _admin(client, db)
+    seed_person(db, person_id="p_a", org_id="p_org", email="alice@web.test")
+    seed_person(db, person_id="p_b", org_id="p_org", email="bob@web.test")
+    resp = client.get("/a/people", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "People" in resp.text
+    assert "alice@web.test" in resp.text
+    assert "bob@web.test" in resp.text
+    assert "padmin@web.test" in resp.text  # admin themselves listed
+
+
+def test_people_search_filters(client, db):
+    token = _admin(client, db, org="p_org2", email="padmin2@web.test")
+    seed_person(
+        db,
+        person_id="p_zoe",
+        org_id="p_org2",
+        email="zoe@web.test",
+    )
+    # default seed name is "Web User"; override email distinct enough
+    resp = client.get("/a/people/list?q=zoe", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'id="people-list"' in resp.text
+    assert "zoe@web.test" in resp.text
+    assert "padmin2@web.test" not in resp.text  # filtered out
+
+
+def test_people_search_no_match(client, db):
+    token = _admin(client, db, org="p_org3", email="padmin3@web.test")
+    resp = client.get("/a/people/list?q=nobody-xyz", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "No people match" in resp.text
+
+
+def test_people_scoped_to_org(client, db):
+    token = _admin(client, db, org="p_org4", email="padmin4@web.test")
+    seed_person(
+        db,
+        person_id="p_outsider",
+        org_id="other_org",
+        email="outsider@web.test",
+    )
+    resp = client.get("/a/people", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "outsider@web.test" not in resp.text
+
+
+def test_people_requires_admin(client, db):
+    seed_person(db, person_id="p_vol", email="pvol@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "pvol@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/a/people", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+def test_people_requires_auth(client):
+    assert client.get("/a/people").status_code == 303
+    assert client.get("/a/people/list").status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -272,3 +272,64 @@ def admin_dashboard(
             "kpis": _dashboard_kpis(db, person.org_id),
         },
     )
+
+
+def _people(db: Session, org_id: str, q: str | None) -> list[dict]:
+    """People in the admin's org, optional case-insensitive name/email
+    search. Direct query (org-scoped) — simpler than threading the
+    API list_people's Query()/pagination deps through a direct call."""
+    from sqlalchemy import or_
+
+    query = db.query(Person).filter(Person.org_id == org_id)
+    if q:
+        like = f"%{q.strip()}%"
+        query = query.filter(or_(Person.name.ilike(like), Person.email.ilike(like)))
+    rows = query.order_by(Person.name.asc()).all()
+    return [
+        {
+            "id": p.id,
+            "name": p.name,
+            "email": p.email,
+            "roles": [r.upper() for r in (p.roles or ["volunteer"])],
+            "status": (p.status or "active").lower(),
+        }
+        for p in rows
+    ]
+
+
+@router.get("/a/people", response_class=HTMLResponse)
+def admin_people(
+    request: Request,
+    q: str | None = None,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/people.html",
+        {
+            "person": person,
+            "active_tab": "people",
+            "people": _people(db, person.org_id, q),
+            "q": q or "",
+        },
+    )
+
+
+@router.get("/a/people/list", response_class=HTMLResponse)
+def admin_people_list(
+    request: Request,
+    q: str | None = None,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """HTMX fragment for live search."""
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/people_list.html",
+        {"people": _people(db, person.org_id, q), "q": q or ""},
+    )

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -58,6 +58,7 @@
 </div>
 {% set tabs = [
   ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
 ] %}
 {% include "_nav.html" %}
 {% endblock %}

--- a/web/templates/admin/people.html
+++ b/web/templates/admin/people.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}People · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <span class="nav-back"></span>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">People</div>
+<div class="scroll">
+  <div class="field">
+    <label class="field-label" for="q">Search</label>
+    <input id="q" name="q" type="search" value="{{ q }}"
+           placeholder="Name or email"
+           hx-get="/a/people/list"
+           hx-trigger="keyup changed delay:300ms, search"
+           hx-target="#people-list" hx-swap="outerHTML">
+  </div>
+  <div class="spacer-12"></div>
+  {% include "partials/people_list.html" %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/partials/people_list.html
+++ b/web/templates/partials/people_list.html
@@ -1,0 +1,26 @@
+{# People rows. #people-list so HTMX live-search swaps it. #}
+<div id="people-list">
+  {% if not people %}
+  <div class="empty">
+    {% if q %}No people match "{{ q }}".{% else %}No people yet.{% endif %}
+  </div>
+  {% else %}
+  <div class="group">
+    {% for p in people %}
+    <div class="row">
+      <div class="avatar sm">{{ p.name[:1]|upper }}</div>
+      <div class="row-main">
+        <div class="row-title">{{ p.name }}</div>
+        <div class="row-sub">{{ p.email or '—' }}</div>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">
+        <span class="mono-data">{{ p.roles|join(' · ') }}</span>
+        <span class="status-text {{ 'confirmed' if p.status == 'active' else 'pending' }}">
+          {{ p.status }}
+        </span>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
`/a/people` — org-scoped people list (avatar/name/email/roles/status) with HTMX live search (debounced → `/a/people/list` fragment). Direct org-scoped query. Admin nav now Dashboard + People.

## Test plan
- [x] 6 web tests: lists members, search filters, no-match, org-scoped, admin-gated, auth-gated
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 81 pass
- [x] **E2E on live server**: 3 people screenshotted (avatars/roles/status); live `q=sarah` confirmed filtering

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)