### PR TITLE
P3.22 — CI uplift: run the web test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - name: OpenAPI contract snapshot
         run: poetry run pytest tests/contract/ -v --tb=short
 
+      - name: Web tests
+        # In-process FastAPI TestClient (no browser) — the cookie/HTMX
+        # web app suite grown across the full-feature marathon.
+        run: poetry run pytest tests/web/ -v --tb=short
+
       - name: Integration tests
         # Sprint 4 PR 4.6a brought back the api_server fixture and a smoke
         # test. PR 4.6b is reviving the previously-failing files; until then

--- a/tests/unit/test_ci_has_web_lane.py
+++ b/tests/unit/test_ci_has_web_lane.py
@@ -1,0 +1,19 @@
+"""Marathon P3.22 — CI must run the web test suite (regression guard).
+
+The cookie/HTMX web app grew ~190 tests across the marathon; they must
+stay gated by CI, not just locally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CI = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+
+
+def test_ci_runs_web_suite():
+    txt = CI.read_text()
+    assert "pytest tests/web/" in txt, "CI no longer runs the web test suite"
+    # Sanity: the other lanes are still present too.
+    for lane in ("tests/unit/", "tests/api/", "tests/contract/"):
+        assert f"pytest {lane}" in txt


### PR DESCRIPTION
## Summary

Adds a **"Web tests"** step (`poetry run pytest tests/web/`) to `.github/workflows/ci.yml`, between the contract and integration lanes. The ~190 cookie/HTMX `TestClient` tests grown across the full-feature marathon were only validated locally — now they're **gated by CI on every PR**. No browser needed (FastAPI `TestClient`, not Playwright). A unit guard test asserts the lane stays wired (and the other lanes remain).

**Completes P3** (launch readiness: Docker, security, observability, ops/pricing, CI uplift). Part of #145.

## Test plan

- [x] `black` / `ruff` clean; `ci.yml` parses as valid YAML
- [x] `tests/unit/test_ci_has_web_lane.py` (1) — `pytest tests/web/` present in CI + other lanes intact
- [x] Full `pytest tests/web` — **191 passed** (exactly what the new CI step will run)

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)