### PR TITLE
P1.5 — web notifications inbox + unread badge + email preferences

### DIFF
--- a/tests/web/test_notifications.py
+++ b/tests/web/test_notifications.py
@@ -1,0 +1,110 @@
+"""Marathon P1.5 — notifications inbox + unread badge + email prefs."""
+
+from __future__ import annotations
+
+from api.models import EmailPreference, Notification
+from api.timeutils import utcnow
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, db, *, pid, org, email, roles=None):
+    seed_person(db, person_id=pid, org_id=org, email=email, roles=roles or ["volunteer"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _notif(db, *, org, recipient, ntype="assignment", opened=False):
+    n = Notification(
+        org_id=org,
+        recipient_id=recipient,
+        type=ntype,
+        status="sent",
+        created_at=utcnow(),
+        opened_at=utcnow() if opened else None,
+    )
+    db.add(n)
+    db.commit()
+    db.refresh(n)
+    return n
+
+
+def test_inbox_requires_auth(client):
+    assert client.get("/v/inbox").status_code == 303
+
+
+def test_inbox_lists_and_unread_badge(client, db):
+    tok = _login(client, db, pid="n1", org="n_o1", email="n1@web.test")
+    _notif(db, org="n_o1", recipient="n1", ntype="assignment")
+    _notif(db, org="n_o1", recipient="n1", ntype="reminder", opened=True)
+
+    inbox = client.get("/v/inbox", cookies={SESSION_COOKIE: tok})
+    assert inbox.status_code == 200
+    assert 'id="inbox-list"' in inbox.text
+    assert 'id="notif-prefs"' in inbox.text
+    assert "New assignment" in inbox.text
+    assert "1 unread" in inbox.text
+
+    # Schedule header shows the unread badge.
+    sched = client.get("/v/schedule", cookies={SESSION_COOKIE: tok})
+    assert "Inbox (1)" in sched.text
+
+
+def test_mark_read_and_read_all(client, db):
+    tok = _login(client, db, pid="n2", org="n_o2", email="n2@web.test")
+    a = _notif(db, org="n_o2", recipient="n2")
+    b = _notif(db, org="n_o2", recipient="n2")
+
+    r = client.post(f"/v/inbox/{a.id}/read", cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    db.refresh(a)
+    assert a.opened_at is not None
+
+    r2 = client.post("/v/inbox/read-all", cookies={SESSION_COOKIE: tok})
+    assert r2.status_code == 200
+    db.refresh(b)
+    assert b.opened_at is not None
+    assert "No notifications yet" not in r2.text
+    assert "unread" not in r2.text  # all read → no "unread" anywhere
+
+
+def test_cannot_read_another_users_notification(client, db):
+    tok = _login(client, db, pid="n3", org="n_o3", email="n3@web.test")
+    seed_person(db, person_id="n3b", org_id="n_o3", email="n3b@web.test", roles=["volunteer"])
+    other = _notif(db, org="n_o3", recipient="n3b")
+
+    r = client.post(f"/v/inbox/{other.id}/read", cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200  # handled gracefully
+    db.refresh(other)
+    assert other.opened_at is None  # untouched
+
+
+def test_preferences_save_and_validate(client, db):
+    tok = _login(client, db, pid="n4", org="n_o4", email="n4@web.test")
+    r = client.post(
+        "/v/inbox/preferences",
+        data={
+            "frequency": "daily",
+            "digest_hour": "9",
+            "types": ["assignment", "cancellation"],
+        },
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    assert "Preferences saved" in r.text
+    pref = (
+        db.query(EmailPreference)
+        .filter(EmailPreference.org_id == "n_o4", EmailPreference.person_id == "n4")
+        .first()
+    )
+    assert pref.frequency == "daily"
+    assert pref.digest_hour == 9
+    assert set(pref.enabled_types) == {"assignment", "cancellation"}
+
+    bad = client.post(
+        "/v/inbox/preferences",
+        data={"frequency": "daily", "digest_hour": "99", "types": ["assignment"]},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert bad.status_code == 400
+    assert "between 0 and 23" in bad.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -9,7 +9,16 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Assignment, Constraint, Event, Person, Team, TeamMember
+from api.models import (
+    Assignment,
+    Constraint,
+    EmailPreference,
+    Event,
+    Notification,
+    Person,
+    Team,
+    TeamMember,
+)
 from web.deps import get_session_admin, get_session_user
 
 router = APIRouter(tags=["web-pages"])
@@ -94,6 +103,7 @@ def volunteer_schedule(
             "person": person,
             "active_tab": "schedule",
             "rows": _my_schedule_rows(db, person),
+            "unread": _unread_count(db, person),
         },
     )
 
@@ -209,6 +219,110 @@ def _account_ctx(person: Person) -> dict:
         "saved": False,
         "error": None,
     }
+
+
+NOTIF_TYPES = ["assignment", "reminder", "update", "cancellation"]
+_NOTIF_LABELS = {
+    "assignment": "New assignment",
+    "reminder": "Reminder",
+    "update": "Schedule update",
+    "cancellation": "Cancellation",
+}
+
+
+def _notif_label(t: str | None) -> str:
+    key = (t or "").lower()
+    return _NOTIF_LABELS.get(key, (t or "Notification").replace("_", " ").title())
+
+
+def _inbox(db: Session, person: Person) -> dict:
+    """The signed-in user's own notifications, newest first."""
+    rows = (
+        db.query(Notification)
+        .filter(
+            Notification.org_id == person.org_id,
+            Notification.recipient_id == person.id,
+        )
+        .order_by(Notification.created_at.desc())
+        .limit(100)
+        .all()
+    )
+    out = []
+    unread = 0
+    for n in rows:
+        is_unread = n.opened_at is None and n.clicked_at is None
+        if is_unread:
+            unread += 1
+        out.append(
+            {
+                "id": n.id,
+                "label": _notif_label(n.type),
+                "event_id": n.event_id,
+                "when": n.created_at.strftime("%a %d %b %Y, %H:%M") if n.created_at else "",
+                "unread": is_unread,
+                "status": (n.status or "").lower(),
+            }
+        )
+    return {"rows": out, "unread": unread}
+
+
+def _unread_count(db: Session, person: Person) -> int:
+    from sqlalchemy import func
+
+    return (
+        db.query(func.count(Notification.id))
+        .filter(
+            Notification.org_id == person.org_id,
+            Notification.recipient_id == person.id,
+            Notification.opened_at.is_(None),
+            Notification.clicked_at.is_(None),
+        )
+        .scalar()
+        or 0
+    )
+
+
+def _email_prefs(db: Session, person: Person) -> dict:
+    p = (
+        db.query(EmailPreference)
+        .filter(
+            EmailPreference.org_id == person.org_id,
+            EmailPreference.person_id == person.id,
+        )
+        .first()
+    )
+    if not p:
+        return {
+            "frequency": "immediate",
+            "enabled_types": list(NOTIF_TYPES),
+            "digest_hour": 8,
+        }
+    return {
+        "frequency": p.frequency or "immediate",
+        "enabled_types": list(p.enabled_types or NOTIF_TYPES),
+        "digest_hour": p.digest_hour if p.digest_hour is not None else 8,
+    }
+
+
+@router.get("/v/inbox", response_class=HTMLResponse)
+def volunteer_inbox(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "volunteer/inbox.html",
+        {
+            "person": person,
+            "active_tab": None,
+            "inbox": _inbox(db, person),
+            "prefs": _email_prefs(db, person),
+            "notif_types": NOTIF_TYPES,
+        },
+    )
 
 
 def _my_calendar(request: Request, db: Session, person: Person) -> dict:

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -14,7 +14,7 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import Person
+from api.models import EmailPreference, Notification, Person
 from api.routers.assignments import (
     accept_assignment,
     decline_assignment,
@@ -61,11 +61,15 @@ from api.schemas.organization import OrganizationUpdate
 from api.schemas.person import PersonUpdate
 from api.schemas.solver import SolveRequest
 from api.schemas.team import TeamCreate, TeamMemberAdd, TeamMemberRemove, TeamUpdate
+from api.timeutils import utcnow
 from web.deps import get_session_admin, get_session_user
 from web.routers.pages import (
+    NOTIF_TYPES,
     RRULE_PRESETS,
     _constraints,
+    _email_prefs,
     _events,
+    _inbox,
     _my_assignment,
     _my_calendar,
     _my_exceptions,
@@ -623,6 +627,125 @@ def team_member_remove(
     except HTTPException as exc:
         return _teams_list(request, person, db, error=str(exc.detail))
     return _teams_list(request, person, db)
+
+
+# ── Notifications inbox + email preferences ──────────────────────────
+
+
+def _inbox_list(request: Request, person: Person, db: Session):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/inbox_list.html",
+        {"inbox": _inbox(db, person)},
+    )
+
+
+def _notif_prefs(request: Request, person: Person, db: Session, *, saved=False, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/notif_prefs.html",
+        {
+            "prefs": _email_prefs(db, person),
+            "notif_types": NOTIF_TYPES,
+            "saved": saved,
+            "error": error,
+        },
+        status_code=400 if error else 200,
+    )
+
+
+@router.post("/v/inbox/{notification_id}/read", response_class=HTMLResponse)
+def inbox_mark_read(
+    request: Request,
+    notification_id: int,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    """Org-scoped + recipient-scoped direct update (reusing the API
+    handler would query Notification without an org_id filter, which
+    the strict tenancy guard rejects)."""
+    n = (
+        db.query(Notification)
+        .filter(
+            Notification.org_id == person.org_id,
+            Notification.id == notification_id,
+            Notification.recipient_id == person.id,
+        )
+        .first()
+    )
+    if n is not None and n.opened_at is None:
+        n.opened_at = utcnow()
+        db.commit()
+    return _inbox_list(request, person, db)
+
+
+@router.post("/v/inbox/read-all", response_class=HTMLResponse)
+def inbox_mark_all_read(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    """No bulk API endpoint exists — stamp opened_at directly (same
+    org-scoped recipient filter the API's per-item handler enforces)."""
+    now = utcnow()
+    (
+        db.query(Notification)
+        .filter(
+            Notification.org_id == person.org_id,
+            Notification.recipient_id == person.id,
+            Notification.opened_at.is_(None),
+        )
+        .update({Notification.opened_at: now}, synchronize_session=False)
+    )
+    db.commit()
+    return _inbox_list(request, person, db)
+
+
+@router.post("/v/inbox/preferences", response_class=HTMLResponse)
+def inbox_save_preferences(
+    request: Request,
+    frequency: str = Form("immediate"),
+    digest_hour: int = Form(8),
+    types: list[str] = Form(default=[]),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    """Upsert the signed-in user's email preferences (org-scoped direct
+    write — the API handler isn't org-filtered for the tenancy guard)."""
+    if not 0 <= digest_hour <= 23:
+        return _notif_prefs(request, person, db, error="Digest hour must be between 0 and 23.")
+    if frequency not in ("immediate", "daily", "weekly", "disabled"):
+        frequency = "immediate"
+    valid_types = [t for t in types if t in NOTIF_TYPES]
+
+    pref = (
+        db.query(EmailPreference)
+        .filter(
+            EmailPreference.org_id == person.org_id,
+            EmailPreference.person_id == person.id,
+        )
+        .first()
+    )
+    if pref is None:
+        import secrets
+
+        pref = EmailPreference(
+            person_id=person.id,
+            org_id=person.org_id,
+            language=person.language or "en",
+            timezone=person.timezone or "UTC",
+            unsubscribe_token=secrets.token_urlsafe(32),
+        )
+        db.add(pref)
+    pref.frequency = frequency
+    pref.enabled_types = valid_types
+    pref.digest_hour = digest_hour
+    db.commit()
+    return _notif_prefs(request, person, db, saved=True)
 
 
 # ── Admin: constraints ───────────────────────────────────────────────

--- a/web/templates/partials/inbox_list.html
+++ b/web/templates/partials/inbox_list.html
@@ -1,0 +1,48 @@
+{# Notification inbox list. #inbox-list so HTMX swaps it after read /
+   read-all. #}
+<div id="inbox-list">
+  <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+    <div class="mono-label" style="margin:0;flex:1">
+      Inbox{% if inbox.unread %} · {{ inbox.unread }} unread{% endif %}
+    </div>
+    {% if inbox.unread %}
+    <button class="btn btn-secondary" style="width:auto;padding:6px 12px"
+            hx-post="/v/inbox/read-all"
+            hx-target="#inbox-list" hx-swap="outerHTML">
+      Mark all read
+    </button>
+    {% endif %}
+  </div>
+  <div class="spacer-12"></div>
+
+  {% if not inbox.rows %}
+  <div class="empty">No notifications yet.</div>
+  {% else %}
+  <div class="group">
+    {% for n in inbox.rows %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">
+          {% if n.unread %}<span aria-hidden="true">● </span>{% endif %}{{ n.label }}
+        </div>
+        <div class="row-sub">
+          {{ n.when }}{% if n.event_id %} · {{ n.event_id }}{% endif %}
+        </div>
+        <div style="margin-top:4px">
+          <span class="status-text {{ 'pending' if n.unread else 'confirmed' }}">
+            {{ 'unread' if n.unread else 'read' }}
+          </span>
+        </div>
+      </div>
+      {% if n.unread %}
+      <button class="btn btn-secondary" style="width:auto;padding:6px 12px"
+              hx-post="/v/inbox/{{ n.id }}/read"
+              hx-target="#inbox-list" hx-swap="outerHTML">
+        Mark read
+      </button>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>

--- a/web/templates/partials/notif_prefs.html
+++ b/web/templates/partials/notif_prefs.html
@@ -1,0 +1,43 @@
+{# Email-notification preferences. #notif-prefs so HTMX swaps it after
+   save. #}
+<div id="notif-prefs">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% elif saved %}
+  <div class="form-notice" role="status">Preferences saved.</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <form hx-post="/v/inbox/preferences"
+        hx-target="#notif-prefs" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="np_freq">Email frequency</label>
+      <select id="np_freq" name="frequency"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        {% for f in ['immediate', 'daily', 'weekly', 'disabled'] %}
+        <option value="{{ f }}" {% if prefs.frequency == f %}selected{% endif %}>{{ f }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="field">
+      <label class="field-label">Notify me about</label>
+      {% for t in notif_types %}
+      <label style="display:flex;align-items:center;gap:10px;padding:6px 0;cursor:pointer">
+        <input type="checkbox" name="types" value="{{ t }}"
+               {% if t in prefs.enabled_types %}checked{% endif %}>
+        <span class="row-title" style="font-size:14px;text-transform:capitalize">{{ t }}</span>
+      </label>
+      {% endfor %}
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="np_hour">Digest hour (0–23)</label>
+      <input id="np_hour" name="digest_hour" type="number" min="0" max="23"
+             step="1" value="{{ prefs.digest_hour }}">
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Save preferences</button>
+  </form>
+</div>

--- a/web/templates/volunteer/inbox.html
+++ b/web/templates/volunteer/inbox.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Inbox · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/v/schedule">‹ Schedule</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Inbox</div>
+<div class="scroll">
+  {% include "partials/inbox_list.html" %}
+
+  <div class="mono-label" style="margin-top:18px">Email preferences</div>
+  {% include "partials/notif_prefs.html" %}
+</div>
+{% set tabs = [
+  ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
+  ('/v/profile', '◍', 'Profile', 'profile'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/volunteer/schedule.html
+++ b/web/templates/volunteer/schedule.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Schedule · SignUpFlow{% endblock %}
 {% block body %}
-<div class="nav"><span class="nav-back"></span><span class="nav-action"></span></div>
+<div class="nav">
+  <span class="nav-back"></span>
+  <a class="nav-action" href="/v/inbox">Inbox{% if unread %} ({{ unread }}){% endif %}</a>
+</div>
 <div class="page-title">Schedule</div>
 <div class="scroll">
   {% if not rows %}


### PR DESCRIPTION
## Summary

**`/v/inbox`**: the signed-in user's notifications (type / event / date, unread state), **mark-read** + **mark-all-read**, and an **email-preferences** form (frequency, enabled types, digest hour). Unread-count badge on the schedule header (`Inbox (N)`).

Mutations are org-scoped direct writes — reusing the API notification handlers would `SELECT Notification` without an `org_id` filter, which the strict tenancy guard rejects. New `EmailPreference` rows get an `unsubscribe_token` (NOT NULL). Inbox dict key is `rows` (not `items`) to dodge Jinja's `dict.items()` attribute collision.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_notifications.py` — 5 cases (auth gate, list+unread badge, mark-read + mark-all, cross-user isolation, prefs save+validate)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 154 passed
- [x] Live Playwright e2e: seed notifications → schedule badge `Inbox (2)` → open inbox → mark one → mark all → save prefs; no JS errors; screenshot visually verified

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)