### PR TITLE
Web: solution-review live SSE + fix dropped-publish (Sprint 11 PR 11.19)

### DIFF
--- a/tests/web/test_solution_sse.py
+++ b/tests/web/test_solution_sse.py
@@ -1,0 +1,115 @@
+"""Sprint 11.19 — solution-review live SSE (cookie-authed mirror).
+
+The SSE happy-path body is an infinite generator (event_bus.subscribe);
+a sync TestClient would hang trying to read it, so we exercise the
+guard paths (auth / ownership) that short-circuit BEFORE streaming
+starts. The event_bus round-trip itself is covered by the Sprint 10.4
+API tests (tests/api/test_solutions_stream.py) — this route is a thin
+cookie-authed mirror over the same topic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from api.models import Assignment, Event, Solution
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="se_org", email="seadmin@web.test"):
+    seed_person(db, person_id="se_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _seed_solution(db, org):
+    vol = seed_person(db, person_id=f"{org}_v", org_id=org, email=f"{org}v@web.test")
+    sol = Solution(
+        org_id=org,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=95.0,
+        solve_ms=8.0,
+    )
+    db.add(sol)
+    db.add(
+        Event(
+            id=f"{org}_ev",
+            org_id=org,
+            type="Sunday Service",
+            start_time=datetime(2099, 6, 7, 10, 0),
+            end_time=datetime(2099, 6, 7, 11, 30),
+        )
+    )
+    db.commit()
+    db.refresh(sol)
+    db.add(
+        Assignment(
+            solution_id=sol.id,
+            event_id=f"{org}_ev",
+            person_id=vol.id,
+            role="usher",
+            status="confirmed",
+        )
+    )
+    db.commit()
+    return sol
+
+
+def test_review_page_wires_sse(client, db):
+    token = _admin(client, db, org="se_o1", email="se1@web.test")
+    sol = _seed_solution(db, "se_o1")
+    resp = client.get(f"/a/solution/{sol.id}", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'hx-ext="sse"' in resp.text
+    assert f'sse-connect="/a/solution/{sol.id}/stream"' in resp.text
+    assert 'hx-trigger="sse:message"' in resp.text
+    assert 'id="solution-assignments"' in resp.text
+
+
+def test_assignments_fragment_renders(client, db):
+    token = _admin(client, db, org="se_o2", email="se2@web.test")
+    sol = _seed_solution(db, "se_o2")
+    resp = client.get(
+        f"/a/solution/{sol.id}/assignments",
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert 'id="solution-assignments"' in resp.text
+    assert "Sunday Service" in resp.text
+    assert "Web User" in resp.text
+
+
+def test_assignments_fragment_404_other_org(client, db):
+    token = _admin(client, db, org="se_o3", email="se3@web.test")
+    other = _seed_solution(db, "se_other")
+    resp = client.get(
+        f"/a/solution/{other.id}/assignments",
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 404
+
+
+def test_stream_404_for_unknown_solution(client, db):
+    token = _admin(client, db, org="se_o4", email="se4@web.test")
+    # Unknown id → HTTPException raised before the streaming body, so
+    # the sync client doesn't hang.
+    resp = client.get("/a/solution/999999/stream", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 404
+
+
+def test_stream_requires_admin(client, db):
+    seed_person(db, person_id="se_vol", email="sevol@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "sevol@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    resp = client.get("/a/solution/1/stream", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 303
+
+
+def test_stream_requires_auth(client):
+    assert client.get("/a/solution/1/stream").status_code == 303
+    assert client.get("/a/solution/1/assignments").status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -403,31 +403,44 @@ def admin_solver(
     )
 
 
+def _solution_owned(db: Session, person: Person, sid: int):
+    """The Solution row iff it belongs to the caller's org, else None."""
+    from api.models import Solution
+
+    return db.query(Solution).filter(Solution.id == sid, Solution.org_id == person.org_id).first()
+
+
+def _solution_events(db: Session, person: Person, sid: int) -> list[dict] | None:
+    """Event-grouped assignees for an owned solution, formatted. None →
+    404 (unknown or other-org). Shared by the full review page and the
+    SSE-driven assignments refetch."""
+    from api.routers.solutions import get_solution_assignments
+
+    if _solution_owned(db, person, sid) is None:
+        return None
+    assignments = get_solution_assignments(sid, db)
+    return [
+        {
+            "event_type": e.event_type or e.event_id,
+            "date_label": e.event_start.strftime("%a %d %b %Y · %H:%M").upper()
+            if e.event_start
+            else "",
+            "assignees": [a.person_name or a.person_id for a in e.assignees],
+        }
+        for e in assignments.events
+    ]
+
+
 def _solution_review(db: Session, person: Person, sid: int) -> dict | None:
     """Solution header + event-grouped assignments + stats for a solution
     in the admin's org. None → 404."""
