### PR TITLE
P2.17 — generate inbox notifications on publish

### DIFF
--- a/tests/web/test_notif_generation.py
+++ b/tests/web/test_notif_generation.py
@@ -1,0 +1,84 @@
+"""Marathon P2.17 — publishing a solution emits inbox notifications."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Assignment, Event, Notification, Solution
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _login(client, email):
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def test_publish_creates_inbox_notifications(client, db):
+    seed_person(db, person_id="ng_adm", org_id="ng_o1", email="ngadm@web.test", roles=["admin"])
+    seed_person(db, person_id="ng_vol", org_id="ng_o1", email="ngvol@web.test", roles=["volunteer"])
+    sol = Solution(
+        org_id="ng_o1", hard_violations=0, soft_score=1.0, health_score=90.0, solve_ms=5.0
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    start = datetime(2026, 6, 7, 10, 0, 0)
+    db.add(
+        Event(
+            id="ng_ev",
+            org_id="ng_o1",
+            type="Sunday Service",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+        )
+    )
+    db.commit()
+    db.add(
+        Assignment(
+            event_id="ng_ev",
+            person_id="ng_vol",
+            role="usher",
+            solution_id=sol.id,
+            status="confirmed",
+        )
+    )
+    db.commit()
+
+    atok = _login(client, "ngadm@web.test")
+    pub = client.post(f"/a/solution/{sol.id}/publish", cookies={SESSION_COOKIE: atok})
+    assert pub.status_code == 200
+    assert "Published" in pub.text
+
+    notif = (
+        db.query(Notification)
+        .filter(
+            Notification.org_id == "ng_o1",
+            Notification.recipient_id == "ng_vol",
+            Notification.type == "assignment",
+        )
+        .first()
+    )
+    assert notif is not None
+    assert notif.event_id == "ng_ev"
+
+    # The volunteer sees it in their inbox (P1.5).
+    vtok = _login(client, "ngvol@web.test")
+    inbox = client.get("/v/inbox", cookies={SESSION_COOKIE: vtok})
+    assert inbox.status_code == 200
+    assert "New assignment" in inbox.text
+    assert "1 unread" in inbox.text
+
+
+def test_publish_without_assignments_still_ok(client, db):
+    seed_person(db, person_id="ng_a2", org_id="ng_o2", email="ng2@web.test", roles=["admin"])
+    sol = Solution(
+        org_id="ng_o2", hard_violations=0, soft_score=1.0, health_score=90.0, solve_ms=5.0
+    )
+    db.add(sol)
+    db.commit()
+    db.refresh(sol)
+    tok = _login(client, "ng2@web.test")
+    pub = client.post(f"/a/solution/{sol.id}/publish", cookies={SESSION_COOKIE: tok})
+    assert pub.status_code == 200
+    assert db.query(Notification).filter(Notification.org_id == "ng_o2").first() is None

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -1332,6 +1332,39 @@ def solver_run(
 # ── Admin: publish solution + compare ────────────────────────────────
 
 
+def _emit_publish_notifications(db: Session, person: Person, sid: int) -> None:
+    """Best-effort: create inbox Notification rows for everyone assigned
+    in the just-published solution. Inline + org-scoped on purpose —
+    notification_service.create_assignment_notifications queries Person
+    un-scoped, which the strict tenancy guard rejects. DB-only, no email
+    dependency. Never breaks the publish response."""
+    try:
+        rows = (
+            db.query(Assignment.person_id, Assignment.event_id)
+            .join(Event, Assignment.event_id == Event.id)
+            .filter(
+                Event.org_id == person.org_id,
+                Assignment.solution_id == sid,
+            )
+            .all()
+        )
+        for person_id, event_id in rows:
+            db.add(
+                Notification(
+                    org_id=person.org_id,
+                    recipient_id=person_id,
+                    type="assignment",
+                    status="pending",
+                    event_id=event_id,
+                    template_data={"event_id": event_id, "solution_id": sid},
+                )
+            )
+        if rows:
+            db.commit()
+    except Exception:
+        db.rollback()
+
+
 def _publish_state(request: Request, person: Person, db: Session, sid: int, *, error=None):
     """Re-render #publish-state from the solution's current state
     (is_published + rollback eligibility), always carrying solution_id
@@ -1374,6 +1407,7 @@ def solution_publish(
         publish_solution(solution_id, request, person, db)
     except HTTPException as exc:
         return _publish_state(request, person, db, solution_id, error=str(exc.detail))
+    _emit_publish_notifications(db, person, solution_id)
     return _publish_state(request, person, db, solution_id)
 
 


### PR DESCRIPTION
## Summary

Publishing a solution now **emits Notification rows** (type `assignment`, status `pending`, `event_id`, `template_data`) for every assignee — feeding the P1.5 inbox. Implemented inline + org-scoped in the web publish handler: `notification_service.create_assignment_notifications` queries `Person` un-scoped, which the strict tenancy guard rejects, so a direct org-scoped `Assignment ⋈ Event` gather + `Notification` insert is used instead. Best-effort (`try/except` + rollback) so it never breaks the publish response; DB-only, no email/Mailtrap dependency.

**Completes P2** (backend wiring: billing, email, SMS, notifications). Part of #145.

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_notif_generation.py` (2) — publish→notification row + volunteer inbox shows "New assignment" / "1 unread"; publish with no assignments still 200, no notifications
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 194 passed
- [x] Live Playwright e2e: seed solution+assignment → publish via review page → `/v/inbox` shows the new-assignment notice; no JS errors; screenshot visually verified

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)