### PR TITLE
P1.11 — web swap-request review

### DIFF
--- a/tests/web/test_swaps.py
+++ b/tests/web/test_swaps.py
@@ -1,0 +1,85 @@
+"""Marathon P1.11 — swap-request review."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _seed_swap(db, org, *, status="swap_requested"):
+    seed_person(db, person_id=f"{org}_p", org_id=org, email=f"p@{org}.test", roles=["volunteer"])
+    start = datetime(2026, 6, 7, 10, 0, 0)
+    db.add(
+        Event(
+            id=f"{org}_ev",
+            org_id=org,
+            type="Sunday Service",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+        )
+    )
+    db.commit()
+    a = Assignment(event_id=f"{org}_ev", person_id=f"{org}_p", role="usher", status=status)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def test_swaps_admin_only(client, db):
+    seed_person(db, person_id="sw_vol", email="swvol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "swvol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert client.get("/a/swaps").status_code == 303
+    assert client.get("/a/swaps", cookies={SESSION_COOKIE: vtok}).status_code == 303
+
+    tok = _admin(client, db, org="sw_o1", email="sw1@web.test")
+    resp = client.get("/a/swaps", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert "Swap requests" in resp.text
+    assert "No swap requests" in resp.text  # none yet
+
+
+def test_only_swap_requested_listed(client, db):
+    tok = _admin(client, db, org="sw_o2", email="sw2@web.test")
+    _seed_swap(db, "sw_o2", status="confirmed")  # not a swap
+    resp = client.get("/a/swaps", cookies={SESSION_COOKIE: tok})
+    assert "No swap requests" in resp.text
+
+
+def test_deny_keeps_assignment(client, db):
+    tok = _admin(client, db, org="sw_o3", email="sw3@web.test")
+    a = _seed_swap(db, "sw_o3")
+    listed = client.get("/a/swaps", cookies={SESSION_COOKIE: tok})
+    assert "Sunday Service" in listed.text
+
+    r = client.post(f"/a/swaps/{a.id}/deny", cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    db.refresh(a)
+    assert a.status == "confirmed"
+    assert "No swap requests" in r.text  # no longer pending
+
+
+def test_approve_unassigns(client, db):
+    tok = _admin(client, db, org="sw_o4", email="sw4@web.test")
+    a = _seed_swap(db, "sw_o4")
+    aid = a.id
+    r = client.post(f"/a/swaps/{aid}/approve", cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    assert db.query(Assignment).filter(Assignment.id == aid).first() is None
+    assert "No swap requests" in r.text
+
+
+def test_dashboard_links_to_swaps(client, db):
+    tok = _admin(client, db, org="sw_o5", email="sw5@web.test")
+    dash = client.get("/a/dashboard", cookies={SESSION_COOKIE: tok})
+    assert 'href="/a/swaps"' in dash.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -654,6 +654,51 @@ def _events(db: Session, org_id: str) -> dict:
     return {"upcoming": upcoming, "past": past}
 
 
+def _swap_requests(db: Session, org_id: str) -> list[dict]:
+    """Assignments the volunteer flagged for swap, org-scoped via the
+    Event join."""
+    rows = (
+        db.query(Assignment, Event, Person)
+        .join(Event, Assignment.event_id == Event.id)
+        .join(Person, Assignment.person_id == Person.id)
+        .filter(Event.org_id == org_id, Assignment.status == "swap_requested")
+        .order_by(Event.start_time.asc())
+        .all()
+    )
+    return [
+        {
+            "assignment_id": a.id,
+            "event_id": a.event_id,
+            "event_type": e.type,
+            "when": e.start_time.strftime("%a %d %b %Y · %H:%M") if e.start_time else "",
+            "person_id": p.id,
+            "person_name": p.name,
+            "role": a.role,
+        }
+        for a, e, p in rows
+    ]
+
+
+@router.get("/a/swaps", response_class=HTMLResponse)
+def admin_swaps(
+    request: Request,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "admin/swaps.html",
+        {
+            "person": person,
+            "active_tab": "events",
+            "swaps": _swap_requests(db, person.org_id),
+            "error": None,
+        },
+    )
+
+
 def _all_assignments(db: Session, org_id: str, person_id: str | None) -> dict:
     """Org-wide assignments (Assignment ⋈ Event ⋈ Person), newest event
     first, optionally filtered to one person. Org-scoped via the Event

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from api.database import get_db
-from api.models import EmailPreference, Notification, Person
+from api.models import Assignment, EmailPreference, Event, Notification, Person
 from api.routers.assignments import (
     accept_assignment,
     decline_assignment,
@@ -90,6 +90,7 @@ from web.routers.pages import (
     _recurring,
     _solution_owned,
     _solution_review,
+    _swap_requests,
     _teams,
 )
 
@@ -827,6 +828,75 @@ def event_assignment_remove(
     except HTTPException:
         pass  # already gone — return a fresh, correct list
     return _event_assignments_partial(request, person, db, event_id)
+
+
+# ── Admin: swap-request review ───────────────────────────────────────
+
+
+def _swaps_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/swaps_list.html",
+        {"swaps": _swap_requests(db, person.org_id), "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+def _owned_swap(db: Session, person: Person, assignment_id: int):
+    """The swap-requested assignment in the admin's org, or None."""
+    return (
+        db.query(Assignment)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(
+            Event.org_id == person.org_id,
+            Assignment.id == assignment_id,
+            Assignment.status == "swap_requested",
+        )
+        .first()
+    )
+
+
+@router.post("/a/swaps/{assignment_id}/approve", response_class=HTMLResponse)
+def swap_approve(
+    request: Request,
+    assignment_id: int,
+    background_tasks: BackgroundTasks,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Approve the swap = unassign the volunteer (frees the slot). Reuses
+    manage_assignment so the solution-stream publish still fires."""
+    a = _owned_swap(db, person, assignment_id)
+    if a is None:
+        return _swaps_list(request, person, db)
+    try:
+        manage_assignment(
+            a.event_id,
+            AssignmentRequest(person_id=a.person_id, action="unassign"),
+            background_tasks,
+            person,
+            db,
+        )
+    except HTTPException as exc:
+        return _swaps_list(request, person, db, error=str(exc.detail))
+    return _swaps_list(request, person, db)
+
+
+@router.post("/a/swaps/{assignment_id}/deny", response_class=HTMLResponse)
+def swap_deny(
+    request: Request,
+    assignment_id: int,
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Deny the swap = keep the volunteer on; reset status to confirmed."""
+    a = _owned_swap(db, person, assignment_id)
+    if a is not None:
+        a.status = "confirmed"
+        db.commit()
+    return _swaps_list(request, person, db)
 
 
 # ── Admin: recurring series ──────────────────────────────────────────

--- a/web/templates/admin/dashboard.html
+++ b/web/templates/admin/dashboard.html
@@ -34,6 +34,8 @@
   <a class="btn btn-secondary" href="/a/analytics">View detailed analytics →</a>
   <div class="spacer-12"></div>
   <a class="btn btn-secondary" href="/a/assignments">All assignments →</a>
+  <div class="spacer-12"></div>
+  <a class="btn btn-secondary" href="/a/swaps">Swap requests →</a>
 
   <div class="spacer-12"></div>
   <div class="card">

--- a/web/templates/admin/swaps.html
+++ b/web/templates/admin/swaps.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Swap requests · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/a/dashboard">‹ Dashboard</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Swap requests</div>
+<div class="scroll">
+  {% include "partials/swaps_list.html" %}
+</div>
+{% set tabs = [
+  ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),
+  ('/a/people', '◔', 'People', 'people'),
+  ('/a/events', '▤', 'Events', 'events'),
+  ('/a/solver', '◈', 'Solver', 'solver'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/partials/swaps_list.html
+++ b/web/templates/partials/swaps_list.html
@@ -1,0 +1,37 @@
+{# Pending swap requests. #swaps-list so HTMX swaps it after a decision. #}
+<div id="swaps-list">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  {% if not swaps %}
+  <div class="empty">No swap requests. 🎉</div>
+  {% else %}
+  {% for s in swaps %}
+  <div class="card" style="margin-bottom:12px">
+    <div class="row-title">{{ s.event_type }}</div>
+    <div class="row-sub">{{ s.when }}</div>
+    <div style="margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+      <span class="role-chip">{{ s.person_name }}</span>
+      {% if s.role %}<span class="role-chip">{{ s.role }}</span>{% endif %}
+      <span class="status-text swap_requested">swap requested</span>
+    </div>
+    <div class="spacer-12"></div>
+    <div class="btn-row cols-2">
+      <button class="btn btn-go" type="button"
+              hx-post="/a/swaps/{{ s.assignment_id }}/approve"
+              hx-target="#swaps-list" hx-swap="outerHTML"
+              hx-confirm="Approve the swap? {{ s.person_name }} is removed from this shift so you can reassign it.">
+        Approve (unassign)
+      </button>
+      <button class="btn btn-secondary" type="button"
+              hx-post="/a/swaps/{{ s.assignment_id }}/deny"
+              hx-target="#swaps-list" hx-swap="outerHTML">
+        Deny (keep)
+      </button>
+    </div>
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Admin **`/a/swaps`** lists assignments in the `swap_requested` state (org-scoped via the Event join). **Approve** = unassign the volunteer (reuses `manage_assignment` so the solution SSE publish still fires, frees the slot for reassignment); **Deny** = reset the status to `confirmed` (volunteer stays on). No admin swap-approval API exists in the backend ("follow up out of band"), so the decisions are org-scoped web-layer actions. Linked from the dashboard.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_swaps.py` — 5 cases (admin/auth gating + empty, only swap_requested listed, deny→confirmed, approve→unassigned, dashboard link)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 177 passed
- [x] Live Playwright e2e: dashboard → swap requests → pending card → deny; no JS errors; screenshot visually verified

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)