### PR TITLE
P3.18 — production Docker: package web/, migrate on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,13 @@ COPY pyproject.toml poetry.lock* ./
 
 RUN poetry install --only main --no-root --no-directory
 
+# web/ is imported by api.main (`from web.app import mount_web`) — the
+# HTML app won't start without it.
 COPY api/ ./api/
+COPY web/ ./web/
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
+COPY docker-entrypoint.sh ./
 
 RUN poetry install --only main
 
@@ -60,13 +64,17 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder --chown=signupflow:signupflow /app ./
 
 RUN mkdir -p /app/data /app/logs && \
+    chmod +x /app/docker-entrypoint.sh && \
     chown -R signupflow:signupflow /app
 
 USER signupflow
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
+# Entrypoint runs `alembic upgrade head` before exec'ing the CMD, so a
+# fresh Postgres is migrated on first boot.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Production container entrypoint: apply DB migrations, then run the app.
+#
+# Runs `alembic upgrade head` so a fresh Postgres (docker-compose `db`
+# service) is schema-ready on first boot, then exec's the CMD (uvicorn).
+# `exec` keeps uvicorn as PID 1 so signals/healthchecks work.
+set -e
+
+echo "[entrypoint] Applying database migrations (alembic upgrade head)…"
+alembic upgrade head
+echo "[entrypoint] Migrations applied. Starting: $*"
+
+exec "$@"

--- a/tests/unit/test_docker_packaging.py
+++ b/tests/unit/test_docker_packaging.py
@@ -1,0 +1,52 @@
+"""Marathon P3.18 — production Docker image + compose invariants.
+
+Static guards (no Docker daemon needed): the image must package the web
+app and migrate on boot, and compose must wire the API to Postgres. The
+`web/`-missing case is a real regression that crashed the image.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_dockerfile_packages_web_and_migrates():
+    df = (ROOT / "Dockerfile").read_text()
+    # api.main does `from web.app import mount_web` — the app won't start
+    # without web/ in the image.
+    assert "COPY web/ ./web/" in df
+    assert "COPY api/ ./api/" in df
+    assert "COPY docker-entrypoint.sh" in df
+    assert 'ENTRYPOINT ["/app/docker-entrypoint.sh"]' in df
+    assert "uvicorn" in df and "api.main:app" in df
+
+
+def test_entrypoint_runs_migrations_then_execs():
+    p = ROOT / "docker-entrypoint.sh"
+    txt = p.read_text()
+    assert "alembic upgrade head" in txt
+    assert 'exec "$@"' in txt
+    # Executable bit tracked in git so the image can run it.
+    assert os.stat(p).st_mode & stat.S_IXUSR
+
+
+def test_compose_wires_api_to_postgres():
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+    svcs = compose["services"]
+
+    assert "db" in svcs and "postgres" in svcs["db"]["image"]
+    api = svcs["api"]
+    assert "build" in api
+    # API waits for a healthy database.
+    assert api["depends_on"]["db"]["condition"] == "service_healthy"
+    # API talks to the compose Postgres, not sqlite.
+    assert "postgresql://" in api["environment"]["DATABASE_URL"]
+    assert "@db:5432/" in api["environment"]["DATABASE_URL"]
+    # Container healthcheck hits the real /health endpoint.
+    assert "/health" in " ".join(api["healthcheck"]["test"])


### PR DESCRIPTION
## Summary

Fixes a **real shippable bug**: the Dockerfile only `COPY`'d `api/` + `alembic/`, so the production image crashed on import (`api.main` does `from web.app import mount_web`). Now `COPY web/` into the image. Adds **`docker-entrypoint.sh`** that runs `alembic upgrade head` then `exec`'s the CMD (wired as `ENTRYPOINT`), so a fresh docker-compose Postgres is migrated on first boot. A static-invariant unit test guards web/-packaging + migrate-on-boot + compose↔Postgres wiring.

**Verification (Docker daemon unavailable in the run env — `docker compose up` skip-marked per the sandbox rule):** `alembic upgrade head` applies the full chain; the exact container CMD (`uvicorn api.main:app …`) boots & serves — `/health` → `{"status":"healthy","database":"connected"}`, `/auth/login` → 200 (proves `web/` is importable).

First P3 item. Part of the full-feature marathon (#145).

## Test plan

- [x] black/ruff clean
- [x] `tests/unit/test_docker_packaging.py` (3) — Dockerfile packages web/ + entrypoint; entrypoint migrates+exec; compose wires api→Postgres+/health
- [x] `pytest tests/unit/test_docker_packaging.py tests/web tests/contract tests/unit/test_openapi_schema.py` — 197 passed
- [x] alembic chain applies; container CMD boots & serves locally

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)