### PR TITLE
P1.9 — web recurring-events series UI

### DIFF
--- a/tests/web/test_recurring.py
+++ b/tests/web/test_recurring.py
@@ -1,0 +1,102 @@
+"""Marathon P1.9 — recurring-events series UI."""
+
+from __future__ import annotations
+
+from api.models import RecurringSeries
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+WEEKLY = {
+    "title": "Sunday Service",
+    "duration": "60",
+    "location": "",
+    "pattern_type": "weekly",
+    "selected_days": ["sunday"],
+    "start_date": "2026-06-07",
+    "start_time": "10:00",
+    "end_condition_type": "count",
+    "occurrence_count": "8",
+    "role_name": "",
+    "role_count": "",
+}
+
+
+def test_recurring_admin_only(client, db):
+    seed_person(db, person_id="rc_vol", email="rcvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "rcvol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/recurring").status_code == 303
+    assert client.get("/a/recurring", cookies={SESSION_COOKIE: vtok}).status_code == 303
+
+    tok = _admin(client, db, org="rc_o1", email="rc1@web.test")
+    resp = client.get("/a/recurring", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert 'id="recurring-list"' in resp.text
+    assert "New series" in resp.text
+
+
+def test_create_weekly_series(client, db):
+    tok = _admin(client, db, org="rc_o2", email="rc2@web.test")
+    r = client.post("/a/recurring/create", data=WEEKLY, cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200, r.text
+    assert "Sunday Service" in r.text
+    s = db.query(RecurringSeries).filter(RecurringSeries.org_id == "rc_o2").first()
+    assert s is not None
+    assert s.pattern_type == "weekly"
+    assert s.selected_days == ["sunday"]
+
+
+def test_create_validation(client, db):
+    tok = _admin(client, db, org="rc_o3", email="rc3@web.test")
+    no_title = client.post(
+        "/a/recurring/create",
+        data={**WEEKLY, "title": "  "},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert no_title.status_code == 400
+    assert "title is required" in no_title.text.lower()
+
+    bad_date = client.post(
+        "/a/recurring/create",
+        data={**WEEKLY, "start_date": "not-a-date"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert bad_date.status_code == 400
+
+
+def test_create_monthly_and_delete(client, db):
+    tok = _admin(client, db, org="rc_o4", email="rc4@web.test")
+    monthly = {
+        "title": "First Sunday Potluck",
+        "duration": "90",
+        "location": "Hall",
+        "pattern_type": "monthly",
+        "weekday_position": "first",
+        "weekday_name": "sunday",
+        "start_date": "2026-06-07",
+        "start_time": "12:00",
+        "end_condition_type": "count",
+        "occurrence_count": "6",
+        "role_name": "",
+        "role_count": "",
+    }
+    r = client.post("/a/recurring/create", data=monthly, cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    s = db.query(RecurringSeries).filter(RecurringSeries.org_id == "rc_o4").first()
+    assert s.pattern_type == "monthly" and s.weekday_position == "first"
+
+    d = client.post(f"/a/recurring/{s.id}/delete", cookies={SESSION_COOKIE: tok})
+    assert d.status_code == 200
+    assert (
+        db.query(RecurringSeries)
+        .filter(RecurringSeries.id == s.id, RecurringSeries.active.is_(True))
+        .first()
+        is None
+    )

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -16,6 +16,7 @@ from api.models import (
     Event,
     Notification,
     Person,
+    RecurringSeries,
     Team,
     TeamMember,
 )
@@ -651,6 +652,63 @@ def _events(db: Session, org_id: str) -> dict:
         (upcoming if e.start_time and e.start_time >= now else past).append(item)
     past.reverse()  # most-recent past first
     return {"upcoming": upcoming, "past": past}
+
+
+def _recurring(db: Session, org_id: str) -> list[dict]:
+    """Active recurring series for the org (direct org-scoped query)."""
+    rows = (
+        db.query(RecurringSeries)
+        .filter(RecurringSeries.org_id == org_id, RecurringSeries.active.is_(True))
+        .order_by(RecurringSeries.created_at.desc())
+        .all()
+    )
+    out = []
+    for s in rows:
+        if s.pattern_type in ("weekly", "biweekly") and s.selected_days:
+            when = ", ".join(d.title()[:3] for d in s.selected_days)
+        elif s.pattern_type == "monthly" and s.weekday_position and s.weekday_name:
+            when = f"{s.weekday_position} {s.weekday_name.title()}"
+        elif s.pattern_type == "custom" and s.frequency_interval:
+            when = f"every {s.frequency_interval} wk"
+        else:
+            when = ""
+        if s.end_condition_type == "date" and s.end_date:
+            ends = f"until {s.end_date.isoformat()}"
+        elif s.end_condition_type == "count" and s.occurrence_count:
+            ends = f"{s.occurrence_count}×"
+        else:
+            ends = "ongoing"
+        out.append(
+            {
+                "id": s.id,
+                "title": s.title,
+                "pattern": s.pattern_type,
+                "when": when,
+                "ends": ends,
+                "from": s.start_date.isoformat() if s.start_date else "",
+            }
+        )
+    return out
+
+
+@router.get("/a/recurring", response_class=HTMLResponse)
+def admin_recurring(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/recurring.html",
+        {
+            "person": person,
+            "active_tab": "events",
+            "series": _recurring(db, person.org_id),
+            "error": None,
+        },
+    )
 
 
 @router.get("/a/events", response_class=HTMLResponse)

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from api.database import get_db
@@ -39,6 +40,11 @@ from api.routers.events import AssignmentRequest, create_event, delete_event, ma
 from api.routers.invitations import create_invitation
 from api.routers.organizations import get_organization, update_organization
 from api.routers.people import update_current_person
+from api.routers.recurring_events import (
+    RecurringSeriesCreate,
+    create_recurring_series,
+    delete_recurring_series,
+)
 from api.routers.solutions import (
     compare_solutions,
     publish_solution,
@@ -81,6 +87,7 @@ from web.routers.pages import (
     _my_exceptions,
     _my_rrule,
     _my_timeoff,
+    _recurring,
     _solution_owned,
     _solution_review,
     _teams,
@@ -820,6 +827,101 @@ def event_assignment_remove(
     except HTTPException:
         pass  # already gone — return a fresh, correct list
     return _event_assignments_partial(request, person, db, event_id)
+
+
+# ── Admin: recurring series ──────────────────────────────────────────
+
+
+def _recurring_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/recurring_list.html",
+        {"series": _recurring(db, person.org_id), "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+@router.post("/a/recurring/create", response_class=HTMLResponse)
+def recurring_create(
+    request: Request,
+    title: str = Form(""),
+    duration: int = Form(60),
+    location: str = Form(""),
+    pattern_type: str = Form("weekly"),
+    selected_days: list[str] = Form(default=[]),
+    weekday_position: str = Form(""),
+    weekday_name: str = Form(""),
+    frequency_interval: int = Form(0),
+    start_date: str = Form(""),
+    start_time: str = Form(""),
+    end_condition_type: str = Form("count"),
+    end_date: str = Form(""),
+    occurrence_count: int = Form(0),
+    role_name: list[str] = Form(default=[]),
+    role_count: list[str] = Form(default=[]),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from datetime import date as _date
+    from datetime import time as _time
+
+    if not title.strip():
+        return _recurring_list(request, person, db, error="Title is required.")
+
+    role_requirements: dict[str, int] = {}
+    for idx, raw in enumerate(role_name):
+        nm = raw.strip()
+        if not nm:
+            continue
+        try:
+            cnt = int(role_count[idx]) if idx < len(role_count) else 1
+        except (TypeError, ValueError):
+            continue
+        if cnt >= 1:
+            role_requirements[nm] = role_requirements.get(nm, 0) + cnt
+
+    try:
+        payload = RecurringSeriesCreate(
+            title=title.strip(),
+            duration=duration,
+            location=location.strip() or None,
+            role_requirements=role_requirements or None,
+            pattern_type=pattern_type,
+            frequency_interval=frequency_interval or None,
+            selected_days=[d for d in selected_days if d] or None,
+            weekday_position=weekday_position or None,
+            weekday_name=weekday_name or None,
+            start_date=_date.fromisoformat(start_date),
+            start_time=_time.fromisoformat(start_time),
+            end_condition_type=end_condition_type,
+            end_date=_date.fromisoformat(end_date) if end_date else None,
+            occurrence_count=occurrence_count or None,
+        )
+    except (ValidationError, ValueError):
+        return _recurring_list(
+            request, person, db, error="Check the pattern, dates, and end condition."
+        )
+    try:
+        create_recurring_series(payload, person.org_id, person, db)
+    except HTTPException as exc:
+        return _recurring_list(request, person, db, error=str(exc.detail))
+    return _recurring_list(request, person, db)
+
+
+@router.post("/a/recurring/{series_id}/delete", response_class=HTMLResponse)
+def recurring_delete(
+    request: Request,
+    series_id: str,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    try:
+        delete_recurring_series(series_id, person, db)
+    except HTTPException:
+        pass  # already gone — return a fresh, correct list
+    return _recurring_list(request, person, db)
 
 
 # ── Admin: constraints ───────────────────────────────────────────────

--- a/web/templates/admin/recurring.html
+++ b/web/templates/admin/recurring.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Events · SignUpFlow{% endblock %}
+{% block title %}Recurring series · SignUpFlow{% endblock %}
 {% block body %}
 <div class="nav">
-  <a class="nav-back" href="/a/recurring">Recurring ›</a>
+  <a class="nav-back" href="/a/events">‹ Events</a>
   <form method="post" action="/auth/logout" style="margin:0">
     <button class="nav-action" type="submit">Sign out</button>
   </form>
 </div>
-<div class="page-title">Events</div>
+<div class="page-title">Recurring</div>
 <div class="scroll">
-  {% include "partials/events_list.html" %}
+  {% include "partials/recurring_list.html" %}
 </div>
 {% set tabs = [
   ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),

--- a/web/templates/partials/recurring_list.html
+++ b/web/templates/partials/recurring_list.html
@@ -1,0 +1,144 @@
+{# Recurring series list + create/delete. #recurring-list. #}
+<div id="recurring-list" x-data="{ creating: false, pattern: 'weekly', endc: 'count' }">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  <button class="btn btn-primary" type="button"
+          x-show="!creating" @click="creating = true">New series</button>
+
+  <form x-show="creating" x-cloak
+        hx-post="/a/recurring/create"
+        hx-target="#recurring-list" hx-swap="outerHTML">
+    <div class="field">
+      <label class="field-label" for="rs_title">Title</label>
+      <input id="rs_title" name="title" type="text" required
+             placeholder="Sunday 10am Service">
+    </div>
+    <div class="field">
+      <label class="field-label" for="rs_dur">Duration (minutes)</label>
+      <input id="rs_dur" name="duration" type="number" min="1" value="60" required>
+    </div>
+    <div class="field">
+      <label class="field-label" for="rs_loc">Location</label>
+      <input id="rs_loc" name="location" type="text" placeholder="Optional">
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="rs_pat">Pattern</label>
+      <select id="rs_pat" name="pattern_type" x-model="pattern"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        <option value="weekly">weekly</option>
+        <option value="biweekly">biweekly</option>
+        <option value="monthly">monthly</option>
+        <option value="custom">custom</option>
+      </select>
+    </div>
+
+    <div class="field" x-show="pattern === 'weekly' || pattern === 'biweekly'">
+      <label class="field-label">Days</label>
+      {% for d in ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'] %}
+      <label style="display:flex;align-items:center;gap:10px;padding:4px 0;cursor:pointer">
+        <input type="checkbox" name="selected_days" value="{{ d }}">
+        <span class="row-title" style="font-size:14px;text-transform:capitalize">{{ d }}</span>
+      </label>
+      {% endfor %}
+    </div>
+
+    <template x-if="pattern === 'monthly'">
+      <div>
+        <div class="field">
+          <label class="field-label">Which week</label>
+          <select name="weekday_position"
+                  style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+            {% for p in ['first','second','third','fourth','last'] %}
+            <option value="{{ p }}">{{ p }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="field">
+          <label class="field-label">Weekday</label>
+          <select name="weekday_name"
+                  style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+            {% for d in ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'] %}
+            <option value="{{ d }}">{{ d }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    </template>
+
+    <div class="field" x-show="pattern === 'custom'">
+      <label class="field-label" for="rs_int">Every N weeks</label>
+      <input id="rs_int" name="frequency_interval" type="number" min="1" value="3">
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="rs_sd">Start date</label>
+      <input id="rs_sd" name="start_date" type="date" required>
+    </div>
+    <div class="field">
+      <label class="field-label" for="rs_st">Start time</label>
+      <input id="rs_st" name="start_time" type="time" required>
+    </div>
+
+    <div class="field">
+      <label class="field-label" for="rs_end">Ends</label>
+      <select id="rs_end" name="end_condition_type" x-model="endc"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        <option value="count">after N occurrences</option>
+        <option value="date">on a date</option>
+        <option value="indefinite">never (indefinite)</option>
+      </select>
+    </div>
+    <div class="field" x-show="endc === 'count'">
+      <label class="field-label" for="rs_oc">Occurrences</label>
+      <input id="rs_oc" name="occurrence_count" type="number" min="1" max="200" value="12">
+    </div>
+    <div class="field" x-show="endc === 'date'">
+      <label class="field-label" for="rs_ed">End date</label>
+      <input id="rs_ed" name="end_date" type="date">
+    </div>
+
+    <div class="field">
+      <label class="field-label">Role (optional)</label>
+      <div class="btn-row cols-2">
+        <input type="text" name="role_name" placeholder="volunteer">
+        <input type="number" name="role_count" min="1" placeholder="1">
+      </div>
+    </div>
+
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-secondary" type="button" @click="creating = false">Cancel</button>
+      <button class="btn btn-primary" type="submit">Create series</button>
+    </div>
+  </form>
+
+  <div class="mono-label" style="margin-top:18px">Series</div>
+  {% if not series %}
+  <div class="empty">No recurring series yet.</div>
+  {% else %}
+  <div class="group">
+    {% for s in series %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ s.title }}</div>
+        <div style="margin-top:4px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+          <span class="role-chip">{{ s.pattern }}</span>
+          {% if s.when %}<span class="row-sub">{{ s.when }}</span>{% endif %}
+        </div>
+        <div class="row-sub" style="margin-top:4px">from {{ s.from }} · {{ s.ends }}</div>
+      </div>
+      <button class="btn btn-destructive" style="width:auto;padding:6px 12px"
+              hx-post="/a/recurring/{{ s.id }}/delete"
+              hx-target="#recurring-list" hx-swap="outerHTML"
+              hx-confirm="Delete series '{{ s.title }}' and all its occurrences?">
+        Delete
+      </button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Admin **`/a/recurring`**: list + create + delete recurring event series over `api.routers.recurring_events`. The create form uses Alpine-driven conditional fields by pattern (weekly/biweekly day checkboxes, monthly position+weekday, custom interval) and end condition (count / date / indefinite), plus an optional role requirement. Pydantic / value errors surface as a friendly inline 400. Linked from the Events page top nav.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_recurring.py` — 4 cases (admin/auth gating, weekly create, validation 400s, monthly create + delete/deactivate)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 169 passed
- [x] Live Playwright e2e: Events→Recurring, create weekly series (conditional fields) → list → delete; no JS errors; screenshot visually verified

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)