### PR TITLE
P3.20 — observability: /ready probe + error-hook gate

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -56,6 +56,15 @@ async def lifespan(app: FastAPI):
         for _msg in _issues:
             logger.critical("SECURITY: %s", _msg)
 
+    # Observability summary — error reporting is config-gated (no hard
+    # dependency): a DSN turns it on, its absence is a normal dev/sandbox
+    # state, not an error.
+    _err_reporting = "enabled" if _os.getenv("SENTRY_DSN") else "disabled (no SENTRY_DSN)"
+    logger.info(
+        "observability: error_reporting=%s liveness=/health readiness=/ready",
+        _err_reporting,
+    )
+
     logger.info("🚀 SignUpFlow API started")
     logger.info("📖 API docs available at http://localhost:8000/docs")
     print("🚀 SignUpFlow API started")
@@ -137,6 +146,29 @@ def health_check():
         return JSONResponse(status_code=503, content=health_status)
 
     return health_status
+
+
+@app.get("/ready", include_in_schema=False)
+def readiness_check():
+    """Readiness probe (ops-only, not part of the client contract).
+
+    Distinct from /health (liveness): a 503 here tells an orchestrator
+    to keep this instance out of rotation until the DB is reachable.
+    """
+    from sqlalchemy import text
+
+    from api.database import SessionLocal
+
+    try:
+        db = SessionLocal()
+        db.execute(text("SELECT 1"))
+        db.close()
+    except Exception as exc:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "reason": str(exc)},
+        )
+    return {"status": "ready"}
 
 
 app.include_router(auth.router, prefix="/api/v1")

--- a/tests/api/test_readiness.py
+++ b/tests/api/test_readiness.py
@@ -1,0 +1,22 @@
+"""Marathon P3.20 — readiness probe."""
+
+from __future__ import annotations
+
+
+def test_ready_returns_ready(client, db):
+    r = client.get("/ready")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ready"
+
+
+def test_health_still_healthy(client, db):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "healthy"
+
+
+def test_ready_is_ops_only_not_in_contract(client):
+    """Ops probe must stay out of the OpenAPI client contract."""
+    paths = client.get("/openapi.json").json()["paths"]
+    assert "/ready" not in paths
+    assert "/health" in paths  # health remains documented (pre-existing)


### PR DESCRIPTION
## Summary

- **`GET /ready`** readiness probe — DB `SELECT 1` → `200 {"status":"ready"}` or `503 {"status":"not_ready","reason":…}`. `include_in_schema=False`, so it's an ops-only probe and stays **out of the OpenAPI client contract** (no snapshot churn). Distinct from `/health` (liveness): a 503 tells an orchestrator to drop the instance from rotation.
- **Startup observability summary log** — non-fatal, dependency-free: notes whether error reporting is configured (`SENTRY_DSN` present) plus the liveness/readiness paths. DSN absence is a normal dev/sandbox state, not an error.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/api/test_readiness.py` (3) — `/ready` 200 ready, `/health` still healthy, `/ready` absent from `openapi.json` (contract unchanged)
- [x] `tests/contract` + `tests/unit/test_openapi_schema.py` green **without snapshot regen** (confirms ops-only)
- [x] Broad gate `pytest tests/unit tests/api tests/contract tests/web` — **832 passed, 21 skipped, 0 failed**
- [x] Verified live: `/ready` → `{"status":"ready"}`, startup log `observability: error_reporting=disabled (no SENTRY_DSN) liveness=/health readiness=/ready`

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)