### PR TITLE
P1.4 — web constraints DSL editor

### DIFF
--- a/tests/web/test_constraints.py
+++ b/tests/web/test_constraints.py
@@ -1,0 +1,137 @@
+"""Marathon P1.4 — constraints DSL editor."""
+
+from __future__ import annotations
+
+from api.models import Constraint
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_admin", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _cid(db, org):
+    return db.query(Constraint).filter(Constraint.org_id == org).first().id
+
+
+def test_constraints_page_admin_only(client, db):
+    seed_person(db, person_id="c_vol", email="cvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "cvol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/constraints", cookies={SESSION_COOKIE: vtok}).status_code == 303
+    assert client.get("/a/constraints").status_code == 303
+
+    atok = _admin(client, db, org="c_o1", email="c1@web.test")
+    resp = client.get("/a/constraints", cookies={SESSION_COOKIE: atok})
+    assert resp.status_code == 200
+    assert 'id="constraints-list"' in resp.text
+    assert "New constraint" in resp.text
+
+
+def test_constraint_create_with_params(client, db):
+    tok = _admin(client, db, org="c_o2", email="c2@web.test")
+    r = client.post(
+        "/a/constraints/create",
+        data={
+            "key": "min_gap",
+            "type": "soft",
+            "weight": "10",
+            "predicate": "min_gap_hours_satisfied(person_id, 12)",
+            "params": '{"min_hours": 12}',
+        },
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    assert "min_gap" in r.text
+    c = db.query(Constraint).filter(Constraint.org_id == "c_o2").first()
+    assert c.type == "soft"
+    assert c.weight == 10
+    assert c.params == {"min_hours": 12}
+
+
+def test_constraint_create_validation(client, db):
+    tok = _admin(client, db, org="c_o3", email="c3@web.test")
+    base = {"key": "k", "type": "hard", "weight": "", "predicate": "p", "params": ""}
+
+    assert (
+        client.post(
+            "/a/constraints/create",
+            data={**base, "key": "  "},
+            cookies={SESSION_COOKIE: tok},
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            "/a/constraints/create",
+            data={**base, "predicate": ""},
+            cookies={SESSION_COOKIE: tok},
+        ).status_code
+        == 400
+    )
+    bad_json = client.post(
+        "/a/constraints/create",
+        data={**base, "params": "{not json}"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert bad_json.status_code == 400
+    assert "json" in bad_json.text.lower()
+    bad_w = client.post(
+        "/a/constraints/create",
+        data={**base, "weight": "heavy"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert bad_w.status_code == 400
+
+
+def test_constraint_update_and_delete(client, db):
+    tok = _admin(client, db, org="c_o4", email="c4@web.test")
+    client.post(
+        "/a/constraints/create",
+        data={"key": "k1", "type": "hard", "weight": "", "predicate": "p", "params": ""},
+        cookies={SESSION_COOKIE: tok},
+    )
+    cid = _cid(db, "c_o4")
+
+    r = client.post(
+        f"/a/constraints/{cid}/update",
+        data={
+            "type": "soft",
+            "weight": "5",
+            "predicate": "has_role(usher)",
+            "params": "",
+        },
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    c = db.query(Constraint).filter(Constraint.id == cid).first()
+    db.refresh(c)
+    assert c.type == "soft" and c.weight == 5
+    assert c.predicate == "has_role(usher)"
+
+    d = client.post(f"/a/constraints/{cid}/delete", cookies={SESSION_COOKIE: tok})
+    assert d.status_code == 200
+    assert db.query(Constraint).filter(Constraint.id == cid).first() is None
+
+
+def test_constraint_cross_org_isolated(client, db):
+    tok = _admin(client, db, org="c_o5", email="c5@web.test")
+    seed_person(db, person_id="oadm", org_id="c_other", email="o@c.test", roles=["admin"])
+    other = Constraint(org_id="c_other", key="secret", type="hard", predicate="p", params=None)
+    db.add(other)
+    db.commit()
+
+    page = client.get("/a/constraints", cookies={SESSION_COOKIE: tok})
+    assert "secret" not in page.text
+
+    resp = client.post(
+        f"/a/constraints/{other.id}/update",
+        data={"type": "hard", "weight": "", "predicate": "hacked", "params": ""},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert resp.status_code == 400
+    db.refresh(other)
+    assert other.predicate == "p"

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Assignment, Event, Person, Team, TeamMember
+from api.models import Assignment, Constraint, Event, Person, Team, TeamMember
 from web.deps import get_session_admin, get_session_user
 
 router = APIRouter(tags=["web-pages"])
@@ -373,6 +373,49 @@ def _teams(db: Session, org_id: str) -> list[dict]:
             }
         )
     return out
+
+
+def _constraints(db: Session, org_id: str) -> list[dict]:
+    """Scheduling constraints for the org (direct org-scoped query)."""
+    import json
+
+    rows = (
+        db.query(Constraint)
+        .filter(Constraint.org_id == org_id)
+        .order_by(Constraint.key.asc())
+        .all()
+    )
+    return [
+        {
+            "id": c.id,
+            "key": c.key,
+            "type": (c.type or "hard").lower(),
+            "weight": c.weight,
+            "predicate": c.predicate,
+            "params_json": json.dumps(c.params) if c.params else "",
+        }
+        for c in rows
+    ]
+
+
+@router.get("/a/constraints", response_class=HTMLResponse)
+def admin_constraints(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/constraints.html",
+        {
+            "person": person,
+            "active_tab": "solver",
+            "constraints": _constraints(db, person.org_id),
+            "error": None,
+        },
+    )
 
 
 @router.get("/a/teams", response_class=HTMLResponse)

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -30,6 +30,11 @@ from api.routers.availability import (
     set_rrule,
 )
 from api.routers.calendar import reset_calendar_token
+from api.routers.constraints import (
+    create_constraint,
+    delete_constraint,
+    update_constraint,
+)
 from api.routers.events import create_event, delete_event
 from api.routers.invitations import create_invitation
 from api.routers.organizations import get_organization, update_organization
@@ -49,6 +54,7 @@ from api.schemas.availability import (
     AvailabilityRruleUpdate,
     TimeOffCreate,
 )
+from api.schemas.constraint import ConstraintCreate, ConstraintUpdate
 from api.schemas.event import EventCreate
 from api.schemas.invitation import InvitationCreate
 from api.schemas.organization import OrganizationUpdate
@@ -58,6 +64,7 @@ from api.schemas.team import TeamCreate, TeamMemberAdd, TeamMemberRemove, TeamUp
 from web.deps import get_session_admin, get_session_user
 from web.routers.pages import (
     RRULE_PRESETS,
+    _constraints,
     _events,
     _my_assignment,
     _my_calendar,
@@ -616,6 +623,127 @@ def team_member_remove(
     except HTTPException as exc:
         return _teams_list(request, person, db, error=str(exc.detail))
     return _teams_list(request, person, db)
+
+
+# ── Admin: constraints ───────────────────────────────────────────────
+
+
+def _constraints_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/constraints_list.html",
+        {"constraints": _constraints(db, person.org_id), "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+def _parse_constraint_form(ctype: str, weight: str, params: str):
+    """Returns (type, weight|None, params|None) or raises ValueError."""
+    import json
+
+    ctype = ctype if ctype in ("hard", "soft") else "hard"
+    w = weight.strip()
+    weight_val = None
+    if w:
+        try:
+            weight_val = int(w)
+        except ValueError as exc:
+            raise ValueError("Weight must be a whole number.") from exc
+    p = params.strip()
+    params_val = None
+    if p:
+        try:
+            parsed = json.loads(p)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Params must be valid JSON.") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("Params must be a JSON object.")
+        params_val = parsed
+    return ctype, weight_val, params_val
+
+
+@router.post("/a/constraints/create", response_class=HTMLResponse)
+def constraint_create(
+    request: Request,
+    key: str = Form(""),
+    type: str = Form("hard"),
+    weight: str = Form(""),
+    predicate: str = Form(""),
+    params: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    if not key.strip():
+        return _constraints_list(request, person, db, error="Key is required.")
+    if not predicate.strip():
+        return _constraints_list(request, person, db, error="Predicate is required.")
+    try:
+        ctype, weight_val, params_val = _parse_constraint_form(type, weight, params)
+    except ValueError as exc:
+        return _constraints_list(request, person, db, error=str(exc))
+    payload = ConstraintCreate(
+        org_id=person.org_id,
+        key=key.strip(),
+        type=ctype,
+        weight=weight_val,
+        predicate=predicate.strip(),
+        params=params_val,
+    )
+    try:
+        create_constraint(payload, person, db)
+    except HTTPException as exc:
+        return _constraints_list(request, person, db, error=str(exc.detail))
+    return _constraints_list(request, person, db)
+
+
+@router.post("/a/constraints/{constraint_id}/update", response_class=HTMLResponse)
+def constraint_update(
+    request: Request,
+    constraint_id: int,
+    type: str = Form("hard"),
+    weight: str = Form(""),
+    predicate: str = Form(""),
+    params: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    if not predicate.strip():
+        return _constraints_list(request, person, db, error="Predicate is required.")
+    try:
+        ctype, weight_val, params_val = _parse_constraint_form(type, weight, params)
+    except ValueError as exc:
+        return _constraints_list(request, person, db, error=str(exc))
+    try:
+        update_constraint(
+            constraint_id,
+            ConstraintUpdate(
+                type=ctype,
+                weight=weight_val,
+                predicate=predicate.strip(),
+                params=params_val,
+            ),
+            person,
+            db,
+        )
+    except HTTPException as exc:
+        return _constraints_list(request, person, db, error=str(exc.detail))
+    return _constraints_list(request, person, db)
+
+
+@router.post("/a/constraints/{constraint_id}/delete", response_class=HTMLResponse)
+def constraint_delete(
+    request: Request,
+    constraint_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        delete_constraint(constraint_id, person, db)
+    except HTTPException:
+        pass  # already gone — return a fresh, correct list
+    return _constraints_list(request, person, db)
 
 
 # ── Admin: event create / delete ─────────────────────────────────────

--- a/web/templates/admin/constraints.html
+++ b/web/templates/admin/constraints.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Constraints · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/solver">‹ Solver</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Constraints</div>
+<div class="scroll">
+  {% include "partials/constraints_list.html" %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/admin/solver.html
+++ b/web/templates/admin/solver.html
@@ -2,7 +2,7 @@
 {% block title %}Run solver · SignUpFlow{% endblock %}
 {% block body %}
 <div class="nav">
-  <span class="nav-back"></span>
+  <a class="nav-back" href="/a/constraints">Constraints ›</a>
   <form method="post" action="/auth/logout" style="margin:0">
     <button class="nav-action" type="submit">Sign out</button>
   </form>

--- a/web/templates/partials/constraints_list.html
+++ b/web/templates/partials/constraints_list.html
@@ -1,0 +1,122 @@
+{# Constraints list + CRUD. #constraints-list so HTMX swaps it after
+   any mutation. #}
+<div id="constraints-list" x-data="{ creating: false, editId: null }">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <button class="btn btn-primary" type="button"
+          x-show="!creating" @click="creating = true; editId = null">
+    New constraint
+  </button>
+  <form x-show="creating" x-cloak
+        hx-post="/a/constraints/create"
+        hx-target="#constraints-list" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="c_key">Key</label>
+      <input id="c_key" name="key" type="text" required
+             placeholder="max_two_per_month">
+    </div>
+    <div class="field">
+      <label class="field-label" for="c_type">Type</label>
+      <select id="c_type" name="type"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        <option value="hard">hard</option>
+        <option value="soft">soft</option>
+      </select>
+    </div>
+    <div class="field">
+      <label class="field-label" for="c_weight">Weight (soft only)</label>
+      <input id="c_weight" name="weight" type="number" step="1"
+             placeholder="e.g. 10">
+    </div>
+    <div class="field">
+      <label class="field-label" for="c_pred">Predicate</label>
+      <input id="c_pred" name="predicate" type="text" required
+             placeholder="min_gap_hours_satisfied(person_id, 12)">
+      <div class="row-sub" style="margin-top:6px">
+        DSL expression (e.g. <code>has_role(role)</code>,
+        <code>is_day_of_week(day)</code>,
+        <code>count_assignments_in_period(person_id, start, end)</code>).
+      </div>
+    </div>
+    <div class="field">
+      <label class="field-label" for="c_params">Params (JSON, optional)</label>
+      <input id="c_params" name="params" type="text"
+             placeholder='{"min_hours": 12}'>
+    </div>
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-secondary" type="button" @click="creating = false">Cancel</button>
+      <button class="btn btn-primary" type="submit">Create constraint</button>
+    </div>
+  </form>
+
+  <div class="mono-label" style="margin-top:18px">Constraints</div>
+  {% if not constraints %}
+  <div class="empty">No constraints yet. The solver runs with defaults.</div>
+  {% else %}
+  {% for c in constraints %}
+  <div class="card" style="margin-bottom:12px">
+    <div x-show="editId !== {{ c.id }}">
+      <div style="display:flex;align-items:flex-start;gap:8px">
+        <div class="row-main" style="flex:1">
+          <div class="row-title">{{ c.key }}</div>
+          <div style="margin-top:4px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+            <span class="role-chip">{{ c.type }}</span>
+            {% if c.weight is not none %}<span class="role-chip">w={{ c.weight }}</span>{% endif %}
+          </div>
+          <div class="mono-data" style="margin-top:8px;word-break:break-all">{{ c.predicate }}</div>
+          {% if c.params_json %}
+          <div class="row-sub" style="margin-top:4px;word-break:break-all">{{ c.params_json }}</div>
+          {% endif %}
+        </div>
+        <button class="btn btn-secondary" style="width:auto;padding:6px 12px"
+                type="button" @click="editId = {{ c.id }}">Edit</button>
+        <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+                hx-post="/a/constraints/{{ c.id }}/delete"
+                hx-target="#constraints-list" hx-swap="outerHTML"
+                hx-confirm="Delete constraint '{{ c.key }}'?">Delete</button>
+      </div>
+    </div>
+
+    <form x-show="editId === {{ c.id }}" x-cloak
+          hx-post="/a/constraints/{{ c.id }}/update"
+          hx-target="#constraints-list" hx-swap="outerHTML">
+      <div class="field">
+        <label class="field-label">Key</label>
+        <input type="text" value="{{ c.key }}" disabled
+               style="opacity:.6">
+      </div>
+      <div class="field">
+        <label class="field-label">Type</label>
+        <select name="type"
+                style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+          <option value="hard" {% if c.type == 'hard' %}selected{% endif %}>hard</option>
+          <option value="soft" {% if c.type == 'soft' %}selected{% endif %}>soft</option>
+        </select>
+      </div>
+      <div class="field">
+        <label class="field-label">Weight</label>
+        <input name="weight" type="number" step="1"
+               value="{{ c.weight if c.weight is not none else '' }}">
+      </div>
+      <div class="field">
+        <label class="field-label">Predicate</label>
+        <input name="predicate" type="text" required value="{{ c.predicate }}">
+      </div>
+      <div class="field">
+        <label class="field-label">Params (JSON)</label>
+        <input name="params" type="text" value="{{ c.params_json }}">
+      </div>
+      <div class="spacer-12"></div>
+      <div class="btn-row cols-2">
+        <button class="btn btn-secondary" type="button" @click="editId = null">Cancel</button>
+        <button class="btn btn-primary" type="submit">Save</button>
+      </div>
+    </form>
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Admin **`/a/constraints`**: list / create / edit / delete scheduling constraints (key, hard|soft type, weight, predicate DSL, optional params JSON) over `api.routers.constraints`. Org-scoped direct list query; cross-org mutation rejected by the reused `verify_org_member`. Required text fields use `Form("")` + explicit checks so empty submissions return a friendly inline 400 rather than FastAPI's raw 422. Linked from the Solver page.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_constraints.py` — 5 cases (admin/auth gating, create+params, validation 400s, update+delete, cross-org isolation)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 149 passed
- [x] Live Playwright e2e: Solver→Constraints nav, create (soft, weight, predicate, JSON params) → edit predicate → delete; no JS errors; screenshot visually verified

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)