### PR TITLE
P4.24 — Flutter CI lane for the mobile app

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,42 @@
+# Flutter mobile app CI — additive coverage for mobile/.
+#
+# Independent of the main "Lint, type-check, and test" workflow: this
+# gates the Flutter app without blocking backend/web PRs. Runs only when
+# mobile/ (or this workflow) changes.
+name: Mobile CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-ci.yml"
+  pull_request:
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-ci.yml"
+
+jobs:
+  flutter:
+    name: Flutter analyze + test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        # Info-level lints (e.g. Riverpod `.stream` deprecation) don't
+        # fail the build; warnings/errors do.
+        run: flutter analyze --no-fatal-infos
+
+      - name: Test
+        run: flutter test

--- a/mobile/integration_test/deep_link_test.dart
+++ b/mobile/integration_test/deep_link_test.dart
@@ -10,7 +10,6 @@
 // and operator-side smoke against a real device can pick the same
 // failures up via `flutter test integration_test/deep_link_test.dart`.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';

--- a/mobile/integration_test/login_flow_test.dart
+++ b/mobile/integration_test/login_flow_test.dart
@@ -21,8 +21,8 @@ import 'package:signupflow_mobile/auth/login_repository.dart';
 import 'package:signupflow_mobile/auth/secure_token_storage.dart';
 
 class _FakeLoginRepo implements LoginRepository {
-  _FakeLoginRepo({this.role = AuthRole.volunteer});
-  AuthRole role;
+  _FakeLoginRepo();
+  AuthRole role = AuthRole.volunteer;
 
   @override
   Future<AuthState> signIn(String email, String password) async {

--- a/tests/unit/test_mobile_ci_workflow.py
+++ b/tests/unit/test_mobile_ci_workflow.py
@@ -1,0 +1,18 @@
+"""Marathon P4.24 — the Flutter CI workflow stays wired."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WF = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mobile-ci.yml"
+
+
+def test_mobile_ci_workflow_present_and_sane():
+    assert WF.exists(), "mobile-ci.yml workflow missing"
+    txt = WF.read_text()
+    assert "flutter pub get" in txt
+    # Info-level lints must not fail the build (9 known infos in mobile/).
+    assert "flutter analyze --no-fatal-infos" in txt
+    assert "flutter test" in txt
+    # Path-filtered so it doesn't block backend/web-only PRs.
+    assert "mobile/**" in txt


### PR DESCRIPTION
## Summary

Adds **`.github/workflows/mobile-ci.yml`**: `subosito/flutter-action` → `flutter pub get` → `flutter analyze --no-fatal-infos` → `flutter test`. It's an **independent, path-filtered** workflow (`mobile/**`) — adds mobile coverage without blocking backend/web PRs or the main merge gate.

**Locally verified** the gating command: `flutter analyze --no-fatal-infos` exits **0** on the current `mobile/` (0 errors/warnings; 9 info-level Riverpod `.stream` deprecations, intentionally non-fatal). `flutter test` executes on the GH Actions lane where Flutter is provisioned.

Part of the full-feature marathon (#145). Note: P4.23 (regenerate the stale dart client) is **blocked here — no Java runtime for openapi-generator-cli** — filed honestly as #191, not faked.

## Test plan

- [x] `black`/`ruff` clean; `mobile-ci.yml` valid YAML
- [x] `tests/unit/test_mobile_ci_workflow.py` (1) — workflow wired (pub get / analyze --no-fatal-infos / test / path filter)
- [x] Local: `flutter pub get` ok; `flutter analyze --no-fatal-infos` → exit 0

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)