### PR TITLE
P1.8 — web analytics drill-down

### DIFF
--- a/tests/web/test_analytics_page.py
+++ b/tests/web/test_analytics_page.py
@@ -1,0 +1,49 @@
+"""Marathon P1.8 — analytics drill-down page."""
+
+from __future__ import annotations
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_analytics_admin_only(client, db):
+    seed_person(db, person_id="an_vol", email="anvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "anvol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/analytics").status_code == 303
+    assert client.get("/a/analytics", cookies={SESSION_COOKIE: vtok}).status_code == 303
+
+    tok = _admin(client, db, org="an_o1", email="an1@web.test")
+    resp = client.get("/a/analytics", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert "Analytics" in resp.text
+    assert "Participation" in resp.text
+    assert "Schedule health" in resp.text
+    assert "Burnout risk" in resp.text
+
+
+def test_analytics_filters_applied_and_clamped(client, db):
+    tok = _admin(client, db, org="an_o2", email="an2@web.test")
+    ok = client.get("/a/analytics?days=7&threshold=2", cookies={SESSION_COOKIE: tok})
+    assert ok.status_code == 200
+    assert "last 7 days" in ok.text
+    assert "≥ 2 in 30 days" in ok.text
+
+    # Out-of-range values fall back to defaults (30 / 4).
+    clamped = client.get("/a/analytics?days=9999&threshold=0", cookies={SESSION_COOKIE: tok})
+    assert clamped.status_code == 200
+    assert "last 30 days" in clamped.text
+    assert "≥ 4 in 30 days" in clamped.text
+
+
+def test_dashboard_links_to_analytics(client, db):
+    tok = _admin(client, db, org="an_o3", email="an3@web.test")
+    dash = client.get("/a/dashboard", cookies={SESSION_COOKIE: tok})
+    assert dash.status_code == 200
+    assert 'href="/a/analytics"' in dash.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -552,6 +552,44 @@ def admin_teams(
     )
 
 
+def _analytics(db: Session, org_id: str, days: int, threshold: int) -> dict:
+    """Deep analytics — the three API endpoints with explicit args
+    (their Query() defaults don't resolve on a direct call)."""
+    from api.routers.analytics import (
+        get_burnout_risk,
+        get_schedule_health,
+        get_volunteer_stats,
+    )
+
+    vs = get_volunteer_stats(org_id, db, days=days)
+    sh = get_schedule_health(org_id, db)
+    br = get_burnout_risk(org_id, db, threshold=threshold)
+    return {"days": days, "threshold": threshold, "participation": vs, "health": sh, "burnout": br}
+
+
+@router.get("/a/analytics", response_class=HTMLResponse)
+def admin_analytics(
+    request: Request,
+    days: int = 30,
+    threshold: int = 4,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    days = days if 1 <= days <= 365 else 30
+    threshold = threshold if 1 <= threshold <= 50 else 4
+    return templates.TemplateResponse(
+        request,
+        "admin/analytics.html",
+        {
+            "person": person,
+            "active_tab": "dashboard",
+            "a": _analytics(db, person.org_id, days, threshold),
+        },
+    )
+
+
 @router.get("/a/people", response_class=HTMLResponse)
 def admin_people(
     request: Request,

--- a/web/templates/admin/analytics.html
+++ b/web/templates/admin/analytics.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}Analytics · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/dashboard">‹ Dashboard</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Analytics</div>
+<div class="scroll">
+  <form method="get" action="/a/analytics">
+    <div class="btn-row cols-2">
+      <div class="field" style="margin:0">
+        <label class="field-label" for="an_days">Window (days)</label>
+        <input id="an_days" name="days" type="number" min="1" max="365"
+               value="{{ a.days }}">
+      </div>
+      <div class="field" style="margin:0">
+        <label class="field-label" for="an_thr">Burnout threshold</label>
+        <input id="an_thr" name="threshold" type="number" min="1" max="50"
+               value="{{ a.threshold }}">
+      </div>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-secondary" type="submit">Apply filters</button>
+  </form>
+
+  <div class="mono-label" style="margin-top:18px">
+    Participation · last {{ a.participation.period_days }} days
+  </div>
+  <div class="kpi-grid">
+    <div class="kpi">
+      <div class="kpi-value">{{ a.participation.active_volunteers }}<span class="unit">/ {{ a.participation.total_volunteers }}</span></div>
+      <div class="kpi-label">Active volunteers</div>
+    </div>
+    <div class="kpi accent">
+      <div class="kpi-value">{{ a.participation.participation_rate }}<span class="unit">%</span></div>
+      <div class="kpi-label">Participation</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-value">{{ a.participation.total_assignments }}</div>
+      <div class="kpi-label">Assignments</div>
+    </div>
+  </div>
+  <div class="mono-label">Top volunteers</div>
+  {% if not a.participation.top_volunteers %}
+  <div class="empty">No assignments in this window.</div>
+  {% else %}
+  <div class="group">
+    {% for v in a.participation.top_volunteers %}
+    <div class="row">
+      <div class="row-main"><div class="row-title">{{ v.name }}</div></div>
+      <span class="mono-data">{{ v.assignments }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="mono-label" style="margin-top:18px">Schedule health</div>
+  <div class="kpi-grid">
+    <div class="kpi">
+      <div class="kpi-value">{{ a.health.upcoming_events }}</div>
+      <div class="kpi-label">Upcoming events</div>
+    </div>
+    <div class="kpi accent">
+      <div class="kpi-value">{{ a.health.coverage_rate }}<span class="unit">%</span></div>
+      <div class="kpi-label">Coverage</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-value">{{ a.health.events_with_assignments }}</div>
+      <div class="kpi-label">Events staffed</div>
+    </div>
+  </div>
+  {% if a.health.latest_solution %}
+  <a class="btn btn-secondary"
+     href="/a/solution/{{ a.health.latest_solution.id }}">
+    Latest solution · health {{ a.health.latest_solution.health_score|round|int }}
+  </a>
+  {% endif %}
+
+  <div class="mono-label" style="margin-top:18px">
+    Burnout risk · ≥ {{ a.burnout.threshold }} in 30 days
+  </div>
+  {% if a.burnout.at_risk_count == 0 %}
+  <div class="card">
+    <div class="row-sub">No volunteers over the threshold. 🎉</div>
+  </div>
+  {% else %}
+  <div class="group">
+    {% for v in a.burnout.at_risk_volunteers %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ v.name }}</div>
+        <div class="row-sub">{{ v.email or '—' }}</div>
+      </div>
+      <span class="mono-data">{{ v.assignments_last_30_days }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -31,6 +31,9 @@
   </div>
 
   <div class="spacer-12"></div>
+  <a class="btn btn-secondary" href="/a/analytics">View detailed analytics →</a>
+
+  <div class="spacer-12"></div>
   <div class="card">
     <div class="field-label">Burnout watch</div>
     <div class="spacer-12" style="height:4px"></div>


### PR DESCRIPTION
## Summary

Admin **`/a/analytics`**: a detail page combining **participation** (volunteer-stats), **schedule health**, and **burnout risk** from `api.routers.analytics`, with day-window + burnout-threshold filters (passed explicitly so the API `Query()` defaults resolve on a direct call; clamped to sane ranges). Linked from the dashboard ("View detailed analytics →"). Read-only GET page.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_analytics_page.py` — 3 cases (admin/auth gating + sections, filter applied + clamped, dashboard link)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 165 passed
- [x] Live Playwright e2e: dashboard → analytics → change filters → Apply; graceful empty states; no JS errors; screenshot visually verified

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)