### PR TITLE
P1.6 — web manual assignment editing

### DIFF
--- a/tests/web/test_event_assignments.py
+++ b/tests/web/test_event_assignments.py
@@ -1,0 +1,116 @@
+"""Marathon P1.6 — manual assignment editing (per-event assignees)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _event(db, org, eid="ev1"):
+    start = datetime(2026, 6, 7, 10, 0, 0)
+    e = Event(
+        id=eid,
+        org_id=org,
+        type="Sunday Service",
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+    )
+    db.add(e)
+    db.commit()
+    return e
+
+
+def test_page_admin_only_and_404(client, db):
+    seed_person(db, person_id="ea_vol", email="eavol@web.test", roles=["volunteer"])
+    v = client.post("/auth/login", data={"email": "eavol@web.test", "password": "WebPass123!"})
+    vtok = v.cookies[SESSION_COOKIE]
+    assert client.get("/a/events/x/assignments").status_code == 303
+    assert client.get("/a/events/x/assignments", cookies={SESSION_COOKIE: vtok}).status_code == 303
+
+    tok = _admin(client, db, org="ea_o1", email="ea1@web.test")
+    _event(db, "ea_o1")
+    ok = client.get("/a/events/ev1/assignments", cookies={SESSION_COOKIE: tok})
+    assert ok.status_code == 200
+    assert "Sunday Service" in ok.text
+    assert 'id="event-assignments"' in ok.text
+    # Unknown event -> 404
+    assert (
+        client.get("/a/events/nope/assignments", cookies={SESSION_COOKIE: tok}).status_code == 404
+    )
+
+
+def test_add_and_remove_assignee(client, db):
+    tok = _admin(client, db, org="ea_o2", email="ea2@web.test")
+    _event(db, "ea_o2")
+    seed_person(db, person_id="ea_p1", org_id="ea_o2", email="p1@ea.test", roles=["volunteer"])
+
+    r = client.post(
+        "/a/events/ev1/assignments/add",
+        data={"person_id": "ea_p1", "role": "usher"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    assert "ea_p1" in r.text or "Web User" in r.text
+    a = (
+        db.query(Assignment)
+        .filter(Assignment.event_id == "ev1", Assignment.person_id == "ea_p1")
+        .first()
+    )
+    assert a is not None and a.role == "usher" and a.solution_id is None
+
+    # Double-add rejected.
+    dup = client.post(
+        "/a/events/ev1/assignments/add",
+        data={"person_id": "ea_p1", "role": ""},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert dup.status_code == 400
+
+    # Remove.
+    rem = client.post(
+        "/a/events/ev1/assignments/remove",
+        data={"person_id": "ea_p1"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert rem.status_code == 200
+    assert (
+        db.query(Assignment)
+        .filter(Assignment.event_id == "ev1", Assignment.person_id == "ea_p1")
+        .first()
+        is None
+    )
+
+    # Removing a non-assigned person is graceful.
+    again = client.post(
+        "/a/events/ev1/assignments/remove",
+        data={"person_id": "ea_p1"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert again.status_code == 200
+
+
+def test_cross_org_event_blocked(client, db):
+    tok = _admin(client, db, org="ea_o3", email="ea3@web.test")
+    seed_person(db, person_id="other_adm", org_id="ea_other", email="o@ea.test", roles=["admin"])
+    _event(db, "ea_other", eid="secret_ev")
+
+    assert (
+        client.get("/a/events/secret_ev/assignments", cookies={SESSION_COOKIE: tok}).status_code
+        == 404
+    )
+    resp = client.post(
+        "/a/events/secret_ev/assignments/add",
+        data={"person_id": "other_adm", "role": ""},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert resp.status_code in (400, 404)
+    assert db.query(Assignment).filter(Assignment.event_id == "secret_ev").first() is None

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -634,6 +634,58 @@ def admin_events(
     )
 
 
+def _event_assignments(db: Session, org_id: str, event_id: str) -> dict | None:
+    """Current assignees for an event + people who could still be added.
+    Org-scoped via the Event join (mirrors _my_schedule_rows)."""
+    ev = db.query(Event).filter(Event.org_id == org_id, Event.id == event_id).first()
+    if ev is None:
+        return None
+    rows = (
+        db.query(Assignment, Person)
+        .join(Person, Assignment.person_id == Person.id)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(Event.org_id == org_id, Assignment.event_id == event_id)
+        .all()
+    )
+    assigned_ids = {p.id for _, p in rows}
+    people = db.query(Person).filter(Person.org_id == org_id).order_by(Person.name.asc()).all()
+    return {
+        "event": {
+            "id": ev.id,
+            "type": ev.type,
+            "date_label": ev.start_time.strftime("%a %d %b %Y") if ev.start_time else "",
+        },
+        "assignees": [
+            {
+                "assignment_id": a.id,
+                "person_id": p.id,
+                "name": p.name,
+                "role": a.role,
+            }
+            for a, p in rows
+        ],
+        "candidates": [{"id": p.id, "name": p.name} for p in people if p.id not in assigned_ids],
+    }
+
+
+@router.get("/a/events/{event_id}/assignments", response_class=HTMLResponse)
+def admin_event_assignments(
+    request: Request,
+    event_id: str,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    data = _event_assignments(db, person.org_id, event_id)
+    return templates.TemplateResponse(
+        request,
+        "admin/event_assignments.html",
+        {"person": person, "active_tab": "events", "data": data, "error": None},
+        status_code=200 if data else 404,
+    )
+
+
 @router.get("/a/solver", response_class=HTMLResponse)
 def admin_solver(
     request: Request,

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -35,7 +35,7 @@ from api.routers.constraints import (
     delete_constraint,
     update_constraint,
 )
-from api.routers.events import create_event, delete_event
+from api.routers.events import AssignmentRequest, create_event, delete_event, manage_assignment
 from api.routers.invitations import create_invitation
 from api.routers.organizations import get_organization, update_organization
 from api.routers.people import update_current_person
@@ -68,6 +68,7 @@ from web.routers.pages import (
     RRULE_PRESETS,
     _constraints,
     _email_prefs,
+    _event_assignments,
     _events,
     _inbox,
     _my_assignment,
@@ -746,6 +747,73 @@ def inbox_save_preferences(
     pref.digest_hour = digest_hour
     db.commit()
     return _notif_prefs(request, person, db, saved=True)
+
+
+# ── Admin: manual assignment editing ─────────────────────────────────
+
+
+def _event_assignments_partial(
+    request: Request, person: Person, db: Session, event_id: str, *, error=None
+):
+    from web.app import templates
+
+    data = _event_assignments(db, person.org_id, event_id)
+    if data is None:
+        return HTMLResponse(
+            '<div id="event-assignments" class="empty">Event not found.</div>',
+            status_code=404,
+        )
+    return templates.TemplateResponse(
+        request,
+        "partials/event_assignments.html",
+        {"data": data, "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+@router.post("/a/events/{event_id}/assignments/add", response_class=HTMLResponse)
+def event_assignment_add(
+    request: Request,
+    event_id: str,
+    background_tasks: BackgroundTasks,
+    person_id: str = Form(...),
+    role: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        manage_assignment(
+            event_id,
+            AssignmentRequest(person_id=person_id, action="assign", role=role.strip() or None),
+            background_tasks,
+            person,
+            db,
+        )
+    except HTTPException as exc:
+        return _event_assignments_partial(request, person, db, event_id, error=str(exc.detail))
+    return _event_assignments_partial(request, person, db, event_id)
+
+
+@router.post("/a/events/{event_id}/assignments/remove", response_class=HTMLResponse)
+def event_assignment_remove(
+    request: Request,
+    event_id: str,
+    background_tasks: BackgroundTasks,
+    person_id: str = Form(...),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        manage_assignment(
+            event_id,
+            AssignmentRequest(person_id=person_id, action="unassign"),
+            background_tasks,
+            person,
+            db,
+        )
+    except HTTPException:
+        pass  # already gone — return a fresh, correct list
+    return _event_assignments_partial(request, person, db, event_id)
 
 
 # ── Admin: constraints ───────────────────────────────────────────────

--- a/web/templates/admin/event_assignments.html
+++ b/web/templates/admin/event_assignments.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Assignees · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/events">‹ Events</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Assignees</div>
+<div class="scroll">
+  {% if data is none %}
+  <div class="empty">Event not found in your organization.</div>
+  {% else %}
+  {% include "partials/event_assignments.html" %}
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/partials/event_assignments.html
+++ b/web/templates/partials/event_assignments.html
@@ -1,0 +1,67 @@
+{# Per-event assignee editor. #event-assignments so HTMX swaps it after
+   add / remove. #}
+<div id="event-assignments">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <div class="card">
+    <div class="row-title">{{ data.event.type }}</div>
+    {% if data.event.date_label %}
+    <div class="row-sub">{{ data.event.date_label }}</div>
+    {% endif %}
+  </div>
+
+  <div class="mono-label" style="margin-top:18px">
+    Assignees ({{ data.assignees|length }})
+  </div>
+  {% if not data.assignees %}
+  <div class="empty">No one assigned yet.</div>
+  {% else %}
+  <div class="group">
+    {% for a in data.assignees %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ a.name }}</div>
+        {% if a.role %}
+        <div style="margin-top:4px"><span class="role-chip">{{ a.role }}</span></div>
+        {% endif %}
+      </div>
+      <form hx-post="/a/events/{{ data.event.id }}/assignments/remove"
+            hx-target="#event-assignments" hx-swap="outerHTML"
+            style="margin:0">
+        <input type="hidden" name="person_id" value="{{ a.person_id }}">
+        <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+                type="submit">Remove</button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if data.candidates %}
+  <div class="mono-label" style="margin-top:18px">Add someone</div>
+  <form hx-post="/a/events/{{ data.event.id }}/assignments/add"
+        hx-target="#event-assignments" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="ea_person">Person</label>
+      <select id="ea_person" name="person_id" required
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        {% for c in data.candidates %}
+        <option value="{{ c.id }}">{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field">
+      <label class="field-label" for="ea_role">Role (optional)</label>
+      <input id="ea_role" name="role" type="text" placeholder="usher">
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-primary" type="submit">Add to event</button>
+  </form>
+  {% else %}
+  <div class="spacer-12"></div>
+  <div class="row-sub">Everyone in your org is already assigned.</div>
+  {% endif %}
+</div>

--- a/web/templates/partials/events_list.html
+++ b/web/templates/partials/events_list.html
@@ -66,6 +66,8 @@
         <div class="row-title">{{ e.type }}</div>
         <div class="row-sub">{{ e.date_label }}{% if e.time_label %} · {{ e.time_label }}{% endif %}</div>
       </div>
+      <a class="btn btn-secondary" style="width:auto;padding:6px 12px"
+         href="/a/events/{{ e.id }}/assignments">Manage</a>
       <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
               hx-post="/a/events/{{ e.id }}/delete"
               hx-target="#events-list" hx-swap="outerHTML"
@@ -88,6 +90,8 @@
         <div class="row-title">{{ e.type }}</div>
         <div class="row-sub">{{ e.date_label }}{% if e.time_label %} · {{ e.time_label }}{% endif %}</div>
       </div>
+      <a class="btn btn-secondary" style="width:auto;padding:6px 12px"
+         href="/a/events/{{ e.id }}/assignments">Manage</a>
       <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
               hx-post="/a/events/{{ e.id }}/delete"
               hx-target="#events-list" hx-swap="outerHTML"


### PR DESCRIPTION
## Summary

Admin **`/a/events/{event_id}/assignments`**: view current assignees, **add** (person + optional role) / **remove**, via `api.routers.events.manage_assignment`. Uses a FastAPI-injected `BackgroundTasks` so the solution-stream publish on unassign isn't silently dropped (the Sprint 11.19 lesson). Org-scoped via the Event join. A **Manage** link is added to every event row on the Events page.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_event_assignments.py` — 3 cases (admin/auth gating + 404, add/double-add/remove/idempotent-remove, cross-org blocked)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 157 passed
- [x] Live Playwright e2e: create event → Manage → add (with role) → remove; no JS errors; screenshot visually verified

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)