### PR TITLE
Web: admin invite person (Sprint 11 PR 11.14)

### DIFF
--- a/tests/web/test_invite_person.py
+++ b/tests/web/test_invite_person.py
@@ -1,0 +1,97 @@
+"""Sprint 11.14 — admin invite person."""
+
+from __future__ import annotations
+
+from api.models import Invitation
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="i_org", email="iadmin@web.test"):
+    seed_person(db, person_id="i_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_people_page_has_invite_form(client, db):
+    token = _admin(client, db)
+    resp = client.get("/a/people", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Invite person" in resp.text
+    assert 'hx-post="/a/people/invite"' in resp.text
+
+
+def test_invite_creates_invitation(client, db):
+    token = _admin(client, db, org="i_org2", email="iadmin2@web.test")
+    resp = client.post(
+        "/a/people/invite",
+        data={
+            "name": "Jamie Park",
+            "email": "jamie@example.com",
+            "role": "volunteer",
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "Invitation sent to jamie@example.com" in resp.text
+    inv = db.query(Invitation).filter(Invitation.email == "jamie@example.com").first()
+    assert inv is not None
+    assert inv.org_id == "i_org2"
+    assert inv.roles == ["volunteer"]
+    assert inv.status == "pending"
+
+
+def test_invite_admin_role(client, db):
+    token = _admin(client, db, org="i_org3", email="iadmin3@web.test")
+    client.post(
+        "/a/people/invite",
+        data={
+            "name": "New Admin",
+            "email": "newadmin@example.com",
+            "role": "admin",
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    inv = db.query(Invitation).filter(Invitation.email == "newadmin@example.com").first()
+    assert inv.roles == ["admin"]
+
+
+def test_invite_invalid_email_rejected(client, db):
+    token = _admin(client, db, org="i_org4", email="iadmin4@web.test")
+    resp = client.post(
+        "/a/people/invite",
+        data={"name": "Bad", "email": "not-an-email", "role": "volunteer"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 400
+    assert "form-error" in resp.text
+    # Scope by org — the strict tenancy guard rejects bare cross-tenant
+    # SELECTs (including from test code).
+    assert (
+        db.query(Invitation).filter(Invitation.org_id == "i_org4", Invitation.name == "Bad").first()
+        is None
+    )
+
+
+def test_invite_requires_admin(client, db):
+    seed_person(db, person_id="i_vol", email="ivol@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "ivol@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.post(
+        "/a/people/invite",
+        data={"name": "X", "email": "x@example.com", "role": "volunteer"},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+def test_invite_requires_auth(client):
+    resp = client.post(
+        "/a/people/invite",
+        data={"name": "X", "email": "x@example.com", "role": "volunteer"},
+    )
+    assert resp.status_code == 303

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -34,8 +34,10 @@ from api.schemas.availability import (
     AvailabilityRruleUpdate,
     TimeOffCreate,
 )
-from web.deps import get_session_user
+from web.deps import get_session_admin, get_session_user
 from api.routers.calendar import reset_calendar_token
+from api.routers.invitations import create_invitation
+from api.schemas.invitation import InvitationCreate
 from web.routers.pages import (
     RRULE_PRESETS,
     _my_assignment,
@@ -276,3 +278,40 @@ def calendar_reset(
         "partials/calendar_section.html",
         {"calendar": _my_calendar(request, db, person)},
     )
+
+
+# ── Admin: invite person ─────────────────────────────────────────────
+
+
+@router.post("/a/people/invite", response_class=HTMLResponse)
+def people_invite(
+    request: Request,
+    name: str = Form(...),
+    email: str = Form(...),
+    role: str = Form("volunteer"),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Create an invitation in the admin's org. Returns a small result
+    partial (success banner or inline error) swapped into #invite-result.
+    The invitee only appears on /a/people once they accept."""
+    from web.app import templates
+
+    def _result(ok: bool, msg: str, code: int = 200):
+        return templates.TemplateResponse(
+            request,
+            "partials/invite_result.html",
+            {"ok": ok, "msg": msg},
+            status_code=code,
+        )
+
+    role = role if role in ("volunteer", "admin") else "volunteer"
+    try:
+        payload = InvitationCreate(name=name, email=email, roles=[role])
+    except ValueError:
+        return _result(False, "Enter a valid name and email.", 400)
+    try:
+        create_invitation(payload, BackgroundTasks(), org_id=person.org_id, inviter=person, db=db)
+    except HTTPException as exc:
+        return _result(False, str(exc.detail), exc.status_code or 400)
+    return _result(True, f"Invitation sent to {email}.")

--- a/web/templates/admin/people.html
+++ b/web/templates/admin/people.html
@@ -8,7 +8,46 @@
   </form>
 </div>
 <div class="page-title">People</div>
-<div class="scroll">
+<div class="scroll" x-data="{ inviting: false }">
+  <button class="btn btn-primary" type="button"
+          x-show="!inviting" @click="inviting = true">
+    Invite person
+  </button>
+
+  <div x-show="inviting" x-cloak>
+    <div id="invite-result"></div>
+    <form hx-post="/a/people/invite"
+          hx-target="#invite-result" hx-swap="outerHTML"
+          @htmx:after-request="if ($event.detail.successful) $event.target.reset()">
+      <div class="field">
+        <label class="field-label" for="inv_name">Name</label>
+        <input id="inv_name" name="name" type="text" required
+               placeholder="Jamie Park">
+      </div>
+      <div class="field">
+        <label class="field-label" for="inv_email">Email</label>
+        <input id="inv_email" name="email" type="email" required
+               placeholder="jamie@church.org">
+      </div>
+      <div class="field">
+        <label class="field-label" for="inv_role">Role</label>
+        <select id="inv_role" name="role"
+                style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+          <option value="volunteer">Volunteer</option>
+          <option value="admin">Admin</option>
+        </select>
+      </div>
+      <div class="spacer-12"></div>
+      <div class="btn-row cols-2">
+        <button class="btn btn-secondary" type="button"
+                @click="inviting = false">Done</button>
+        <button class="btn btn-primary" type="submit">Send invite</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="spacer-18"></div>
+
   <div class="field">
     <label class="field-label" for="q">Search</label>
     <input id="q" name="q" type="search" value="{{ q }}"

--- a/web/templates/partials/invite_result.html
+++ b/web/templates/partials/invite_result.html
@@ -1,0 +1,8 @@
+{# Invite outcome. Swapped into #invite-result. #}
+<div id="invite-result">
+  {% if ok %}
+  <div class="form-notice" role="status">{{ msg }}</div>
+  {% else %}
+  <div class="form-error" role="alert">{{ msg }}</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
People page Alpine-toggled invite form (name/email/role) → `POST /a/people/invite` reusing `create_invitation` in the admin's org. Returns a result partial (success/inline-error) into `#invite-result`; resets on success. Completes admin onboarding (invite → accept via 11.4).

## Test plan
- [x] 6 web tests: form present, creates invitation, admin role, invalid email rejected, admin-gated, auth-gated
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 87 pass
- [x] **E2E on live server**: live POST → "Invitation sent to jamie@example.com"; people page screenshotted with invite entry

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)