### PR TITLE
P3.21 — ops runbook + public pricing page

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,79 @@
+# SignUpFlow — Operations Runbook
+
+Operator guide for deploying and running SignUpFlow in production. Grounded
+in the actual `Dockerfile`, `docker-compose.yml`, and app endpoints.
+
+## Stack
+
+`docker-compose.yml` runs three services on `signupflow-network`:
+
+- **db** — `postgres:16-alpine`, volume `postgres_data`, `./backups` mounted
+  for dumps, `pg_isready` healthcheck.
+- **redis** — `redis:7-alpine` (caching / rate-limit / sessions).
+- **api** — built from `Dockerfile`; depends on `db` + `redis` being
+  *healthy*; serves the API **and** the same-origin web UI on `:8000`.
+
+## Deploy
+
+```bash
+cp .env.example .env          # then edit secrets (see below)
+docker compose up -d --build
+docker compose ps             # all services should be healthy
+```
+
+The image **entrypoint** (`docker-entrypoint.sh`) runs
+`alembic upgrade head` before starting uvicorn, so a fresh Postgres is
+migrated automatically on first boot. No manual migration step is needed;
+to run migrations by hand: `docker compose exec api alembic upgrade head`.
+
+## Health & readiness
+
+- **Liveness:** `GET /health` → `200` `{"status":"healthy","database":"connected"}`
+  (or `503` if the DB is down). Used by the container `HEALTHCHECK`.
+- **Readiness:** `GET /ready` → `200 {"status":"ready"}` or
+  `503 {"status":"not_ready",...}`. Point the orchestrator/load balancer
+  at `/ready` so a node is pulled from rotation when the DB is unreachable.
+
+## Required configuration
+
+| Env var | Purpose | Notes |
+|---|---|---|
+| `SECRET_KEY` | JWT signing | **Must** be unique & ≥ 32 chars. Production logs a `CRITICAL` if it's the default/short. |
+| `DATABASE_URL` | Postgres DSN | compose sets `postgresql://…@db:5432/…` |
+| `ENVIRONMENT` | `production` enables HSTS + the SECRET_KEY guard | |
+| `EMAIL_ENABLED` + `MAILTRAP_SMTP_USER`/`_PASSWORD` | Transactional email (sandbox: Mailtrap) | or `SENDGRID_API_KEY` for prod |
+| `SMS_ENABLED` + `TWILIO_ACCOUNT_SID`/`_AUTH_TOKEN`/`_PHONE_NUMBER` | SMS | sandbox: Twilio magic number `+15005550006` |
+| `STRIPE_SECRET_KEY` (`sk_test_…` for sandbox) | Billing | absent → billing UI shows setup notice, no crash |
+| `SENTRY_DSN` | Error reporting | absent → disabled (logged at startup) |
+
+Email/SMS/billing are **feature-gated**: absent credentials disable the
+feature with an in-app notice — they never block startup.
+
+## Backups
+
+Postgres data lives in the `postgres_data` volume; `./backups` is mounted
+into the `db` container.
+
+```bash
+# nightly dump
+docker compose exec db pg_dump -U signupflow signupflow > backups/$(date +%F).sql
+# restore
+docker compose exec -T db psql -U signupflow signupflow < backups/<file>.sql
+```
+
+## Common incidents
+
+| Symptom | Check | Action |
+|---|---|---|
+| `api` unhealthy | `docker compose logs api` | DB down? `/health` shows DB status |
+| 503 on `/ready` | DB reachability | restart `db`; verify volume mounted |
+| Login tokens rejected after deploy | `SECRET_KEY` changed | keep `SECRET_KEY` stable across deploys |
+| Emails/SMS not sending | startup log + Settings page | set the sandbox/prod creds; features are gated |
+| Migration error on boot | entrypoint log | `docker compose run --rm api alembic history` |
+
+## Rollback
+
+`docker compose` keeps the previous image until rebuilt. To roll back:
+`docker compose up -d --no-build` with the prior image tag, then
+`alembic downgrade -1` only if a migration must be reversed (rare —
+prefer forward fixes).

