### PR TITLE
P3.19 — security hardening: isolation headers + SECRET_KEY guard

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -45,6 +45,17 @@ from api.routers import (
 async def lifespan(app: FastAPI):
     """Handle application startup and shutdown."""
     init_db()
+
+    # Launch-readiness guard: never run production on a guessable JWT key.
+    import os as _os
+
+    from api.security import SECRET_KEY, secret_key_issues
+
+    _issues = secret_key_issues(SECRET_KEY)
+    if _issues and _os.getenv("ENVIRONMENT", "development").lower() == "production":
+        for _msg in _issues:
+            logger.critical("SECURITY: %s", _msg)
+
     logger.info("🚀 SignUpFlow API started")
     logger.info("📖 API docs available at http://localhost:8000/docs")
     print("🚀 SignUpFlow API started")

--- a/api/security.py
+++ b/api/security.py
@@ -19,8 +19,23 @@ if not hasattr(bcrypt, "__about__"):
     bcrypt.__about__ = _BcryptAbout()
 
 # JWT Configuration
-SECRET_KEY = os.getenv("SECRET_KEY", "your-secret-key-change-in-production-use-env-var")
+_DEFAULT_SECRET_KEY = "your-secret-key-change-in-production-use-env-var"
+SECRET_KEY = os.getenv("SECRET_KEY", _DEFAULT_SECRET_KEY)
 ALGORITHM = "HS256"
+
+
+def secret_key_issues(secret_key: str) -> list[str]:
+    """Return human-readable problems with the JWT signing key (empty =
+    OK). Pure — callable from a startup guard or a unit test. A guessable
+    HS256 key lets anyone forge tokens, so this is a launch blocker."""
+    issues: list[str] = []
+    if secret_key == _DEFAULT_SECRET_KEY:
+        issues.append("SECRET_KEY is the built-in default — set a unique value")
+    if len(secret_key) < 32:
+        issues.append(f"SECRET_KEY is too short ({len(secret_key)} chars; need >= 32)")
+    return issues
+
+
 # Read from env via direct os.getenv (not Settings) so the smoke runbook's
 # short-TTL workflow works without restart-coupling to Settings reload.
 # Default 24h matches the prior hardcoded value. Fractional hours via

--- a/api/utils/security_headers_middleware.py
+++ b/api/utils/security_headers_middleware.py
@@ -81,6 +81,14 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # X-XSS-Protection - Enable browser XSS protection (legacy, but doesn't hurt)
         response.headers["X-XSS-Protection"] = "1; mode=block"
 
+        # Cross-origin isolation — the app (API + same-origin web UI)
+        # never needs to be embedded or read cross-origin.
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+
+        # Block legacy Adobe cross-domain policy files outright.
+        response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+
         return response
 
     def _get_csp_policy(self) -> str:

--- a/tests/unit/test_secret_key_guard.py
+++ b/tests/unit/test_secret_key_guard.py
@@ -1,0 +1,19 @@
+"""Marathon P3.19 — JWT SECRET_KEY launch-readiness guard."""
+
+from __future__ import annotations
+
+from api.security import _DEFAULT_SECRET_KEY, secret_key_issues
+
+
+def test_default_key_flagged():
+    issues = secret_key_issues(_DEFAULT_SECRET_KEY)
+    assert any("default" in i for i in issues)
+
+
+def test_short_key_flagged():
+    issues = secret_key_issues("too-short")
+    assert any("too short" in i for i in issues)
+
+
+def test_strong_unique_key_ok():
+    assert secret_key_issues("k" * 48) == []

--- a/tests/unit/test_security_headers_extra.py
+++ b/tests/unit/test_security_headers_extra.py
@@ -1,0 +1,29 @@
+"""Marathon P3.19 — cross-origin isolation headers on every response."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.utils.security_headers_middleware import add_security_headers_middleware
+
+
+def _client():
+    app = FastAPI()
+
+    @app.get("/x")
+    def _x():
+        return {"ok": True}
+
+    add_security_headers_middleware(app)
+    return TestClient(app)
+
+
+def test_isolation_headers_present():
+    r = _client().get("/x")
+    assert r.headers["Cross-Origin-Opener-Policy"] == "same-origin"
+    assert r.headers["Cross-Origin-Resource-Policy"] == "same-origin"
+    assert r.headers["X-Permitted-Cross-Domain-Policies"] == "none"
+    # Existing hardening still intact.
+    assert r.headers["X-Content-Type-Options"] == "nosniff"
+    assert r.headers["X-Frame-Options"] == "DENY"


### PR DESCRIPTION
## Summary

- **Cross-origin isolation headers** added to `SecurityHeadersMiddleware` (every response): `Cross-Origin-Opener-Policy: same-origin`, `Cross-Origin-Resource-Policy: same-origin`, `X-Permitted-Cross-Domain-Policies: none`. The API + same-origin web UI never need cross-origin embedding/read.
- **Weak-`SECRET_KEY` launch guard**: `api.security.secret_key_issues()` (pure) + a **non-fatal** production startup check that logs `CRITICAL` when the JWT signing key is the built-in default or `< 32` chars. A guessable HS256 key = forgeable tokens — surfaced loudly without breaking boot or tests.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/unit/test_secret_key_guard.py` (3) + `tests/unit/test_security_headers_extra.py` (2) + existing `test_security_headers_middleware.py` (23) — **28 passed, no regression**
- [x] Broad gate `pytest tests/unit tests/api tests/contract tests/web` — **829 passed, 21 skipped, 0 failed**
- [x] Verified live: COOP/CORP/X-Permitted-Cross-Domain-Policies present on `/auth/login` alongside the existing CSP/XFO/XCTO

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)