### PR TITLE
P1.3 — web teams admin: CRUD + membership

### DIFF
--- a/tests/web/test_teams.py
+++ b/tests/web/test_teams.py
@@ -1,0 +1,126 @@
+"""Marathon P1.3 — teams admin CRUD + membership."""
+
+from __future__ import annotations
+
+from api.models import Team, TeamMember
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org="t_org", email="tadmin@web.test"):
+    seed_person(db, person_id="t_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _team_id(db, org):
+    return db.query(Team).filter(Team.org_id == org).first().id
+
+
+def test_teams_page_admin_only(client, db):
+    seed_person(db, person_id="t_vol", email="tvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "tvol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/teams", cookies={SESSION_COOKIE: vtok}).status_code == 303
+    assert client.get("/a/teams").status_code == 303
+
+    atok = _admin(client, db, org="t_o1", email="t1@web.test")
+    resp = client.get("/a/teams", cookies={SESSION_COOKIE: atok})
+    assert resp.status_code == 200
+    assert 'id="teams-list"' in resp.text
+    assert "New team" in resp.text
+
+
+def test_team_create_update_delete(client, db):
+    tok = _admin(client, db, org="t_o2", email="t2@web.test")
+    # Create
+    r = client.post(
+        "/a/teams/create",
+        data={"name": "Worship", "description": "Sunday band"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    assert "Worship" in r.text
+    tid = _team_id(db, "t_o2")
+
+    # Name required
+    bad = client.post("/a/teams/create", data={"name": "  "}, cookies={SESSION_COOKIE: tok})
+    assert bad.status_code == 400
+    assert "required" in bad.text.lower()
+
+    # Update
+    r2 = client.post(
+        f"/a/teams/{tid}/update",
+        data={"name": "Worship Team", "description": "Updated"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r2.status_code == 200
+    assert "Worship Team" in r2.text
+    t = db.query(Team).filter(Team.id == tid).first()
+    db.refresh(t)
+    assert t.name == "Worship Team"
+    assert t.description == "Updated"
+
+    # Delete
+    r3 = client.post(f"/a/teams/{tid}/delete", cookies={SESSION_COOKIE: tok})
+    assert r3.status_code == 200
+    assert db.query(Team).filter(Team.id == tid).first() is None
+
+
+def test_team_membership_add_remove(client, db):
+    tok = _admin(client, db, org="t_o3", email="t3@web.test")
+    seed_person(db, person_id="t_p1", org_id="t_o3", email="p1@t.test", roles=["volunteer"])
+    seed_person(db, person_id="t_p2", org_id="t_o3", email="p2@t.test", roles=["volunteer"])
+    client.post("/a/teams/create", data={"name": "Ushers"}, cookies={SESSION_COOKIE: tok})
+    tid = _team_id(db, "t_o3")
+
+    # Add a member
+    r = client.post(
+        f"/a/teams/{tid}/members/add",
+        data={"person_id": "t_p1"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    assert (
+        db.query(TeamMember)
+        .filter(TeamMember.team_id == tid, TeamMember.person_id == "t_p1")
+        .first()
+        is not None
+    )
+    assert "t_p1" in r.text or "P1 T.test" in r.text or "p1@t.test" not in r.text
+
+    # Remove the member
+    r2 = client.post(
+        f"/a/teams/{tid}/members/remove",
+        data={"person_id": "t_p1"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r2.status_code == 200
+    assert (
+        db.query(TeamMember)
+        .filter(TeamMember.team_id == tid, TeamMember.person_id == "t_p1")
+        .first()
+        is None
+    )
+
+
+def test_team_cross_org_isolated(client, db):
+    tok = _admin(client, db, org="t_o4", email="t4@web.test")
+    # A team in a different org.
+    seed_person(db, person_id="other_admin", org_id="t_other", email="o@t.test", roles=["admin"])
+    other = Team(id="other_team", org_id="t_other", name="Secret")
+    db.add(other)
+    db.commit()
+
+    page = client.get("/a/teams", cookies={SESSION_COOKIE: tok})
+    assert "Secret" not in page.text  # not in this admin's org
+
+    # Mutating another org's team is rejected (verify_org_member).
+    resp = client.post(
+        "/a/teams/other_team/update",
+        data={"name": "Hacked"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert resp.status_code == 400
+    db.refresh(other)
+    assert other.name == "Secret"

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Assignment, Event, Person
+from api.models import Assignment, Event, Person, Team, TeamMember
 from web.deps import get_session_admin, get_session_user
 
 router = APIRouter(tags=["web-pages"])
@@ -344,6 +344,55 @@ def _people(db: Session, org_id: str, q: str | None) -> list[dict]:
         }
         for p in rows
     ]
+
+
+def _teams(db: Session, org_id: str) -> list[dict]:
+    """Teams in the org with members + the people who could still be
+    added (org-scoped direct queries — the API has no team-members
+    listing endpoint)."""
+    teams = db.query(Team).filter(Team.org_id == org_id).order_by(Team.name.asc()).all()
+    people = db.query(Person).filter(Person.org_id == org_id).order_by(Person.name.asc()).all()
+    by_id = {p.id: p for p in people}
+    out = []
+    for t in teams:
+        member_ids = [
+            m.person_id for m in db.query(TeamMember).filter(TeamMember.team_id == t.id).all()
+        ]
+        member_set = set(member_ids)
+        out.append(
+            {
+                "id": t.id,
+                "name": t.name,
+                "description": t.description,
+                "members": [
+                    {"id": pid, "name": by_id[pid].name} for pid in member_ids if pid in by_id
+                ],
+                "candidates": [
+                    {"id": p.id, "name": p.name} for p in people if p.id not in member_set
+                ],
+            }
+        )
+    return out
+
+
+@router.get("/a/teams", response_class=HTMLResponse)
+def admin_teams(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/teams.html",
+        {
+            "person": person,
+            "active_tab": "people",
+            "teams": _teams(db, person.org_id),
+            "error": None,
+        },
+    )
 
 
 @router.get("/a/people", response_class=HTMLResponse)

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -36,6 +36,13 @@ from api.routers.organizations import get_organization, update_organization
 from api.routers.people import update_current_person
 from api.routers.solutions import compare_solutions, publish_solution
 from api.routers.solver import solve_schedule
+from api.routers.teams import (
+    add_team_members,
+    create_team,
+    delete_team,
+    remove_team_members,
+    update_team,
+)
 from api.schemas.assignment import AssignmentDeclineRequest, AssignmentSwapRequest
 from api.schemas.availability import (
     AvailabilityExceptionCreate,
@@ -47,6 +54,7 @@ from api.schemas.invitation import InvitationCreate
 from api.schemas.organization import OrganizationUpdate
 from api.schemas.person import PersonUpdate
 from api.schemas.solver import SolveRequest
+from api.schemas.team import TeamCreate, TeamMemberAdd, TeamMemberRemove, TeamUpdate
 from web.deps import get_session_admin, get_session_user
 from web.routers.pages import (
     RRULE_PRESETS,
@@ -57,6 +65,7 @@ from web.routers.pages import (
     _my_rrule,
     _my_timeoff,
     _solution_owned,
+    _teams,
 )
 
 router = APIRouter(tags=["web-partials"])
@@ -498,6 +507,115 @@ def password_change(
     )
     set_session_cookie(resp, person)
     return resp
+
+
+# ── Admin: teams ─────────────────────────────────────────────────────
+
+
+def _teams_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/teams_list.html",
+        {"teams": _teams(db, person.org_id), "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+@router.post("/a/teams/create", response_class=HTMLResponse)
+def team_create(
+    request: Request,
+    name: str = Form(...),
+    description: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    import uuid
+
+    from web.auth import _slugify
+
+    if not name.strip():
+        return _teams_list(request, person, db, error="Team name is required.")
+    payload = TeamCreate(
+        id=f"{_slugify(name)}-{uuid.uuid4().hex[:8]}",
+        org_id=person.org_id,
+        name=name.strip(),
+        description=description.strip() or None,
+        member_ids=[],
+    )
+    try:
+        create_team(payload, person, db)
+    except HTTPException as exc:
+        return _teams_list(request, person, db, error=str(exc.detail))
+    return _teams_list(request, person, db)
+
+
+@router.post("/a/teams/{team_id}/update", response_class=HTMLResponse)
+def team_update(
+    request: Request,
+    team_id: str,
+    name: str = Form(...),
+    description: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    if not name.strip():
+        return _teams_list(request, person, db, error="Team name is required.")
+    try:
+        update_team(
+            team_id,
+            TeamUpdate(name=name.strip(), description=description.strip() or None),
+            person,
+            db,
+        )
+    except HTTPException as exc:
+        return _teams_list(request, person, db, error=str(exc.detail))
+    return _teams_list(request, person, db)
+
+
+@router.post("/a/teams/{team_id}/delete", response_class=HTMLResponse)
+def team_delete(
+    request: Request,
+    team_id: str,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        delete_team(team_id, person, db)
+    except HTTPException:
+        pass  # already gone — return a fresh, correct list
+    return _teams_list(request, person, db)
+
+
+@router.post("/a/teams/{team_id}/members/add", response_class=HTMLResponse)
+def team_member_add(
+    request: Request,
+    team_id: str,
+    person_id: str = Form(...),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        add_team_members(team_id, TeamMemberAdd(person_ids=[person_id]), person, db)
+    except HTTPException as exc:
+        return _teams_list(request, person, db, error=str(exc.detail))
+    return _teams_list(request, person, db)
+
+
+@router.post("/a/teams/{team_id}/members/remove", response_class=HTMLResponse)
+def team_member_remove(
+    request: Request,
+    team_id: str,
+    person_id: str = Form(...),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        remove_team_members(team_id, TeamMemberRemove(person_ids=[person_id]), person, db)
+    except HTTPException as exc:
+        return _teams_list(request, person, db, error=str(exc.detail))
+    return _teams_list(request, person, db)
 
 
 # ── Admin: event create / delete ─────────────────────────────────────

--- a/web/templates/admin/people.html
+++ b/web/templates/admin/people.html
@@ -2,7 +2,7 @@
 {% block title %}People · SignUpFlow{% endblock %}
 {% block body %}
 <div class="nav">
-  <span class="nav-back"></span>
+  <a class="nav-back" href="/a/teams">Teams ›</a>
   <form method="post" action="/auth/logout" style="margin:0">
     <button class="nav-action" type="submit">Sign out</button>
   </form>

--- a/web/templates/admin/teams.html
+++ b/web/templates/admin/teams.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Teams · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/people">‹ People</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Teams</div>
+<div class="scroll">
+  {% include "partials/teams_list.html" %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/partials/teams_list.html
+++ b/web/templates/partials/teams_list.html
@@ -1,0 +1,106 @@
+{# Teams list + CRUD + membership. #teams-list so HTMX swaps it after
+   any mutation. #}
+<div id="teams-list" x-data="{ creating: false, editId: null }">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <button class="btn btn-primary" type="button"
+          x-show="!creating" @click="creating = true; editId = null">
+    New team
+  </button>
+  <form x-show="creating" x-cloak
+        hx-post="/a/teams/create" hx-target="#teams-list" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="tm_name">Name</label>
+      <input id="tm_name" name="name" type="text" required
+             placeholder="Worship Team">
+    </div>
+    <div class="field">
+      <label class="field-label" for="tm_desc">Description</label>
+      <input id="tm_desc" name="description" type="text"
+             placeholder="Optional">
+    </div>
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-secondary" type="button" @click="creating = false">Cancel</button>
+      <button class="btn btn-primary" type="submit">Create team</button>
+    </div>
+  </form>
+
+  <div class="mono-label" style="margin-top:18px">Teams</div>
+  {% if not teams %}
+  <div class="empty">No teams yet.</div>
+  {% else %}
+  {% for t in teams %}
+  <div class="card" style="margin-bottom:12px">
+    <div x-show="editId !== '{{ t.id }}'">
+      <div style="display:flex;align-items:flex-start;gap:8px">
+        <div class="row-main" style="flex:1">
+          <div class="row-title">{{ t.name }}</div>
+          {% if t.description %}<div class="row-sub">{{ t.description }}</div>{% endif %}
+        </div>
+        <button class="btn btn-secondary" style="width:auto;padding:6px 12px"
+                type="button" @click="editId = '{{ t.id }}'">Edit</button>
+        <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+                hx-post="/a/teams/{{ t.id }}/delete"
+                hx-target="#teams-list" hx-swap="outerHTML"
+                hx-confirm="Delete team '{{ t.name }}'?">Delete</button>
+      </div>
+
+      <div class="spacer-12"></div>
+      <div class="mono-label" style="margin:0 0 6px">Members ({{ t.members|length }})</div>
+      {% if t.members %}
+      <div style="display:flex;flex-wrap:wrap;gap:6px">
+        {% for m in t.members %}
+        <form hx-post="/a/teams/{{ t.id }}/members/remove"
+              hx-target="#teams-list" hx-swap="outerHTML"
+              style="display:inline;margin:0">
+          <input type="hidden" name="person_id" value="{{ m.id }}">
+          <button class="role-chip" type="submit"
+                  title="Remove {{ m.name }}">{{ m.name }} ✕</button>
+        </form>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="row-sub">No members yet.</div>
+      {% endif %}
+
+      {% if t.candidates %}
+      <div class="spacer-12"></div>
+      <form hx-post="/a/teams/{{ t.id }}/members/add"
+            hx-target="#teams-list" hx-swap="outerHTML"
+            class="btn-row cols-2">
+        <select name="person_id" required
+                style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+          {% for c in t.candidates %}
+          <option value="{{ c.id }}">{{ c.name }}</option>
+          {% endfor %}
+        </select>
+        <button class="btn btn-secondary" type="submit">Add member</button>
+      </form>
+      {% endif %}
+    </div>
+
+    <form x-show="editId === '{{ t.id }}'" x-cloak
+          hx-post="/a/teams/{{ t.id }}/update"
+          hx-target="#teams-list" hx-swap="outerHTML">
+      <div class="field">
+        <label class="field-label">Name</label>
+        <input name="name" type="text" required value="{{ t.name }}">
+      </div>
+      <div class="field">
+        <label class="field-label">Description</label>
+        <input name="description" type="text" value="{{ t.description or '' }}">
+      </div>
+      <div class="spacer-12"></div>
+      <div class="btn-row cols-2">
+        <button class="btn btn-secondary" type="button" @click="editId = null">Cancel</button>
+        <button class="btn btn-primary" type="submit">Save</button>
+      </div>
+    </form>
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Admin **`/a/teams`** page: create / edit / delete teams and add / remove members, over `api.routers.teams` (`create_team`, `update_team`, `delete_team`, `add_team_members`, `remove_team_members`). Team + member lists use org-scoped direct queries (the API has no team-members listing endpoint). Linked from the People page; cross-org mutation rejected by the reused `verify_org_member`.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_teams.py` — 4 cases (admin/auth gating, create+update+delete, member add/remove, cross-org isolation)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 144 passed
- [x] Live Playwright e2e: People→Teams nav, create → add member → edit → remove member → delete; no JS errors; screenshots visually verified

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)