--- a/tests/unit/test_runbook_doc.py
+++ b/tests/unit/test_runbook_doc.py
@@ -1,0 +1,20 @@
+"""Marathon P3.21 — ops runbook covers the real deploy surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_runbook_documents_key_ops():
+    txt = (ROOT / "docs" / "RUNBOOK.md").read_text()
+    for needle in (
+        "alembic upgrade head",
+        "/health",
+        "/ready",
+        "docker compose",
+        "SECRET_KEY",
+        "pg_dump",
+    ):
+        assert needle in txt, f"RUNBOOK missing: {needle}"

--- a/tests/web/test_pricing.py
+++ b/tests/web/test_pricing.py
@@ -1,0 +1,23 @@
+"""Marathon P3.21 — public pricing page."""
+
+from __future__ import annotations
+
+
+def test_pricing_is_public_and_lists_tiers(client):
+    # No auth required — mirrors /auth/login.
+    r = client.get("/pricing")
+    assert r.status_code == 200
+    body = r.text
+    assert "Pricing" in body
+    # Tier names are lowercase in HTML (CSS upper-cases for display).
+    for tier in ("free", "starter", "pro", "enterprise"):
+        assert tier in body
+    # Truthful limits from UsageService.PLAN_LIMITS.
+    assert "Unlimited" in body  # enterprise
+    assert "200" in body  # pro volunteers / starter events
+    assert 'href="/auth/signup"' in body
+    assert 'href="/auth/login"' in body
+
+
+def test_login_links_to_pricing(client):
+    assert 'href="/pricing"' in client.get("/auth/login").text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -72,6 +72,46 @@ def _my_assignment(db: Session, person: Person, aid: int) -> dict | None:
     return _row_dict(*row) if row else None
 
 
+def _pricing_tiers() -> list[dict]:
+    """Pricing rows from the canonical UsageService.PLAN_LIMITS so the
+    public page can never drift from what the app actually enforces."""
+    from api.services.usage_service import UsageService
+
+    order = ["free", "starter", "pro", "enterprise"]
+    blurb = {
+        "free": "Get started — small teams & trials.",
+        "starter": "Growing volunteer programs.",
+        "pro": "Established organizations.",
+        "enterprise": "Large / multi-ministry. Custom terms.",
+    }
+
+    def fmt(v):
+        return "Unlimited" if v is None else f"{v:,}"
+
+    rows = []
+    for tier in order:
+        lim = UsageService.PLAN_LIMITS[tier]
+        rows.append(
+            {
+                "tier": tier,
+                "blurb": blurb[tier],
+                "volunteers": fmt(lim["volunteers"]),
+                "events": fmt(lim["events_per_month"]),
+                "storage_mb": fmt(lim["storage_mb"]),
+                "api_per_day": fmt(lim["api_calls_per_day"]),
+            }
+        )
+    return rows
+
+
+@router.get("/pricing", response_class=HTMLResponse)
+def pricing(request: Request):
+    """Public pricing page — no auth (mirrors /auth/login)."""
+    from web.app import templates
+
+    return templates.TemplateResponse(request, "pricing.html", {"tiers": _pricing_tiers()})
+
+
 @router.get("/")
 def root(request: Request):
     # Resolve session lazily so the bare "/" works signed-in or not.

--- a/web/templates/admin/billing.html
+++ b/web/templates/admin/billing.html
@@ -37,6 +37,9 @@
   </div>
   {% endif %}
 
+  <div class="spacer-12"></div>
+  <a class="btn btn-secondary" href="/pricing">View plans &amp; limits →</a>
+
   {% if b.warnings %}
   <div class="spacer-12"></div>
   {% for w in b.warnings %}

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -30,5 +30,6 @@
 
   <a class="auth-link" href="/auth/forgot">Forgot password?</a>
   <a class="auth-link" href="/auth/signup">Create a new organization</a>
+  <a class="auth-link" href="/pricing">View pricing</a>
 </div>
 {% endblock %}

--- a/web/templates/pricing.html
+++ b/web/templates/pricing.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}Pricing · SignUpFlow{% endblock %}
+{% block body %}
+<div class="auth-wrap">
+  <div class="brand-mark">S</div>
+  <div class="wordmark">SIGNUP<span class="slash">/</span>FLOW</div>
+  <div class="auth-sub">Pricing</div>
+</div>
+<div class="scroll">
+  {% for t in tiers %}
+  <div class="card" style="margin-bottom:12px">
+    <div class="page-title" style="padding:0;font-size:22px;text-transform:uppercase">
+      {{ t.tier }}
+    </div>
+    <div class="row-sub" style="margin-top:4px">{{ t.blurb }}</div>
+    <div class="spacer-12"></div>
+    <div class="group">
+      <div class="row">
+        <div class="row-main"><div class="row-title">Volunteers</div></div>
+        <span class="mono-data">{{ t.volunteers }}</span>
+      </div>
+      <div class="row">
+        <div class="row-main"><div class="row-title">Events / month</div></div>
+        <span class="mono-data">{{ t.events }}</span>
+      </div>
+      <div class="row">
+        <div class="row-main"><div class="row-title">Storage</div></div>
+        <span class="mono-data">{{ t.storage_mb }} MB</span>
+      </div>
+      <div class="row">
+        <div class="row-main"><div class="row-title">API calls / day</div></div>
+        <span class="mono-data">{{ t.api_per_day }}</span>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+
+  <div class="spacer-12"></div>
+  <a class="btn btn-primary" href="/auth/signup">Create your organization</a>
+  <div class="spacer-12"></div>
+  <a class="auth-link" href="/auth/login">Already have an account? Sign in</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **`docs/RUNBOOK.md`** — operator guide grounded in the real stack: docker-compose (db/redis/api), the image entrypoint running `alembic upgrade head`, `/health` (liveness) + `/ready` (readiness), feature-gated email/SMS/Stripe/Sentry env, `pg_dump` backups, an incident table, and rollback steps.
- **Public `/pricing` page** — no auth (mirrors `/auth/login`), built from the canonical `UsageService.PLAN_LIMITS` so it can never drift from the quotas the app actually enforces (free/starter/pro/enterprise → volunteers, events/mo, storage, API/day; enterprise = Unlimited). Linked from the login page and the admin billing page.

Part of the full-feature marathon (#145).

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_pricing.py` (2) — public, lists all tiers + truthful limits + signup/login links; login links to /pricing
- [x] `tests/unit/test_runbook_doc.py` (1) — runbook covers alembic/health/ready/compose/SECRET_KEY/pg_dump
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 197 passed (no contract change — web route stays out of schema)
- [x] Live Playwright e2e: login → View pricing → all 4 tiers with correct limits; no JS errors; screenshot visually verified

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)