### PR TITLE
Web event-create form sets role requirements (fixes #141)

### DIFF
--- a/tests/web/test_event_crud.py
+++ b/tests/web/test_event_crud.py
@@ -49,6 +49,73 @@ def test_create_event(client, db):
     assert ev.end_time == datetime(2099, 6, 7, 11, 30)
 
 
+def test_events_create_form_has_roles_field(client, db):
+    token = _admin(client, db, org="ec_roles_form", email="ecrf@web.test")
+    resp = client.get("/a/events", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert "Roles needed" in resp.text
+    assert 'name="role_name"' in resp.text
+    assert 'name="role_count"' in resp.text
+
+
+def test_create_event_with_roles(client, db):
+    token = _admin(client, db, org="ec_roles", email="ecroles@web.test")
+    resp = client.post(
+        "/a/events/create",
+        data={
+            "type": "Sunday Service",
+            "event_date": "2099-06-07",
+            "start_time": "10:00",
+            "end_time": "11:30",
+            "role_name": ["volunteer", "greeter"],
+            "role_count": ["2", "1"],
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    ev = db.query(Event).filter(Event.org_id == "ec_roles", Event.type == "Sunday Service").first()
+    assert ev is not None
+    assert ev.extra_data.get("role_counts") == {"volunteer": 2, "greeter": 1}
+
+
+def test_create_event_skips_blank_and_invalid_roles(client, db):
+    token = _admin(client, db, org="ec_roles2", email="ecroles2@web.test")
+    resp = client.post(
+        "/a/events/create",
+        data={
+            "type": "Partial Roles",
+            "event_date": "2099-06-08",
+            "start_time": "10:00",
+            "end_time": "11:00",
+            "role_name": ["volunteer", "", "  ", "usher"],
+            "role_count": ["3", "5", "2", "0"],
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    ev = db.query(Event).filter(Event.org_id == "ec_roles2", Event.type == "Partial Roles").first()
+    assert ev is not None
+    assert ev.extra_data.get("role_counts") == {"volunteer": 3}
+
+
+def test_create_event_without_roles_has_no_role_counts(client, db):
+    token = _admin(client, db, org="ec_roles3", email="ecroles3@web.test")
+    resp = client.post(
+        "/a/events/create",
+        data={
+            "type": "No Roles Event",
+            "event_date": "2099-06-09",
+            "start_time": "10:00",
+            "end_time": "11:00",
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    ev = db.query(Event).filter(Event.org_id == "ec_roles3", Event.type == "No Roles Event").first()
+    assert ev is not None
+    assert "role_counts" not in (ev.extra_data or {})
+
+
 def test_create_event_end_before_start_rejected(client, db):
     token = _admin(client, db, org="ec_org3", email="ecadmin3@web.test")
     resp = client.post(

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -356,11 +356,16 @@ def event_create(
     event_date: str = Form(...),
     start_time: str = Form(...),
     end_time: str = Form(...),
+    role_name: list[str] = Form(default=[]),
+    role_count: list[str] = Form(default=[]),
     person: Person = Depends(get_session_admin),
     db: Session = Depends(get_db),
 ):
     """Create an event in the admin's org. Combines the date + two time
-    inputs into start/end datetimes; generates a unique slug id."""
+    inputs into start/end datetimes; generates a unique slug id. Parallel
+    role_name/role_count rows become extra_data.role_counts so the solver
+    has roles to assign — without this a web-created event gets 0
+    assignments (issue #141)."""
     import uuid
     from datetime import datetime
 
@@ -377,6 +382,20 @@ def event_create(
     if end_dt <= start_dt:
         return _err("End time must be after start time.")
 
+    role_counts: dict[str, int] = {}
+    for idx, raw_name in enumerate(role_name):
+        name = raw_name.strip()
+        if not name:
+            continue
+        raw_count = role_count[idx] if idx < len(role_count) else "1"
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+        if count < 1:
+            continue
+        role_counts[name] = role_counts.get(name, 0) + count
+
     event_id = f"{_slugify(type)}-{uuid.uuid4().hex[:8]}"
     try:
         payload = EventCreate(
@@ -385,6 +404,7 @@ def event_create(
             type=type,
             start_time=start_dt,
             end_time=end_dt,
+            extra_data={"role_counts": role_counts} if role_counts else None,
         )
     except ValueError:
         return _err("Invalid event details.")

--- a/web/templates/partials/events_list.html
+++ b/web/templates/partials/events_list.html
@@ -30,6 +30,24 @@
       <label class="field-label" for="ev_end">End</label>
       <input id="ev_end" name="end_time" type="time" required>
     </div>
+    <div class="field" x-data="{ roles: [{ name: '', count: 1 }] }">
+      <label class="field-label">Roles needed</label>
+      <div class="row-sub" style="margin-bottom:8px">
+        Volunteers the solver assigns per role. Leave blank for none.
+      </div>
+      <template x-for="(r, i) in roles" :key="i">
+        <div class="btn-row cols-2" style="margin-bottom:8px">
+          <input type="text" name="role_name" x-model="r.name"
+                 placeholder="volunteer">
+          <input type="number" name="role_count" x-model="r.count"
+                 min="1" step="1" placeholder="1">
+        </div>
+      </template>
+      <button class="btn btn-secondary" type="button"
+              @click="roles.push({ name: '', count: 1 })">
+        Add another role
+      </button>
+    </div>
     <div class="spacer-12"></div>
     <div class="btn-row cols-2">
       <button class="btn btn-secondary" type="button" @click="creating = false">Cancel</button>


### PR DESCRIPTION
## Summary

Closes #141. The Sprint 11.16 web event-create form (`POST /a/events/create`) only collected type/date/start/end, so web-created events had **no `extra_data.role_counts`** and the solver assigned **0 volunteers** — a web-only admin couldn't get anyone scheduled without DB access.

This adds a repeatable **"Roles needed"** field set (role name + count rows, "Add another role") to the create form. The handler parses parallel `role_name`/`role_count` form arrays into `extra_data.role_counts`:

- trims and skips blank role names
- skips non-integer or `< 1` counts
- sums duplicate role names
- no-role submissions leave `extra_data` empty → existing behavior unchanged

## Changes

- `web/routers/partials.py` — `event_create` accepts `role_name`/`role_count` form arrays, builds `role_counts`, passes via `EventCreate.extra_data`
- `web/templates/partials/events_list.html` — Alpine-driven repeatable role rows
- `tests/web/test_event_crud.py` — +4 tests (form field present, roles persisted, blank/invalid skipped, no-roles unchanged)

## Test plan

- [x] `tests/web/` — 120 passed
- [x] `tests/contract/` — 1 passed (no OpenAPI drift; web HTMX routes are not in the `api.main` snapshot, so no snapshot refresh needed)
- [x] full `tests/unit/` deterministic order — 325 passed
- [x] `black --check api tests` / `ruff check api tests` clean

## Note on unit-tier flakiness

`make test-unit-fast` shows order-dependent failures in `tests/unit/test_solver_stability.py` (`UNIQUE constraint failed: people.id`). This is a **pre-existing test-isolation bug**, unrelated to this web change: with this branch's changes stashed (clean main), `make test-unit-fast` fails *worse* (8 failed). Filed separately as a tracking issue. This PR does not touch the unit tier.

https://claude.ai/code/session_013kaGUF1osuwhjg1bEPL7HJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013kaGUF1osuwhjg1bEPL7HJ)_