### PR TITLE
P4.25 — honest unpark: README banners reflect true status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 ## Features
 
 - **Greedy Heuristic Solver** — auto-generate fair schedules with role-based constraints
-- **Responsive web app** — full admin + volunteer workflow in the browser, served by the same FastAPI process ([walkthrough below](#web-app--end-to-end-walkthrough))
+- **Responsive web app** — full admin + volunteer workflow in the browser, served by the same FastAPI process ([walkthrough below](#web-app--end-to-end-walkthrough)) — the primary surface
+- **Flutter mobile app** (`mobile/`) — volunteer + admin app, CI-gated (analyze + test); see `mobile/README.md` for status
 - **CLI + API** — schedule from YAML files or through REST endpoints
 - **Multi-tenant** — full org isolation with JWT auth and RBAC (admin/volunteer)
 - **Invitation system** — token-based volunteer onboarding

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,25 +1,41 @@
-> ## ⏸️ Sprint 11+: mobile feature work is paused
+# SignUpFlow — Flutter mobile app
+
+> ## ▶️ Un-parked — but read the codegen note
 >
-> The product is moving to a responsive **web app** (`/web`, HTMX +
-> FastAPI on the same backend). New screens and features land there.
-> This Flutter app stays in the repo, its CI lane keeps running, and
-> bug fixes are still welcome — but no new feature work until the web
-> app reaches parity. See the Sprint 11 plan.
+> The responsive **web app** (`/web`, HTMX + FastAPI, same backend) is
+> the primary, now full-featured surface (auth, volunteer & admin
+> workflows, billing/email/SMS status, analytics, notifications). This
+> Flutter app is **active again**: it has a CI lane (analyze + test on
+> GitHub Actions — `.github/workflows/mobile-ci.yml`) and feature/bug
+> work is welcome.
+>
+> **Known gap (tracked in #191):** the generated API client in
+> `mobile/api_client/` predates endpoints added during the full-feature
+> work — `POST /api/v1/auth/change-password`, the billing router, and
+> `/api/sms/*`. Regenerate it before building features that use those:
+>
+> ```
+> make mobile-codegen   # needs a JDK 17 (openapi-generator-cli)
+> ```
+>
+> The OpenAPI snapshot (`tests/contract/openapi.snapshot.json`) is
+> already current, so codegen is a clean mechanical step.
 
-# signupflow_mobile
+## Stack
 
-A new Flutter project.
+Flutter + Dart, Riverpod (state), GoRouter (nav), secure storage for the
+session token. Talks to the FastAPI backend via the generated
+`signupflow_api` Dart client (path dependency at `mobile/api_client/`).
 
-## Getting Started
+## Develop
 
-This project is a starting point for a Flutter application.
+```bash
+flutter pub get
+flutter analyze --no-fatal-infos   # CI gate (info-level lints non-fatal)
+flutter test
+```
 
-A few resources to get you started if this is your first Flutter project:
+After backend API changes, refresh the client with `make mobile-codegen`
+(from the repo root) and re-run the contract snapshot tests first.
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+For Flutter basics see the [online documentation](https://docs.flutter.dev/).

--- a/tests/unit/test_readme_unpark.py
+++ b/tests/unit/test_readme_unpark.py
@@ -1,0 +1,23 @@
+"""Marathon P4.25 — README banners reflect honest, current status."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_mobile_readme_unparked_and_honest():
+    txt = (ROOT / "mobile" / "README.md").read_text()
+    # No longer the stale "paused / no new feature work" banner.
+    assert "feature work is paused" not in txt
+    assert "no new feature work" not in txt
+    # Un-parked, but the codegen gap is stated (not hidden).
+    assert "Un-parked" in txt
+    assert "#191" in txt
+    assert "make mobile-codegen" in txt
+
+
+def test_root_readme_mentions_mobile():
+    txt = (ROOT / "README.md").read_text()
+    assert "Flutter mobile app" in txt


### PR DESCRIPTION
## Summary

Replaces the Sprint-11 *"mobile feature work is paused"* banner with an **accurate** status:
- the web app is the **primary, full-featured** surface;
- the Flutter app is **un-parked** and **CI-gated** (analyze + test);
- the generated API client is **stale vs the P2 endpoints** and regeneration is **blocked in this environment (no JDK)** — stated openly and tracked in **#191**, not faked.

Root README gains a one-line CI-gated mobile note. A guard test pins the honest wording (no "paused", mentions #191 + `make mobile-codegen`).

**Final marathon item.** Part of #145.

## Test plan

- [x] `black`/`ruff` clean
- [x] `tests/unit/test_readme_unpark.py` (2) — mobile banner un-parked + states the codegen gap (#191); root README mentions the Flutter app
- [x] Docs-only + guard test (no app code)

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)