### PR TITLE
P1.1 — web org settings page

### DIFF
--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -1,0 +1,102 @@
+"""Marathon P1.1 — org/account settings page."""
+
+from __future__ import annotations
+
+from api.models import Organization
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="s_org", email="sadmin@web.test"):
+    seed_person(db, person_id="s_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_settings_page_renders_for_admin(client, db):
+    token = _admin(client, db, org="s_o1", email="s1@web.test")
+    resp = client.get("/a/settings", cookies={SESSION_COOKIE: token})
+    assert resp.status_code == 200
+    assert 'id="settings-form"' in resp.text
+    assert "Web Org" in resp.text  # current org name pre-filled
+    assert "Save settings" in resp.text
+
+
+def test_settings_requires_admin(client, db):
+    seed_person(db, person_id="s_vol", email="svol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "svol@web.test", "password": "WebPass123!"})
+    token = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/settings", cookies={SESSION_COOKIE: token}).status_code == 303
+    assert (
+        client.post(
+            "/a/settings",
+            data={"name": "X"},
+            cookies={SESSION_COOKIE: token},
+        ).status_code
+        == 303
+    )
+
+
+def test_settings_requires_auth(client):
+    assert client.get("/a/settings").status_code == 303
+    assert client.post("/a/settings", data={"name": "X"}).status_code == 303
+
+
+def test_settings_save_updates_org(client, db):
+    token = _admin(client, db, org="s_o2", email="s2@web.test")
+    resp = client.post(
+        "/a/settings",
+        data={
+            "name": "Grace Community Church",
+            "region": "US-CA",
+            "timezone": "America/Los_Angeles",
+        },
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 200
+    assert "Settings saved" in resp.text
+    assert "Grace Community Church" in resp.text
+
+    org = db.query(Organization).filter(Organization.id == "s_o2").first()
+    db.refresh(org)
+    assert org.name == "Grace Community Church"
+    assert org.region == "US-CA"
+    assert (org.config or {}).get("timezone") == "America/Los_Angeles"
+
+
+def test_settings_name_required(client, db):
+    token = _admin(client, db, org="s_o3", email="s3@web.test")
+    resp = client.post(
+        "/a/settings",
+        data={"name": "   ", "region": "", "timezone": ""},
+        cookies={SESSION_COOKIE: token},
+    )
+    assert resp.status_code == 400
+    assert "required" in resp.text.lower()
+
+
+def test_settings_preserves_other_config_and_clears_timezone(client, db):
+    token = _admin(client, db, org="s_o4", email="s4@web.test")
+    org = db.query(Organization).filter(Organization.id == "s_o4").first()
+    org.config = {"foo": "bar"}
+    db.commit()
+
+    # Set a timezone — keeps foo, adds timezone.
+    client.post(
+        "/a/settings",
+        data={"name": "Web Org", "region": "", "timezone": "UTC"},
+        cookies={SESSION_COOKIE: token},
+    )
+    db.refresh(org)
+    assert org.config.get("foo") == "bar"
+    assert org.config.get("timezone") == "UTC"
+
+    # Clear timezone — foo stays, timezone removed.
+    client.post(
+        "/a/settings",
+        data={"name": "Web Org", "region": "", "timezone": ""},
+        cookies={SESSION_COOKIE: token},
+    )
+    db.refresh(org)
+    assert org.config.get("foo") == "bar"
+    assert "timezone" not in org.config

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -65,8 +65,8 @@ def _my_assignment(db: Session, person: Person, aid: int) -> dict | None:
 @router.get("/")
 def root(request: Request):
     # Resolve session lazily so the bare "/" works signed-in or not.
-    from web.deps import _resolve_person
     from api.database import SessionLocal
+    from web.deps import _resolve_person
 
     db = SessionLocal()
     try:
@@ -270,6 +270,40 @@ def admin_dashboard(
             "person": person,
             "active_tab": "dashboard",
             "kpis": _dashboard_kpis(db, person.org_id),
+        },
+    )
+
+
+def _org_settings(db: Session, org_id: str) -> dict:
+    """Current org settings for the form (timezone lives in config)."""
+    from api.routers.organizations import get_organization
+
+    org = get_organization(org_id, db)
+    config = org.config or {}
+    return {
+        "name": org.name,
+        "region": org.region,
+        "timezone": config.get("timezone", ""),
+    }
+
+
+@router.get("/a/settings", response_class=HTMLResponse)
+def admin_settings(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/settings.html",
+        {
+            "person": person,
+            "active_tab": None,
+            "org": _org_settings(db, person.org_id),
+            "error": None,
+            "saved": False,
         },
     )
 

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -28,21 +28,23 @@ from api.routers.availability import (
     delete_timeoff,
     set_rrule,
 )
+from api.routers.calendar import reset_calendar_token
+from api.routers.events import create_event, delete_event
+from api.routers.invitations import create_invitation
+from api.routers.organizations import get_organization, update_organization
+from api.routers.solutions import compare_solutions, publish_solution
+from api.routers.solver import solve_schedule
 from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
 from api.schemas.availability import (
     AvailabilityExceptionCreate,
     AvailabilityRruleUpdate,
     TimeOffCreate,
 )
-from web.deps import get_session_admin, get_session_user
-from api.routers.calendar import reset_calendar_token
-from api.routers.events import create_event, delete_event
-from api.routers.invitations import create_invitation
-from api.routers.solutions import compare_solutions, publish_solution
-from api.routers.solver import solve_schedule
 from api.schemas.event import EventCreate
 from api.schemas.invitation import InvitationCreate
+from api.schemas.organization import OrganizationUpdate
 from api.schemas.solver import SolveRequest
+from web.deps import get_session_admin, get_session_user
 from web.routers.pages import (
     RRULE_PRESETS,
     _events,
@@ -51,7 +53,6 @@ from web.routers.pages import (
     _my_exceptions,
     _my_rrule,
     _my_timeoff,
-    _org_solutions,
     _solution_owned,
 )
 
@@ -334,6 +335,71 @@ def people_invite(
     except HTTPException as exc:
         return _result(False, str(exc.detail), exc.status_code or 400)
     return _result(True, f"Invitation sent to {email}.")
+
+
+# ── Admin: organization settings ─────────────────────────────────────
+
+
+@router.post("/a/settings", response_class=HTMLResponse)
+def settings_save(
+    request: Request,
+    name: str = Form(...),
+    region: str = Form(""),
+    timezone: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Update the admin's own organization. Timezone is merged into the
+    org config dict (other config keys preserved). Reuses the API's
+    update_organization so the same validation applies."""
+    from web.app import templates
+
+    def _render(*, error=None, saved=False, org=None):
+        if org is None:
+            org = {
+                "name": name,
+                "region": region or None,
+                "timezone": timezone or "",
+            }
+        return templates.TemplateResponse(
+            request,
+            "partials/settings_form.html",
+            {"org": org, "error": error, "saved": saved},
+            status_code=400 if error else 200,
+        )
+
+    if not name.strip():
+        return _render(error="Organization name is required.")
+
+    current = get_organization(person.org_id, db)
+    config = dict(current.config or {})
+    tz = timezone.strip()
+    if tz:
+        config["timezone"] = tz
+    else:
+        config.pop("timezone", None)
+
+    try:
+        payload = OrganizationUpdate(
+            name=name.strip(),
+            region=region.strip() or None,
+            config=config,
+        )
+    except ValueError:
+        return _render(error="Invalid settings.")
+    try:
+        update_organization(person.org_id, payload, db)
+    except HTTPException as exc:
+        return _render(error=str(exc.detail), org=None)
+
+    return _render(
+        saved=True,
+        org={
+            "name": name.strip(),
+            "region": region.strip() or None,
+            "timezone": tz,
+        },
+    )
 
 
 # ── Admin: event create / delete ─────────────────────────────────────

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -2,7 +2,7 @@
 {% block title %}Dashboard · SignUpFlow{% endblock %}
 {% block body %}
 <div class="nav">
-  <span class="nav-back"></span>
+  <a class="nav-back" href="/a/settings">⚙ Settings</a>
   <form method="post" action="/auth/logout" style="margin:0">
     <button class="nav-action" type="submit">Sign out</button>
   </form>

--- a/web/templates/admin/settings.html
+++ b/web/templates/admin/settings.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Settings · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/dashboard">‹ Dashboard</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Settings</div>
+<div class="scroll">
+  <div class="mono-label" style="margin-top:8px">Organization</div>
+  {% include "partials/settings_form.html" %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/partials/settings_form.html
+++ b/web/templates/partials/settings_form.html
@@ -1,0 +1,37 @@
+{# Organization settings form. #settings-form so HTMX swaps it after save. #}
+<div id="settings-form">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% elif saved %}
+  <div class="form-notice" role="status">Settings saved.</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <form hx-post="/a/settings"
+        hx-target="#settings-form" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="org_name">Organization name</label>
+      <input id="org_name" name="name" type="text" required
+             value="{{ org.name }}" placeholder="Grace Community Church">
+    </div>
+    <div class="field">
+      <label class="field-label" for="org_region">Region</label>
+      <input id="org_region" name="region" type="text"
+             value="{{ org.region or '' }}" placeholder="US-CA">
+      <div class="row-sub" style="margin-top:6px">
+        Region code used for holidays / locale (e.g. US-CA, CA-ON). Optional.
+      </div>
+    </div>
+    <div class="field">
+      <label class="field-label" for="org_timezone">Timezone</label>
+      <input id="org_timezone" name="timezone" type="text"
+             value="{{ org.timezone or '' }}" placeholder="America/Los_Angeles">
+      <div class="row-sub" style="margin-top:6px">
+        IANA name, used as the default for events. Optional.
+      </div>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Save settings</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary

Admin-gated **`/a/settings`** page: view & edit organization **name, region, timezone**. Timezone is stored in `org.config["timezone"]` (other config keys preserved). Reuses `api.routers.organizations.get_organization` / `update_organization` — same validation — scoped to the admin's own org. Linked from the dashboard top nav (`⚙ Settings`).

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 132 passed (incl. new `tests/web/test_settings.py`, 6 cases: render, auth/admin gating, save+persist, name-required, config-key preservation)
- [x] Live Playwright e2e: signup → dashboard → Settings → edit → save → reload persists; no JS errors; screenshot visually verified

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)