### PR TITLE
P2.15 — email (Mailtrap sandbox) status surface

### DIFF
--- a/tests/web/test_email_status.py
+++ b/tests/web/test_email_status.py
@@ -1,0 +1,34 @@
+"""Marathon P2.15 — email-delivery status on the settings page."""
+
+from __future__ import annotations
+
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _admin(client, db, *, org, email):
+    seed_person(db, person_id=f"{org}_adm", org_id=org, email=email, roles=["admin"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_email_section_disabled_by_default(client, db):
+    tok = _admin(client, db, org="em_o1", email="em1@web.test")
+    resp = client.get("/a/settings", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert "Email delivery" in resp.text
+    # TESTING=true globally → email gate off → guidance shown.
+    assert "EMAIL_ENABLED" in resp.text
+    assert "disabled" in resp.text
+
+
+def test_email_section_enabled_with_smtp(client, db, monkeypatch):
+    tok = _admin(client, db, org="em_o2", email="em2@web.test")
+    monkeypatch.setenv("TESTING", "")
+    monkeypatch.setenv("EMAIL_ENABLED", "true")
+    monkeypatch.setenv("MAILTRAP_SMTP_USER", "sandbox-user")
+    monkeypatch.setenv("MAILTRAP_SMTP_PASSWORD", "sandbox-pass")
+    resp = client.get("/a/settings", cookies={SESSION_COOKIE: tok})
+    assert resp.status_code == 200
+    assert "SMTP / Mailtrap" in resp.text
+    assert "Sending as" in resp.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -415,6 +415,26 @@ def _org_settings(db: Session, org_id: str) -> dict:
     }
 
 
+def _email_status() -> dict:
+    """Non-secret email-delivery config for the settings page. Reflects
+    the same gate the password-reset / invitation senders use."""
+    from api.services.email_service import EmailService
+
+    svc = EmailService()
+    if not svc.enabled:
+        backend = "disabled"
+    elif svc.use_sendgrid:
+        backend = "SendGrid"
+    else:
+        backend = "SMTP / Mailtrap"
+    return {
+        "enabled": svc.enabled,
+        "backend": backend,
+        "host": None if svc.use_sendgrid else svc.smtp_host,
+        "from_email": svc.from_email,
+    }
+
+
 @router.get("/a/settings", response_class=HTMLResponse)
 def admin_settings(
     request: Request,
@@ -434,6 +454,7 @@ def admin_settings(
             "saved": False,
             "profile": _account_ctx(person),
             "pw": {"error": None, "saved": False},
+            "email": _email_status(),
         },
     )
 

--- a/web/templates/admin/settings.html
+++ b/web/templates/admin/settings.html
@@ -17,6 +17,29 @@
 
   <div class="mono-label">Security</div>
   {% include "partials/password_form.html" %}
+
+  <div class="mono-label">Email delivery</div>
+  <div class="card">
+    <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+      <div class="row-title">Transactional email</div>
+      <span class="status-text {{ 'confirmed' if email.enabled else 'pending' }}">
+        {{ email.backend }}
+      </span>
+    </div>
+    {% if email.enabled %}
+    <div class="row-sub" style="margin-top:4px">
+      Sending as {{ email.from_email }}{% if email.host %} via {{ email.host }}{% endif %}.
+      Password-reset &amp; invitation emails are delivered.
+    </div>
+    {% else %}
+    <div class="row-sub" style="margin-top:4px">
+      Password-reset &amp; invitation emails are wired but not sent. For a
+      sandbox, set <code>EMAIL_ENABLED=true</code> and the
+      <code>MAILTRAP_SMTP_USER</code> / <code>MAILTRAP_SMTP_PASSWORD</code>
+      env vars (or <code>SENDGRID_API_KEY</code> for production).
+    </div>
+    {% endif %}
+  </div>
 </div>
 {% set tabs = [
   ('/a/dashboard', '▣', 'Dashboard', 'dashboard'),


### PR DESCRIPTION
## Summary

Password-reset & invitation emails **already dispatch** via the `email_service` singleton (Mailtrap SMTP defaults, `EMAIL_ENABLED` gate, graceful no-op when off — calls already wired in `password_reset.py` / `invitations.py`). This PR adds an admin-visible **"Email delivery"** section on the settings page: enabled state, backend (SMTP/Mailtrap vs SendGrid vs disabled), from-address, and sandbox setup guidance. No secrets shown; CI-safe (the global `TESTING` gate keeps it `disabled` in tests).

Sandbox rule honored — nothing blocks on real creds; the page transparently states how to enable Mailtrap.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_email_status.py` (2) — disabled-by-default guidance; SMTP/Mailtrap shown when env enabled (monkeypatched)
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 189 passed
- [x] Live Playwright e2e: settings → Email delivery section shows DISABLED + setup guidance; no JS errors; screenshot visually verified

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)