### PR TITLE
P1.12 — web CSV people import

### DIFF
--- a/tests/web/test_csv_import.py
+++ b/tests/web/test_csv_import.py
@@ -1,0 +1,85 @@
+"""Marathon P1.12 — CSV people import."""
+
+from __future__ import annotations
+
+from api.models import Person
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _count(db, org):
+    return db.query(Person).filter(Person.org_id == org).count()
+
+
+def test_import_admin_only(client, db):
+    seed_person(db, person_id="ci_vol", email="civol@web.test", roles=["volunteer"])
+    login = client.post("/auth/login", data={"email": "civol@web.test", "password": "WebPass123!"})
+    vtok = login.cookies[SESSION_COOKIE]
+    assert (
+        client.post("/a/people/import", data={"csv_text": "A,a@x.io,volunteer"}).status_code == 303
+    )
+    assert (
+        client.post(
+            "/a/people/import",
+            data={"csv_text": "A,a@x.io,volunteer"},
+            cookies={SESSION_COOKIE: vtok},
+        ).status_code
+        == 303
+    )
+
+
+def test_import_creates_people(client, db):
+    tok = _admin(client, db, org="ci_o1", email="ci1@web.test")
+    before = _count(db, "ci_o1")
+    csv = (
+        "name,email,roles\n"
+        "Jamie Park,jamie@hopechapel.org,volunteer;usher\n"
+        "Sam Lee,sam@hopechapel.org,volunteer\n"
+    )
+    r = client.post("/a/people/import", data={"csv_text": csv}, cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    assert "Imported 2" in r.text
+    assert _count(db, "ci_o1") == before + 2
+    jamie = (
+        db.query(Person)
+        .filter(Person.org_id == "ci_o1", Person.email == "jamie@hopechapel.org")
+        .first()
+    )
+    assert jamie is not None
+    assert set(jamie.roles) == {"volunteer", "usher"}
+
+
+def test_import_validation(client, db):
+    tok = _admin(client, db, org="ci_o2", email="ci2@web.test")
+    empty = client.post("/a/people/import", data={"csv_text": "   "}, cookies={SESSION_COOKIE: tok})
+    assert empty.status_code == 400
+    assert "at least one" in empty.text.lower()
+
+    header_only = client.post(
+        "/a/people/import",
+        data={"csv_text": "name,email,roles"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert header_only.status_code == 400
+    assert "no data rows" in header_only.text.lower()
+
+
+def test_import_reports_row_errors(client, db):
+    tok = _admin(client, db, org="ci_o3", email="ci3@web.test")
+    csv = "Good Person,good@hopechapel.org,volunteer\nBad Person,not-an-email,volunteer\n"
+    r = client.post("/a/people/import", data={"csv_text": csv}, cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 200
+    assert "Imported 1" in r.text
+    assert "error" in r.text.lower()  # the bad-email row is reported
+
+
+def test_people_page_has_import_button(client, db):
+    tok = _admin(client, db, org="ci_o4", email="ci4@web.test")
+    page = client.get("/a/people", cookies={SESSION_COOKIE: tok})
+    assert "Import CSV" in page.text

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -39,7 +39,7 @@ from api.routers.constraints import (
 from api.routers.events import AssignmentRequest, create_event, delete_event, manage_assignment
 from api.routers.invitations import create_invitation
 from api.routers.organizations import get_organization, update_organization
-from api.routers.people import update_current_person
+from api.routers.people import bulk_import_people, update_current_person
 from api.routers.recurring_events import (
     RecurringSeriesCreate,
     create_recurring_series,
@@ -373,6 +373,73 @@ def people_invite(
     except HTTPException as exc:
         return _result(False, str(exc.detail), exc.status_code or 400)
     return _result(True, f"Invitation sent to {email}.")
+
+
+@router.post("/a/people/import", response_class=HTMLResponse)
+def people_import(
+    request: Request,
+    csv_text: str = Form(""),
+    person: Person = Depends(get_session_admin),
+    db: Session = Depends(get_db),
+):
+    """Bulk-import people from pasted CSV (name,email,roles). Each row
+    becomes a PersonCreate; reuses the API bulk_import_people so the
+    same validation, dedupe, and caps apply."""
+    import csv
+    import io
+    import uuid
+
+    from web.app import templates
+    from web.auth import _slugify
+
+    def _render(*, result=None, error=None):
+        return templates.TemplateResponse(
+            request,
+            "partials/import_result.html",
+            {"result": result, "error": error},
+            status_code=400 if error else 200,
+        )
+
+    text = csv_text.strip()
+    if not text:
+        return _render(error="Paste at least one CSV row (name,email,roles).")
+
+    items = []
+    reader = csv.reader(io.StringIO(text))
+    for row in reader:
+        cells = [c.strip() for c in row]
+        if not cells or not cells[0]:
+            continue
+        if cells[0].lower() == "name":  # header row
+            continue
+        name = cells[0]
+        email = cells[1] if len(cells) > 1 and cells[1] else None
+        roles_raw = cells[2] if len(cells) > 2 and cells[2] else ""
+        roles = [r.strip() for r in roles_raw.replace("|", ";").split(";") if r.strip()]
+        items.append(
+            {
+                "id": f"{_slugify(name)}-{uuid.uuid4().hex[:8]}",
+                "org_id": person.org_id,
+                "name": name,
+                "email": email,
+                "roles": roles or ["volunteer"],
+            }
+        )
+
+    if not items:
+        return _render(error="No data rows found (a header line alone isn't enough).")
+
+    try:
+        resp = bulk_import_people(request, {"items": items}, person.org_id, person, db)
+    except HTTPException as exc:
+        return _render(error=str(exc.detail))
+    return _render(
+        result={
+            "created": resp.created,
+            "skipped": resp.skipped,
+            "errors": [{"index": e.index, "reason": e.reason} for e in resp.errors],
+        }
+    )
 
 
 # ── Admin: organization settings ─────────────────────────────────────

--- a/web/templates/admin/people.html
+++ b/web/templates/admin/people.html
@@ -8,11 +8,36 @@
   </form>
 </div>
 <div class="page-title">People</div>
-<div class="scroll" x-data="{ inviting: false }">
-  <button class="btn btn-primary" type="button"
-          x-show="!inviting" @click="inviting = true">
-    Invite person
-  </button>
+<div class="scroll" x-data="{ inviting: false, importing: false }">
+  <div class="btn-row cols-2" x-show="!inviting && !importing">
+    <button class="btn btn-primary" type="button"
+            @click="inviting = true">Invite person</button>
+    <button class="btn btn-secondary" type="button"
+            @click="importing = true">Import CSV</button>
+  </div>
+
+  <div x-show="importing" x-cloak>
+    <div id="import-result"></div>
+    <form hx-post="/a/people/import"
+          hx-target="#import-result" hx-swap="outerHTML">
+      <div class="field">
+        <label class="field-label" for="csv_text">
+          CSV rows — <code>name,email,roles</code> (roles ;-separated)
+        </label>
+        <textarea id="csv_text" name="csv_text" rows="6"
+                  style="width:100%;font-family:inherit;font-size:14px"
+                  placeholder="Jamie Park,jamie@church.org,volunteer;usher
+Sam Lee,sam@church.org,volunteer"></textarea>
+      </div>
+      <div class="spacer-12"></div>
+      <div class="btn-row cols-2">
+        <button class="btn btn-secondary" type="button"
+                @click="importing = false">Done</button>
+        <button class="btn btn-primary" type="submit">Import</button>
+      </div>
+    </form>
+    <div class="spacer-18"></div>
+  </div>
 
   <div x-show="inviting" x-cloak>
     <div id="invite-result"></div>

--- a/web/templates/partials/import_result.html
+++ b/web/templates/partials/import_result.html
@@ -1,0 +1,24 @@
+{# CSV import outcome. #import-result so HTMX swaps it after submit. #}
+<div id="import-result">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  {% elif result %}
+  <div class="form-notice" role="status">
+    Imported {{ result.created }} · skipped {{ result.skipped }}
+    (duplicates){% if result.errors %} · {{ result.errors|length }} error(s){% endif %}.
+  </div>
+  {% if result.errors %}
+  <div class="spacer-12"></div>
+  <div class="group">
+    {% for e in result.errors %}
+    <div class="row">
+      <div class="row-main">
+        <div class="row-title">Row {{ e.index + 1 }}</div>
+        <div class="row-sub">{{ e.reason }}</div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

The People page gains an **Import CSV** panel: paste `name,email,roles` rows; each becomes a `PersonCreate` (unique slug id, org-scoped, roles `;`-separated) and is sent to `api.routers.people.bulk_import_people`, which applies the same validation, dedupe, and item cap. A result partial shows **created / skipped / per-row errors**.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_csv_import.py` — 5 cases (admin/auth gating, creates people + role parse, empty/header-only 400s, per-row error reporting, page has button)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 182 passed
- [x] Live Playwright e2e: People → Import CSV → paste 2 rows → "Imported 2" → reload shows them; no JS errors; screenshot visually verified

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)