-    from api.models import Solution
-    from api.routers.solutions import get_solution, get_solution_assignments
-    from api.routers.solutions import get_solution_stats
+    from api.routers.solutions import get_solution, get_solution_stats
 
-    sol = db.query(Solution).filter(Solution.id == sid, Solution.org_id == person.org_id).first()
-    if sol is None:
+    if _solution_owned(db, person, sid) is None:
         return None
     detail = get_solution(sid, db)
-    assignments = get_solution_assignments(sid, db)
     stats = get_solution_stats(sid, person, db)
-
-    events = []
-    for e in assignments.events:
-        events.append(
-            {
-                "event_type": e.event_type or e.event_id,
-                "date_label": e.event_start.strftime("%a %d %b %Y · %H:%M").upper()
-                if e.event_start
-                else "",
-                "assignees": [a.person_name or a.person_id for a in e.assignees],
-            }
-        )
+    events = _solution_events(db, person, sid)
     return {
         "id": detail.id,
         "health_score": round(detail.health_score),
@@ -471,4 +484,70 @@ def admin_solution_review(
         request,
         "admin/solution_review.html",
         {"person": person, "active_tab": "solver", "review": review},
+    )
+
+
+@router.get("/a/solution/{solution_id}/assignments", response_class=HTMLResponse)
+def admin_solution_assignments(
+    request: Request,
+    solution_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """HTMX fragment: the event-grouped assignments block, refetched on
+    each SSE event."""
+    from web.app import templates
+
+    events = _solution_events(db, person, solution_id)
+    if events is None:
+        return templates.TemplateResponse(
+            request,
+            "partials/solution_assignments.html",
+            {"events": []},
+            status_code=404,
+        )
+    return templates.TemplateResponse(
+        request,
+        "partials/solution_assignments.html",
+        {"events": events},
+    )
+
+
+@router.get("/a/solution/{solution_id}/stream")
+async def admin_solution_stream(
+    solution_id: int,
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Cookie-authed SSE mirror of GET /api/v1/solutions/{id}/assignments
+    /stream (which is Bearer-only). Same per-process event_bus topic
+    (solution:{id}) the assignment-mutation endpoints publish to."""
+    import json
+
+    from fastapi.responses import StreamingResponse
+
+    from api.services import event_bus
+
+    if _solution_owned(db, person, solution_id) is None:
+        from fastapi import HTTPException, status
+
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Solution not found")
+
+    topic = f"solution:{solution_id}"
+
+    async def _stream():
+        yield ": stream open\n\n"
+        async for event in event_bus.subscribe(topic):
+            if await request.is_disconnected():
+                break
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(
+        _stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+        },
     )

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -72,15 +72,24 @@ def _card(request: Request, person: Person, db: Session, aid: int):
     return templates.TemplateResponse(request, "partials/assignment_detail_card.html", {"row": row})
 
 
+# NOTE: these routes declare `background_tasks: BackgroundTasks` as a
+# FastAPI param (not a throwaway BackgroundTasks()) and pass it to the
+# API handler. The handler queues event_bus.publish via add_task;
+# FastAPI runs those AFTER the response. A discarded BackgroundTasks()
+# would silently drop the publish, so the Solution-Review SSE stream
+# (11.19) never fires. Caught by the 11.19 live e2e test.
+
+
 @router.post("/v/schedule/{assignment_id}/accept", response_class=HTMLResponse)
 def accept(
     request: Request,
     assignment_id: int,
+    background_tasks: BackgroundTasks,
     person: Person = Depends(get_session_user),
     db: Session = Depends(get_db),
 ):
     try:
-        accept_assignment(assignment_id, request, BackgroundTasks(), person, db)
+        accept_assignment(assignment_id, request, background_tasks, person, db)
     except HTTPException:
         return _gone()
     return _card(request, person, db, assignment_id)
@@ -90,6 +99,7 @@ def accept(
 def decline(
     request: Request,
     assignment_id: int,
+    background_tasks: BackgroundTasks,
     decline_reason: str = Form(...),
     person: Person = Depends(get_session_user),
     db: Session = Depends(get_db),
@@ -99,7 +109,7 @@ def decline(
             assignment_id,
             AssignmentDeclineRequest(decline_reason=decline_reason),
             request,
-            BackgroundTasks(),
+            background_tasks,
             person,
             db,
         )
@@ -112,6 +122,7 @@ def decline(
 def swap(
     request: Request,
     assignment_id: int,
+    background_tasks: BackgroundTasks,
     note: str | None = Form(None),
     person: Person = Depends(get_session_user),
     db: Session = Depends(get_db),
@@ -121,7 +132,7 @@ def swap(
             assignment_id,
             AssignmentSwapRequest(note=note),
             request,
-            BackgroundTasks(),
+            background_tasks,
             person,
             db,
         )

--- a/web/templates/admin/solution_review.html
+++ b/web/templates/admin/solution_review.html
@@ -52,25 +52,19 @@
     <div class="spacer-12"></div>
 
     <div x-show="seg==='assignments'">
-      {% if not review.events %}
-      <div class="empty">No assignments in this solution.</div>
-      {% else %}
-      {% for e in review.events %}
-      <div class="card">
-        <div class="row-title">{{ e.event_type }}</div>
-        <div class="row-sub">{{ e.date_label }}</div>
-        <div class="spacer-12" style="height:8px"></div>
-        <div style="display:flex;flex-wrap:wrap;gap:6px">
-          {% for name in e.assignees %}
-          <span class="role-chip">{{ name }}</span>
-          {% endfor %}
-          {% if not e.assignees %}
-          <span class="row-sub">Unfilled</span>
-          {% endif %}
+      {# Live updates: HTMX SSE ext connects to the cookie-authed web
+         stream; each event triggers a refetch of #solution-assignments
+         (Sprint 10.4 event_bus → Sprint 11.19). #}
+      <div hx-ext="sse"
+           sse-connect="/a/solution/{{ review.id }}/stream">
+        <div hx-get="/a/solution/{{ review.id }}/assignments"
+             hx-trigger="sse:message"
+             hx-target="#solution-assignments"
+             hx-swap="outerHTML">
+          {% set events = review.events %}
+          {% include "partials/solution_assignments.html" %}
         </div>
       </div>
-      {% endfor %}
-      {% endif %}
     </div>
 
     <div x-show="seg==='stats'" x-cloak>

--- a/web/templates/partials/solution_assignments.html
+++ b/web/templates/partials/solution_assignments.html
@@ -1,0 +1,23 @@
+{# Event-grouped assignments for a solution. #solution-assignments so
+   the SSE refetch (sse:message) outerHTML-swaps it live. #}
+<div id="solution-assignments">
+  {% if not events %}
+  <div class="empty">No assignments in this solution.</div>
+  {% else %}
+  {% for e in events %}
+  <div class="card">
+    <div class="row-title">{{ e.event_type }}</div>
+    <div class="row-sub">{{ e.date_label }}</div>
+    <div class="spacer-12" style="height:8px"></div>
+    <div style="display:flex;flex-wrap:wrap;gap:6px">
+      {% for name in e.assignees %}
+      <span class="role-chip">{{ name }}</span>
+      {% endfor %}
+      {% if not e.assignees %}
+      <span class="row-sub">Unfilled</span>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
Solution Review live-refreshes via HTMX SSE → new cookie-authed `GET /a/solution/{id}/stream` (mirror of the Bearer-only API SSE from 10.4, same `event_bus` topic) + assignments-fragment refetch on each event.

**Bug fix (11.7, surfaced by this PR's live e2e):** web accept/decline/swap passed a throwaway `BackgroundTasks()`; called directly (not via FastAPI), the queued `event_bus.publish` never ran → SSE never fired. Now uses a FastAPI-injected `BackgroundTasks`.

## Test plan
- [x] 6 web tests (sse wiring, assignments fragment + 404s, stream gated — guard paths, no hang)
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 114 pass
- [x] **E2E on live server (real proof)**: opened SSE as admin, volunteer accepted assignment → stream delivered `data: {"type":"assignment.changed","solution_id":1,"status":"confirmed"}`. Validates the 10.4/10.4b event_bus infra through the web layer.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)