### PR TITLE
P1.10 — web admin all-assignments + per-person view

### DIFF
--- a/tests/web/test_all_assignments.py
+++ b/tests/web/test_all_assignments.py
@@ -1,0 +1,75 @@
+"""Marathon P1.10 — admin all-assignments + per-person view."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _event(db, org, eid):
+    start = datetime(2026, 6, 7, 10, 0, 0)
+    db.add(
+        Event(
+            id=eid,
+            org_id=org,
+            type="Sunday Service",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+        )
+    )
+    db.commit()
+
+
+def _assign(db, eid, pid, role=None, solution_id=None):
+    a = Assignment(event_id=eid, person_id=pid, role=role, solution_id=solution_id)
+    db.add(a)
+    db.commit()
+
+
+def test_all_assignments_admin_only(client, db):
+    seed_person(db, person_id="aa_vol", email="aavol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "aavol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/assignments").status_code == 303
+    assert client.get("/a/assignments", cookies={SESSION_COOKIE: vtok}).status_code == 303
+
+    tok = _admin(client, db, org="aa_o1", email="aa1@web.test")
+    resp = client.get("/a/assignments", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert "Assignments" in resp.text
+    assert "No assignments" in resp.text  # empty org
+
+
+def test_lists_and_person_filter(client, db):
+    tok = _admin(client, db, org="aa_o2", email="aa2@web.test")
+    seed_person(db, person_id="aa_p1", org_id="aa_o2", email="p1@aa.test", roles=["volunteer"])
+    seed_person(db, person_id="aa_p2", org_id="aa_o2", email="p2@aa.test", roles=["volunteer"])
+    _event(db, "aa_o2", "aa_ev")
+    _assign(db, "aa_ev", "aa_p1", role="usher")  # manual
+    _assign(db, "aa_ev", "aa_p2", solution_id=None)
+
+    allv = client.get("/a/assignments", cookies={SESSION_COOKIE: tok})
+    assert allv.status_code == 200
+    assert "Sunday Service" in allv.text
+    assert "2 assignments" in allv.text
+    assert "manual" in allv.text
+
+    one = client.get("/a/assignments?person_id=aa_p1", cookies={SESSION_COOKIE: tok})
+    assert "1 assignment" in one.text
+    # Web User is the seeded name for both; ensure the filter narrowed the count.
+    assert "2 assignments" not in one.text
+
+
+def test_dashboard_links_to_assignments(client, db):
+    tok = _admin(client, db, org="aa_o3", email="aa3@web.test")
+    dash = client.get("/a/dashboard", cookies={SESSION_COOKIE: tok})
+    assert 'href="/a/assignments"' in dash.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -654,6 +654,60 @@ def _events(db: Session, org_id: str) -> dict:
     return {"upcoming": upcoming, "past": past}
 
 
+def _all_assignments(db: Session, org_id: str, person_id: str | None) -> dict:
+    """Org-wide assignments (Assignment ⋈ Event ⋈ Person), newest event
+    first, optionally filtered to one person. Org-scoped via the Event
+    join (mirrors api get_all_assignments)."""
+    q = (
+        db.query(Assignment, Event, Person)
+        .join(Event, Assignment.event_id == Event.id)
+        .join(Person, Assignment.person_id == Person.id)
+        .filter(Event.org_id == org_id)
+    )
+    if person_id:
+        q = q.filter(Assignment.person_id == person_id)
+    joined = q.order_by(Event.start_time.desc()).all()
+    out = [
+        {
+            "event_type": e.type,
+            "when": e.start_time.strftime("%a %d %b %Y · %H:%M") if e.start_time else "",
+            "person_id": p.id,
+            "person_name": p.name,
+            "role": a.role,
+            "status": (a.status or "pending").lower(),
+            "manual": a.solution_id is None,
+        }
+        for a, e, p in joined
+    ]
+    people = db.query(Person).filter(Person.org_id == org_id).order_by(Person.name.asc()).all()
+    return {
+        "rows": out,
+        "total": len(out),
+        "people": [{"id": p.id, "name": p.name} for p in people],
+        "person_id": person_id or "",
+    }
+
+
+@router.get("/a/assignments", response_class=HTMLResponse)
+def admin_all_assignments(
+    request: Request,
+    person_id: str | None = None,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/assignments.html",
+        {
+            "person": person,
+            "active_tab": "events",
+            "data": _all_assignments(db, person.org_id, person_id),
+        },
+    )
+
+
 def _recurring(db: Session, org_id: str) -> list[dict]:
     """Active recurring series for the org (direct org-scoped query)."""
     rows = (

--- a/web/templates/admin/assignments.html
+++ b/web/templates/admin/assignments.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Assignments · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/dashboard">‹ Dashboard</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Assignments</div>
+<div class="scroll">
+  <form method="get" action="/a/assignments">
+    <div class="field">
+      <label class="field-label" for="al_person">Filter by person</label>
+      <select id="al_person" name="person_id"
+              style="border:0;background:transparent;font-family:inherit;font-size:15px;color:var(--ink-1)">
+        <option value="">All people</option>
+        {% for p in data.people %}
+        <option value="{{ p.id }}"
+          {% if p.id == data.person_id %}selected{% endif %}>{{ p.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="spacer-12"></div>
+    <button class="btn btn-secondary" type="submit">Apply</button>
+  </form>
+
+  <div class="mono-label" style="margin-top:18px">
+    {{ data.total }} assignment{{ '' if data.total == 1 else 's' }}
+  </div>
+  {% if not data.rows %}
+  <div class="empty">No assignments{% if data.person_id %} for this person{% endif %}.</div>
+  {% else %}
+  <div class="group">
+    {% for r in data.rows %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">{{ r.event_type }}</div>
+        <div class="row-sub">{{ r.when }}</div>
+        <div style="margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+          <span class="role-chip">{{ r.person_name }}</span>
+          {% if r.role %}<span class="role-chip">{{ r.role }}</span>{% endif %}
+          <span class="role-chip">{{ 'manual' if r.manual else 'solver' }}</span>
+          <span class="status-text {{ r.status }}">{{ r.status }}</span>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -32,6 +32,8 @@
 
   <div class="spacer-12"></div>
   <a class="btn btn-secondary" href="/a/analytics">View detailed analytics →</a>
+  <div class="spacer-12"></div>
+  <a class="btn btn-secondary" href="/a/assignments">All assignments →</a>
 
   <div class="spacer-12"></div>
   <div class="card">


### PR DESCRIPTION
## Summary

Admin **`/a/assignments`**: org-wide assignment list (event, date, person, role, manual/solver badge, status) with an optional **per-person filter**, mirroring `api get_all_assignments` via an org-scoped `Assignment ⋈ Event ⋈ Person` query. Context list key is `rows` (not `items`) to avoid Jinja's `dict.items()` collision. Linked from the dashboard ("All assignments →").

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_all_assignments.py` — 3 cases (admin/auth gating + empty state, list + person filter + manual badge, dashboard link)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 172 passed
- [x] Live Playwright e2e: dashboard → all-assignments → seeded row visible → person filter; no JS errors; screenshot visually verified

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)