### PR TITLE
Web: publish solution + compare (Sprint 11 PR 11.20)

### DIFF
--- a/tests/web/test_publish_compare.py
+++ b/tests/web/test_publish_compare.py
@@ -1,0 +1,115 @@
+"""Sprint 11.20 — publish solution + compare."""
+
+from __future__ import annotations
+
+from api.models import Solution
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="pc_org", email="pcadmin@web.test"):
+    seed_person(db, person_id="pc_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _sol(db, org):
+    s = Solution(
+        org_id=org,
+        hard_violations=0,
+        soft_score=1.0,
+        health_score=90.0,
+        solve_ms=5.0,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def test_publish_marks_solution_and_unpublishes_prior(client, db):
+    token = _admin(client, db, org="pc_o1", email="pc1@web.test")
+    s1 = _sol(db, "pc_o1")
+    s2 = _sol(db, "pc_o1")
+    # Publish s1.
+    r1 = client.post(f"/a/solution/{s1.id}/publish", cookies={SESSION_COOKIE: token})
+    assert r1.status_code == 200
+    assert "Published" in r1.text
+    db.refresh(s1)
+    assert s1.is_published is True
+    # Publish s2 → s1 auto-unpublished.
+    r2 = client.post(f"/a/solution/{s2.id}/publish", cookies={SESSION_COOKIE: token})
+    assert r2.status_code == 200
+    db.refresh(s1)
+    db.refresh(s2)
+    assert s2.is_published is True
+    assert s1.is_published is False
+
+
+def test_publish_404_other_org(client, db):
+    token = _admin(client, db, org="pc_o2", email="pc2@web.test")
+    other = _sol(db, "pc_other")
+    resp = client.post(f"/a/solution/{other.id}/publish", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 404
+
+
+def test_review_page_shows_publish_control(client, db):
+    token = _admin(client, db, org="pc_o3", email="pc3@web.test")
+    s = _sol(db, "pc_o3")
+    resp = client.get(f"/a/solution/{s.id}", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'id="publish-state"' in resp.text
+    assert "Publish this solution" in resp.text
+    assert "Compare with another solution" in resp.text
+
+
+def test_compare_page_needs_two(client, db):
+    token = _admin(client, db, org="pc_o4", email="pc4@web.test")
+    _sol(db, "pc_o4")  # only one
+    resp = client.get("/a/compare", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Need at least two solutions" in resp.text
+
+
+def test_compare_runs_diff(client, db):
+    token = _admin(client, db, org="pc_o5", email="pc5@web.test")
+    a = _sol(db, "pc_o5")
+    b = _sol(db, "pc_o5")
+    page = client.get("/a/compare", cookies={SESSION_COOKIE: token})
+    assert "Solution A" in page.text and "Solution B" in page.text
+    resp = client.post(
+        "/a/compare",
+        data={"solution_a": a.id, "solution_b": b.id},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert 'id="compare-result"' in resp.text
+    assert "Moves" in resp.text  # diff KPI grid rendered
+
+
+def test_compare_other_org_rejected(client, db):
+    token = _admin(client, db, org="pc_o6", email="pc6@web.test")
+    a = _sol(db, "pc_o6")
+    other = _sol(db, "pc_other2")
+    resp = client.post(
+        "/a/compare",
+        data={"solution_a": a.id, "solution_b": other.id},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 404
+
+
+def test_publish_compare_require_admin(client, db):
+    seed_person(db, person_id="pc_vol", email="pcvol@web.test", roles=["volunteer"])
+    login = client.post(
+        "/auth/login",
+        data={"email": "pcvol@web.test", "password": "WebPass123!"},
+    )
+    token = login.cookies[SESSION_COOKIE]
+    assert client.post("/a/solution/1/publish", cookies={SESSION_COOKIE: token}).status_code == 303
+    assert client.get("/a/compare", cookies={SESSION_COOKIE: token}).status_code == 303
+
+
+def test_publish_compare_require_auth(client):
+    assert client.post("/a/solution/1/publish").status_code == 303
+    assert client.get("/a/compare").status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -551,3 +551,43 @@ async def admin_solution_stream(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+def _org_solutions(db: Session, org_id: str) -> list[dict]:
+    """Org solutions newest-first, for the compare pickers."""
+    from api.models import Solution
+
+    rows = (
+        db.query(Solution)
+        .filter(Solution.org_id == org_id)
+        .order_by(Solution.created_at.desc())
+        .all()
+    )
+    return [
+        {
+            "id": s.id,
+            "label": f"#{s.id} · "
+            + (s.created_at.strftime("%d %b %Y").upper() if s.created_at else "")
+            + (" · PUBLISHED" if s.is_published else ""),
+        }
+        for s in rows
+    ]
+
+
+@router.get("/a/compare", response_class=HTMLResponse)
+def admin_compare(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/compare.html",
+        {
+            "person": person,
+            "active_tab": "solver",
+            "solutions": _org_solutions(db, person.org_id),
+        },
+    )

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -38,6 +38,7 @@ from web.deps import get_session_admin, get_session_user
 from api.routers.calendar import reset_calendar_token
 from api.routers.events import create_event, delete_event
 from api.routers.invitations import create_invitation
+from api.routers.solutions import compare_solutions, publish_solution
 from api.routers.solver import solve_schedule
 from api.schemas.event import EventCreate
 from api.schemas.invitation import InvitationCreate
@@ -50,6 +51,8 @@ from web.routers.pages import (
     _my_exceptions,
     _my_rrule,
     _my_timeoff,
+    _org_solutions,
+    _solution_owned,
 )
 
 router = APIRouter(tags=["web-partials"])
@@ -456,5 +459,83 @@ def solver_run(
                 "hard_violations": m.hard_violations,
                 "solve_ms": round(m.solve_ms),
             }
+        },
+    )
+
+
+# ── Admin: publish solution + compare ────────────────────────────────
+
+
+@router.post("/a/solution/{solution_id}/publish", response_class=HTMLResponse)
+def solution_publish(
+    request: Request,
+    solution_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Publish the solution (unpublishes any prior in the org). Returns
+    the refreshed publish-state fragment."""
+    from web.app import templates
+
+    if _solution_owned(db, person, solution_id) is None:
+        return HTMLResponse(
+            '<div id="publish-state" class="empty">Solution not found.</div>',
+            status_code=404,
+        )
+    try:
+        publish_solution(solution_id, request, person, db)
+    except HTTPException as exc:
+        return templates.TemplateResponse(
+            request,
+            "partials/publish_state.html",
+            {"published": False, "error": str(exc.detail)},
+            status_code=exc.status_code or 400,
+        )
+    return templates.TemplateResponse(
+        request, "partials/publish_state.html", {"published": True, "error": None}
+    )
+
+
+@router.post("/a/compare", response_class=HTMLResponse)
+def compare_run(
+    request: Request,
+    solution_a: int = Form(...),
+    solution_b: int = Form(...),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    def _err(msg: str, code: int = 400):
+        return templates.TemplateResponse(
+            request,
+            "partials/compare_result.html",
+            {"diff": None, "error": msg},
+            status_code=code,
+        )
+
+    if (
+        _solution_owned(db, person, solution_a) is None
+        or _solution_owned(db, person, solution_b) is None
+    ):
+        return _err("Pick two solutions from your organization.", 404)
+    try:
+        diff = compare_solutions(solution_a, solution_b, person, db)
+    except HTTPException as exc:
+        return _err(str(exc.detail), exc.status_code or 400)
+    return templates.TemplateResponse(
+        request,
+        "partials/compare_result.html",
+        {
+            "diff": {
+                "a": diff.solution_a_id,
+                "b": diff.solution_b_id,
+                "added": len(diff.added),
+                "removed": len(diff.removed),
+                "unchanged": diff.unchanged_count,
+                "moves": diff.moves,
+                "affected": diff.affected_persons,
+            },
+            "error": None,
         },
     )

--- a/web/templates/admin/compare.html
+++ b/web/templates/admin/compare.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Compare solutions · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/solver">‹ Solver</a>
+  <span class="nav-title-inline">Compare</span>
+  <span class="nav-action"></span>
+</div>
+<div class="page-title">Compare</div>
+<div class="scroll">
+  {% if solutions|length < 2 %}
+  <div class="empty">Need at least two solutions to compare. Run the solver again.</div>
+  {% else %}
+  <form hx-post="/a/compare"
+        hx-target="#compare-result" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="solution_a">Solution A</label>
+      <select id="solution_a" name="solution_a"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        {% for s in solutions %}
+        <option value="{{ s.id }}">{{ s.label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field">
+      <label class="field-label" for="solution_b">Solution B</label>
+      <select id="solution_b" name="solution_b"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        {% for s in solutions %}
+        <option value="{{ s.id }}"
+          {% if loop.index == 2 %}selected{% endif %}>{{ s.label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Compare</button>
+  </form>
+  <div class="spacer-18"></div>
+  <div id="compare-result"></div>
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/admin/solution_review.html
+++ b/web/templates/admin/solution_review.html
@@ -39,6 +39,13 @@
         <div class="kpi-label">Soft score</div>
       </div>
     </div>
+    <div class="spacer-12"></div>
+    {% set solution_id = review.id %}
+    {% set published = review.is_published %}
+    {% set error = None %}
+    {% include "partials/publish_state.html" %}
+    <div class="spacer-12"></div>
+    <a class="btn btn-secondary" href="/a/compare">Compare with another solution</a>
   </div>
 
   <div class="spacer-12"></div>

--- a/web/templates/partials/compare_result.html
+++ b/web/templates/partials/compare_result.html
@@ -1,0 +1,28 @@
+{# Diff of two solutions. #compare-result. #}
+<div id="compare-result">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% elif diff %}
+  <div class="card">
+    <div class="field-label">#{{ diff.a }} → #{{ diff.b }}</div>
+    <div class="spacer-12" style="height:6px"></div>
+    <div class="kpi-grid">
+      <div class="kpi"><div class="kpi-value">{{ diff.added }}</div>
+        <div class="kpi-label">Added</div></div>
+      <div class="kpi"><div class="kpi-value">{{ diff.removed }}</div>
+        <div class="kpi-label">Removed</div></div>
+      <div class="kpi"><div class="kpi-value">{{ diff.unchanged }}</div>
+        <div class="kpi-label">Unchanged</div></div>
+      <div class="kpi accent"><div class="kpi-value">{{ diff.moves }}</div>
+        <div class="kpi-label">Moves</div></div>
+    </div>
+    {% if diff.affected %}
+    <div class="spacer-12"></div>
+    <div class="mono-label" style="margin:0 0 6px">Affected people</div>
+    <div style="display:flex;flex-wrap:wrap;gap:6px">
+      {% for p in diff.affected %}<span class="role-chip">{{ p }}</span>{% endfor %}
+    </div>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>

--- a/web/templates/partials/publish_state.html
+++ b/web/templates/partials/publish_state.html
@@ -1,0 +1,17 @@
+{# Publish control / state for a solution. #publish-state. #}
+<div id="publish-state">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% elif published %}
+  <div class="form-notice" role="status">
+    Published — volunteers now see these assignments on their schedule.
+  </div>
+  {% else %}
+  <button class="btn btn-go" type="button"
+          hx-post="/a/solution/{{ solution_id }}/publish"
+          hx-target="#publish-state" hx-swap="outerHTML"
+          hx-confirm="Publish this solution? Any previously published solution in your org is replaced.">
+    Publish this solution
+  </button>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
Solution Review publish control (`#publish-state`) → `POST /a/solution/{id}/publish` (`publish_solution`, unpublishes prior) + "Published" notice/badge. New `/a/compare` page: two org-scoped pickers → `POST /a/compare` (`compare_solutions`) → diff KPI grid (added/removed/unchanged/moves + affected). Org-scoped (404 cross-org). **Final Sprint 11 feature — all 20 done.**

## Test plan
- [x] 8 web tests: publish marks+unpublishes prior, publish 404 other-org, review shows control, compare needs-two, compare runs diff, cross-org rejected, admin-gated, auth-gated
- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 122 pass
- [x] **E2E on live server**: solve x2 → publish S1 (badge+notice) → compare S1 vs S2 (diff rendered); screenshotted brand-correct (dark mode)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)