### PR TITLE
Web: admin events list (Sprint 11 PR 11.15)

### DIFF
--- a/tests/web/test_events.py
+++ b/tests/web/test_events.py
@@ -1,0 +1,87 @@
+"""Sprint 11.15 — admin events list."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Event
+from api.timeutils import utcnow
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="e_org", email="eadmin@web.test"):
+    seed_person(db, person_id="e_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_events_empty(client, db):
+    token = _admin(client, db)
+    resp = client.get("/a/events", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Events" in resp.text
+    assert "No upcoming events" in resp.text
+    assert "No past events" in resp.text
+
+
+def test_events_split_upcoming_past(client, db):
+    token = _admin(client, db, org="e_org2", email="eadmin2@web.test")
+    now = utcnow()
+    db.add(
+        Event(
+            id="e_up",
+            org_id="e_org2",
+            type="Future Service",
+            start_time=now + timedelta(days=7),
+            end_time=now + timedelta(days=7, hours=1),
+        )
+    )
+    db.add(
+        Event(
+            id="e_past",
+            org_id="e_org2",
+            type="Old Meeting",
+            start_time=now - timedelta(days=7),
+            end_time=now - timedelta(days=7) + timedelta(hours=1),
+        )
+    )
+    db.commit()
+    resp = client.get("/a/events", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Future Service" in resp.text
+    assert "Old Meeting" in resp.text
+    # Upcoming section appears before Past in the document.
+    assert resp.text.index("Future Service") < resp.text.index("Old Meeting")
+
+
+def test_events_scoped_to_org(client, db):
+    token = _admin(client, db, org="e_org3", email="eadmin3@web.test")
+    db.add(
+        Event(
+            id="e_other",
+            org_id="other_org",
+            type="Not Mine Event",
+            start_time=datetime(2099, 1, 1, 10),
+            end_time=datetime(2099, 1, 1, 11),
+        )
+    )
+    db.commit()
+    resp = client.get("/a/events", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Not Mine Event" not in resp.text
+
+
+def test_events_requires_admin(client, db):
+    seed_person(db, person_id="e_vol", email="evol@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "evol@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/a/events", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 303
+
+
+def test_events_requires_auth(client):
+    assert client.get("/a/events").status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -333,3 +333,47 @@ def admin_people_list(
         "partials/people_list.html",
         {"people": _people(db, person.org_id, q), "q": q or ""},
     )
+
+
+def _events(db: Session, org_id: str) -> dict:
+    """Org events split into upcoming vs past, formatted. Direct query
+    (org-scoped) — simpler than the API list_events Query()/pagination
+    deps via a direct call."""
+    from api.timeutils import utcnow
+
+    now = utcnow()
+    rows = db.query(Event).filter(Event.org_id == org_id).order_by(Event.start_time.asc()).all()
+    upcoming, past = [], []
+    for e in rows:
+        item = {
+            "id": e.id,
+            "type": e.type,
+            "date_label": e.start_time.strftime("%a %d %b %Y").upper() if e.start_time else "",
+            "time_label": (
+                f"{e.start_time.strftime('%H:%M')}–{e.end_time.strftime('%H:%M')}"
+                if e.start_time and e.end_time
+                else ""
+            ),
+        }
+        (upcoming if e.start_time and e.start_time >= now else past).append(item)
+    past.reverse()  # most-recent past first
+    return {"upcoming": upcoming, "past": past}
+
+
+@router.get("/a/events", response_class=HTMLResponse)
+def admin_events(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/events.html",
+        {
+            "person": person,
+            "active_tab": "events",
+            "events": _events(db, person.org_id),
+        },
+    )

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -59,6 +59,7 @@
 {% set tabs = [
   ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
   ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
 ] %}
 {% include "_nav.html" %}
 {% endblock %}

--- a/web/templates/admin/events.html
+++ b/web/templates/admin/events.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %}Events · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <span class="nav-back"></span>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Events</div>
+<div class="scroll">
+  <div class="mono-label" style="margin-top:8px">Upcoming</div>
+  {% if not events.upcoming %}
+  <div class="empty">No upcoming events.</div>
+  {% else %}
+  <div class="group">
+    {% for e in events.upcoming %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ e.type }}</div>
+        <div class="row-sub">{{ e.date_label }}</div>
+      </div>
+      {% if e.time_label %}<span class="time-chip">{{ e.time_label }}</span>{% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="mono-label">Past</div>
+  {% if not events.past %}
+  <div class="empty">No past events.</div>
+  {% else %}
+  <div class="group">
+    {% for e in events.past %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ e.type }}</div>
+        <div class="row-sub">{{ e.date_label }}</div>
+      </div>
+      {% if e.time_label %}<span class="time-chip">{{ e.time_label }}</span>{% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/admin/people.html
+++ b/web/templates/admin/people.html
@@ -62,6 +62,7 @@
 {% set tabs = [
   ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
   ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
 ] %}
 {% include "_nav.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
`/a/events` — org-scoped events split Upcoming vs Past (recent-first), rows with type/date/time-chip. Direct org-scoped query. Admin nav now Dashboard · People · Events.

## Test plan
- [x] 5 web tests: empty, upcoming/past split + order, org-scoped, admin-gated, auth-gated
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 92 pass
- [x] **E2E on live server**: 3 events seeded, screenshotted brand-correct (Upcoming/Past, time-chips, 3-tab nav)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)