### PR TITLE
P1.7 — web solution unpublish + rollback

### DIFF
--- a/tests/web/test_publish_lifecycle.py
+++ b/tests/web/test_publish_lifecycle.py
@@ -1,0 +1,92 @@
+"""Marathon P1.7 — solution unpublish + rollback (web)."""
+
+from __future__ import annotations
+
+from api.models import Solution
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _sol(db, org):
+    s = Solution(org_id=org, hard_violations=0, soft_score=1.0, health_score=90.0, solve_ms=5.0)
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def test_publish_then_unpublish_cycle(client, db):
+    tok = _admin(client, db, org="pl_o1", email="pl1@web.test")
+    s = _sol(db, "pl_o1")
+
+    pub = client.post(f"/a/solution/{s.id}/publish", cookies={SESSION_COOKIE: tok})
+    assert pub.status_code == 200
+    assert "Published" in pub.text
+    assert "Unpublish" in pub.text
+    db.refresh(s)
+    assert s.is_published is True
+
+    unp = client.post(f"/a/solution/{s.id}/unpublish", cookies={SESSION_COOKIE: tok})
+    assert unp.status_code == 200
+    assert "Publish this solution" in unp.text
+    db.refresh(s)
+    assert s.is_published is False
+    # Previously published → rollback now offered.
+    assert "Roll back to this version" in unp.text
+
+
+def test_rollback_restores_previous(client, db):
+    tok = _admin(client, db, org="pl_o2", email="pl2@web.test")
+    s1 = _sol(db, "pl_o2")
+    s2 = _sol(db, "pl_o2")
+
+    client.post(f"/a/solution/{s1.id}/publish", cookies={SESSION_COOKIE: tok})
+    # Publishing s2 unpublishes s1.
+    client.post(f"/a/solution/{s2.id}/publish", cookies={SESSION_COOKIE: tok})
+    db.refresh(s1)
+    db.refresh(s2)
+    assert s1.is_published is False and s2.is_published is True
+
+    # Roll back to s1 (it was published before → eligible).
+    rb = client.post(f"/a/solution/{s1.id}/rollback", cookies={SESSION_COOKIE: tok})
+    assert rb.status_code == 200
+    assert "Published" in rb.text
+    db.refresh(s1)
+    db.refresh(s2)
+    assert s1.is_published is True
+    assert s2.is_published is False
+
+
+def test_rollback_never_published_rejected(client, db):
+    tok = _admin(client, db, org="pl_o3", email="pl3@web.test")
+    s = _sol(db, "pl_o3")
+    rb = client.post(f"/a/solution/{s.id}/rollback", cookies={SESSION_COOKIE: tok})
+    assert rb.status_code == 400
+    assert "never been published" in rb.text.lower()
+    db.refresh(s)
+    assert s.is_published is False
+
+
+def test_lifecycle_other_org_404(client, db):
+    tok = _admin(client, db, org="pl_o4", email="pl4@web.test")
+    other = _sol(db, "pl_other")
+    for action in ("publish", "unpublish", "rollback"):
+        r = client.post(f"/a/solution/{other.id}/{action}", cookies={SESSION_COOKIE: tok})
+        assert r.status_code == 404
+
+
+def test_lifecycle_requires_admin(client, db):
+    seed_person(db, person_id="pl_vol", email="plvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "plvol@web.test", "password": "WebPass123!"})
+    tok = login.cookies[SESSION_COOKIE]
+    for action in ("publish", "unpublish", "rollback"):
+        assert (
+            client.post(f"/a/solution/1/{action}", cookies={SESSION_COOKIE: tok}).status_code == 303
+        )
+        assert client.post(f"/a/solution/1/{action}").status_code == 303

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -745,9 +745,21 @@ def _solution_review(db: Session, person: Person, sid: int) -> dict | None:
 
     if _solution_owned(db, person, sid) is None:
         return None
+    from api.models import AuditAction, AuditLog
+
     detail = get_solution(sid, db)
     stats = get_solution_stats(sid, person, db)
     events = _solution_events(db, person, sid)
+    ever_published = (
+        db.query(AuditLog)
+        .filter(
+            AuditLog.organization_id == person.org_id,
+            AuditLog.resource_id == str(sid),
+            AuditLog.action.in_([AuditAction.SOLUTION_PUBLISHED, AuditAction.SOLUTION_ROLLED_BACK]),
+        )
+        .count()
+        > 0
+    )
     return {
         "id": detail.id,
         "health_score": round(detail.health_score),
@@ -755,6 +767,7 @@ def _solution_review(db: Session, person: Person, sid: int) -> dict | None:
         "soft_score": round(detail.soft_score, 1),
         "assignment_count": detail.assignment_count,
         "is_published": detail.is_published,
+        "can_rollback": ever_published and not detail.is_published,
         "created_label": detail.created_at.strftime("%a %d %b %Y").upper()
         if detail.created_at
         else "",

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -39,7 +39,12 @@ from api.routers.events import AssignmentRequest, create_event, delete_event, ma
 from api.routers.invitations import create_invitation
 from api.routers.organizations import get_organization, update_organization
 from api.routers.people import update_current_person
-from api.routers.solutions import compare_solutions, publish_solution
+from api.routers.solutions import (
+    compare_solutions,
+    publish_solution,
+    rollback_solution,
+    unpublish_solution,
+)
 from api.routers.solver import solve_schedule
 from api.routers.teams import (
     add_team_members,
@@ -77,6 +82,7 @@ from web.routers.pages import (
     _my_rrule,
     _my_timeoff,
     _solution_owned,
+    _solution_review,
     _teams,
 )
 
@@ -1087,6 +1093,31 @@ def solver_run(
 # ── Admin: publish solution + compare ────────────────────────────────
 
 
+def _publish_state(request: Request, person: Person, db: Session, sid: int, *, error=None):
+    """Re-render #publish-state from the solution's current state
+    (is_published + rollback eligibility), always carrying solution_id
+    so the swapped fragment's buttons keep working."""
+    from web.app import templates
+
+    review = _solution_review(db, person, sid)
+    if review is None:
+        return HTMLResponse(
+            '<div id="publish-state" class="empty">Solution not found.</div>',
+            status_code=404,
+        )
+    return templates.TemplateResponse(
+        request,
+        "partials/publish_state.html",
+        {
+            "solution_id": sid,
+            "published": review["is_published"],
+            "can_rollback": review["can_rollback"],
+            "error": error,
+        },
+        status_code=400 if error else 200,
+    )
+
+
 @router.post("/a/solution/{solution_id}/publish", response_class=HTMLResponse)
 def solution_publish(
     request: Request,
@@ -1094,10 +1125,7 @@ def solution_publish(
     person: Person = Depends(get_session_admin),
     db: Session = Depends(get_db),
 ):
-    """Publish the solution (unpublishes any prior in the org). Returns
-    the refreshed publish-state fragment."""
-    from web.app import templates
-
+    """Publish the solution (unpublishes any prior in the org)."""
     if _solution_owned(db, person, solution_id) is None:
         return HTMLResponse(
             '<div id="publish-state" class="empty">Solution not found.</div>',
@@ -1106,15 +1134,49 @@ def solution_publish(
     try:
         publish_solution(solution_id, request, person, db)
     except HTTPException as exc:
-        return templates.TemplateResponse(
-            request,
-            "partials/publish_state.html",
-            {"published": False, "error": str(exc.detail)},
-            status_code=exc.status_code or 400,
+        return _publish_state(request, person, db, solution_id, error=str(exc.detail))
+    return _publish_state(request, person, db, solution_id)
+
+
+@router.post("/a/solution/{solution_id}/unpublish", response_class=HTMLResponse)
+def solution_unpublish(
+    request: Request,
+    solution_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Unpublish the solution; volunteers stop seeing its assignments."""
+    if _solution_owned(db, person, solution_id) is None:
+        return HTMLResponse(
+            '<div id="publish-state" class="empty">Solution not found.</div>',
+            status_code=404,
         )
-    return templates.TemplateResponse(
-        request, "partials/publish_state.html", {"published": True, "error": None}
-    )
+    try:
+        unpublish_solution(solution_id, request, person, db)
+    except HTTPException as exc:
+        return _publish_state(request, person, db, solution_id, error=str(exc.detail))
+    return _publish_state(request, person, db, solution_id)
+
+
+@router.post("/a/solution/{solution_id}/rollback", response_class=HTMLResponse)
+def solution_rollback(
+    request: Request,
+    solution_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Re-publish a previously-published solution, replacing the current
+    one (rejected with a friendly error if it was never published)."""
+    if _solution_owned(db, person, solution_id) is None:
+        return HTMLResponse(
+            '<div id="publish-state" class="empty">Solution not found.</div>',
+            status_code=404,
+        )
+    try:
+        rollback_solution(solution_id, request, person, db)
+    except HTTPException as exc:
+        return _publish_state(request, person, db, solution_id, error=str(exc.detail))
+    return _publish_state(request, person, db, solution_id)
 
 
 @router.post("/a/compare", response_class=HTMLResponse)

--- a/web/templates/admin/solution_review.html
+++ b/web/templates/admin/solution_review.html
@@ -42,6 +42,7 @@
     <div class="spacer-12"></div>
     {% set solution_id = review.id %}
     {% set published = review.is_published %}
+    {% set can_rollback = review.can_rollback %}
     {% set error = None %}
     {% include "partials/publish_state.html" %}
     <div class="spacer-12"></div>

--- a/web/templates/partials/publish_state.html
+++ b/web/templates/partials/publish_state.html
@@ -1,4 +1,4 @@
-{# Publish control / state for a solution. #publish-state. #}
+{# Publish / unpublish / rollback control for a solution. #publish-state. #}
 <div id="publish-state">
   {% if error %}
   <div class="form-error" role="alert">{{ error }}</div>
@@ -6,6 +6,13 @@
   <div class="form-notice" role="status">
     Published — volunteers now see these assignments on their schedule.
   </div>
+  <div class="spacer-12"></div>
+  <button class="btn btn-destructive" type="button"
+          hx-post="/a/solution/{{ solution_id }}/unpublish"
+          hx-target="#publish-state" hx-swap="outerHTML"
+          hx-confirm="Unpublish this solution? Volunteers will no longer see these assignments.">
+    Unpublish
+  </button>
   {% else %}
   <button class="btn btn-go" type="button"
           hx-post="/a/solution/{{ solution_id }}/publish"
@@ -13,5 +20,14 @@
           hx-confirm="Publish this solution? Any previously published solution in your org is replaced.">
     Publish this solution
   </button>
+  {% if can_rollback %}
+  <div class="spacer-12"></div>
+  <button class="btn btn-secondary" type="button"
+          hx-post="/a/solution/{{ solution_id }}/rollback"
+          hx-target="#publish-state" hx-swap="outerHTML"
+          hx-confirm="Roll back to this solution? It is re-published and any currently-published solution is replaced.">
+    Roll back to this version
+  </button>
+  {% endif %}
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary

Solution Review now offers **Unpublish** (when published) and **Roll back to this version** (when previously published but not current), alongside **Publish**, via `api.routers.solutions.unpublish_solution` / `rollback_solution`. `_solution_review` computes `can_rollback` from the org-scoped audit trail. Shared `_publish_state` helper re-renders from live state and always carries `solution_id`.

Part of the full-feature marathon (#145).

## Test plan
- [x] black/ruff clean; tests/web/test_publish_lifecycle.py (5) + test_publish_compare.py (8) = 13 passed
- [x] pytest tests/web tests/contract tests/unit/test_openapi_schema.py — 162 passed
- [x] Live Playwright e2e: publish→unpublish→rollback, screenshot verified

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)