### PR TITLE
Overnight A — committed Playwright e2e harness + blocking CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,37 @@ jobs:
         env:
           DATABASE_URL: postgresql+psycopg2://signupflow:signupflow@localhost:5432/signupflow_ci
         run: poetry run alembic upgrade head
+
+  e2e:
+    name: End-to-end (Playwright)
+    runs-on: ubuntu-latest
+    # Blocking lane: real uvicorn + headless Chromium drive the full web
+    # workflows. Deterministic (throwaway SQLite per run, no external
+    # network, sandbox env). The merge protocol won't merge if this is red.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "1.8.3"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi
+
+      - name: Install Playwright + Chromium
+        # playwright is e2e-only; installed here (not in poetry.lock) so
+        # the main dependency graph stays lean.
+        run: |
+          poetry run pip install "playwright==1.60.0"
+          poetry run playwright install --with-deps chromium
+
+      - name: Run e2e suite
+        run: poetry run pytest tests/e2e/ -v --tb=short

--- a/tests/e2e/_helpers.py
+++ b/tests/e2e/_helpers.py
@@ -1,0 +1,59 @@
+"""Reusable e2e flow steps (signup, invite, seeding) — distilled from
+the marathon's throwaway drivers so every committed flow shares one
+hardened implementation."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+
+def rid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def signup_admin(
+    page, base_url, *, org="Hope Chapel", name="Admin Dana", email=None, password="HopePass123!"
+):
+    """Create an org + first admin via the signup form; lands on the
+    admin dashboard. Returns the admin email."""
+    email = email or f"admin+{rid()}@hope.e2e"
+    page.goto(f"{base_url}/auth/signup")
+    page.fill("#org_name", org)
+    page.fill("#name", name)
+    page.fill("#email", email)
+    page.fill("#password", password)
+    page.click("button[type=submit]")
+    page.wait_for_url("**/a/dashboard")
+    return email
+
+
+def invite_token(db_path, email):
+    """Read the invitation token straight from the DB (email delivery is
+    disabled in the sandbox)."""
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT token FROM invitations WHERE email=? ORDER BY created_at DESC LIMIT 1",
+            (email,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        con.close()
+
+
+def accept_invitation(context, base_url, token, *, password="VolPass123!"):
+    """Accept an invite in a fresh (logged-out) page; lands authed."""
+    pg = context.new_page()
+    pg.goto(f"{base_url}/auth/invitation/{token}")
+    pg.wait_for_selector("text=You're invited")
+    pg.fill("#password", password)
+    pg.click("button[type=submit]")
+    pg.wait_for_url("**/v/schedule")
+    return pg
+
+
+def no_js_errors(page):
+    """Assert the page accumulated no uncaught JS errors (regression
+    guard for the CSP/Alpine-dead class of bug)."""
+    assert not getattr(page, "test_errors", []), f"JS errors: {page.test_errors}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,142 @@
+"""Committed browser e2e harness (overnight marathon, 2026-05-19).
+
+Boots the real app (uvicorn) against a throwaway SQLite DB and drives it
+with Playwright — the durable replacement for the prior throwaway
+`/tmp/*_driver.py` scripts. Deterministic: fresh DB per session, no
+external network, sandbox env (Stripe/SMS/email all disabled by default).
+
+Run only via the dedicated e2e lane: `pytest tests/e2e/`.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def db_path(tmp_path_factory) -> str:
+    """Filesystem path of the throwaway SQLite DB the live server uses —
+    e2e tests may seed rows directly through it (sqlite3)."""
+    return str(tmp_path_factory.mktemp("e2e") / "e2e.db")
+
+
+@pytest.fixture(scope="session")
+def live_server(db_path):
+    """Real uvicorn process on an ephemeral port, fresh DB, /health-gated."""
+    import os
+
+    port = _free_port()
+    dsn = f"sqlite:///{db_path}"
+    # Inherit the real environment (HOME/LANG/venv vars CI needs) and only
+    # override what makes the run deterministic + sandboxed.
+    env = {
+        **os.environ,
+        "SIGNUPFLOW_DB": dsn,
+        "DATABASE_URL": dsn,
+        "SECRET_KEY": "e2e-overnight-secret-key-min-32-chars-long-xx",
+        "ENVIRONMENT": "development",
+        "EMAIL_ENABLED": "false",
+        "SMS_ENABLED": "false",
+    }
+    # The pytest process (root conftest) sets these, which would force the
+    # live server onto an in-memory DB the test can't seed/read. They must
+    # be ABSENT (not empty) for the server to use the real db_path file.
+    for _k in ("TESTING", "TESTING_FORCE_MEMORY", "PYTEST_CURRENT_TEST"):
+        env.pop(_k, None)
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "api.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        cwd=str(Path(__file__).resolve().parents[2]),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 60
+    try:
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError("uvicorn exited before becoming ready")
+            try:
+                with urllib.request.urlopen(f"{base}/health", timeout=2) as r:
+                    if r.status == 200:
+                        break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError("live server did not become healthy in 60s")
+        yield base
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.fixture(scope="session")
+def _browser():
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+@pytest.fixture
+def new_context(_browser):
+    """Factory for isolated browser contexts. Multi-actor flows (admin +
+    volunteers) MUST each get their own context — pages in one context
+    share cookies, so a second login silently overwrites the session."""
+    made = []
+
+    def _make():
+        ctx = _browser.new_context(viewport={"width": 430, "height": 932}, device_scale_factor=2)
+        made.append(ctx)
+        return ctx
+
+    yield _make
+    for c in made:
+        c.close()
+
+
+@pytest.fixture
+def context(new_context):
+    """Fresh isolated browser context per test (clean cookies)."""
+    return new_context()
+
+
+@pytest.fixture
+def page(context):
+    """A page that auto-accepts hx-confirm dialogs and fails the test on
+    any uncaught JS error (catches the CSP/Alpine class of bug)."""
+    pg = context.new_page()
+    errors: list[str] = []
+    pg.on("pageerror", lambda e: errors.append(str(e)))
+    pg.on("dialog", lambda d: d.accept())
+    pg.test_errors = errors  # asserted by tests/helpers at end
+    yield pg

--- a/tests/e2e/test_smoke_full_loop.py
+++ b/tests/e2e/test_smoke_full_loop.py
@@ -1,0 +1,78 @@
+"""Canonical end-to-end loop — proves the harness + blocking lane.
+
+signup → dashboard → invite volunteer → accept invite → create event
+with a role → run solver → review solution → publish → volunteer sees
+the shift → accepts it → admin review shows them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+
+pytestmark = pytest.mark.e2e
+
+
+def test_full_loop(live_server, new_context, page, db_path):
+    base = live_server
+    r = rid()
+    vol_email = f"jamie+{r}@hope.e2e"
+
+    signup_admin(page, base)
+
+    # Invite a volunteer.
+    page.goto(f"{base}/a/people")
+    page.click("button:has-text('Invite person')")
+    page.fill("#inv_name", "Jamie Park")
+    page.fill("#inv_email", vol_email)
+    page.select_option("#inv_role", "volunteer")
+    page.click("button:has-text('Send invite')")
+    page.wait_for_selector("#invite-result:has-text('Invitation sent')")
+
+    tok = invite_token(db_path, vol_email)
+    assert tok, "invitation token not found in DB"
+    # Volunteer gets an isolated context so accepting the invite does not
+    # overwrite the admin's session cookie.
+    vol_page = accept_invitation(new_context(), base, tok)
+
+    # Admin creates an event with a role the solver can fill.
+    page.goto(f"{base}/a/events")
+    page.click("button:has-text('New event')")
+    page.wait_for_selector("#ev_type", state="visible")
+    page.fill("#ev_type", "Sunday 10am Service")
+    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_start", "10:00")
+    page.fill("#ev_end", "11:30")
+    page.fill("input[name=role_name]", "volunteer")
+    page.fill("input[name=role_count]", "1")
+    page.click("button:has-text('Create event')")
+    page.wait_for_selector("#events-list:has-text('Sunday 10am Service')")
+
+    # Solve.
+    page.goto(f"{base}/a/solver")
+    page.fill("#from_date", "2026-05-19")
+    page.fill("#to_date", "2026-06-30")
+    page.click("button:has-text('Run solver')")
+    page.wait_for_selector("#solver-result:has-text('Review solution')")
+    page.click("a:has-text('Review solution')")
+    page.wait_for_url("**/a/solution/**")
+    page.wait_for_selector("#publish-state")
+
+    # Publish.
+    page.click("button:has-text('Publish this solution')")
+    page.wait_for_selector("#publish-state:has-text('Unpublish')")
+
+    # Volunteer sees and accepts the published shift.
+    vol_page.goto(f"{base}/v/schedule")
+    vol_page.wait_for_selector("text=Sunday 10am Service")
+    vol_page.click("a:has-text('Sunday 10am Service')")
+    vol_page.wait_for_selector("#assignment-card")
+    vol_page.click("button:has-text('Accept')")
+    vol_page.wait_for_selector("#assignment-card .status-text.confirmed")
+
+    # Admin review reflects the assignee.
+    page.reload()
+    page.wait_for_selector("text=Jamie Park")
+
+    no_js_errors(page)

--- a/tests/unit/test_e2e_lane.py
+++ b/tests/unit/test_e2e_lane.py
@@ -1,0 +1,24 @@
+"""Overnight A — the blocking e2e lane + harness stay wired."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_e2e_ci_job_present():
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert "e2e:" in ci, "e2e CI job missing"
+    assert "pytest tests/e2e/" in ci
+    assert "playwright install --with-deps chromium" in ci
+
+
+def test_e2e_harness_committed():
+    e2e = ROOT / "tests" / "e2e"
+    assert (e2e / "conftest.py").exists()
+    assert (e2e / "_helpers.py").exists()
+    assert (e2e / "test_smoke_full_loop.py").exists()
+    conf = (e2e / "conftest.py").read_text()
+    assert "def live_server" in conf
+    assert "sync_playwright" in conf


### PR DESCRIPTION
## Summary

The prior marathon's e2e was throwaway `/tmp/*_driver.py` — **zero committed e2e coverage**. This lands a durable, CI-gated suite:

- **`tests/e2e/conftest.py`** — session **live-server** fixture (real `uvicorn` on a fresh throwaway SQLite, `/health`-gated; inherits env for CI but pops the root-conftest `TESTING`/`TESTING_FORCE_MEMORY` so the server uses the file DB the test seeds), an **isolated-context factory** (multi-actor flows — pages in one context share cookies), and a `page` fixture that **fails on any uncaught JS error** (regression guard for the CSP/Alpine-dead class of bug).
- **`tests/e2e/_helpers.py`** — hardened signup / invite-token / accept-invite steps distilled from the marathon drivers.
- **`tests/e2e/test_smoke_full_loop.py`** — signup→invite→accept→event w/ role→solver→publish→volunteer accept→admin review.
- **`ci.yml`** — new **blocking** `e2e` job: `poetry install` → `playwright install --with-deps chromium` → `pytest tests/e2e/`. Playwright is e2e-only (pip-installed in the job, pinned `1.60.0`; kept out of the main lock).
- Unit guard pins the lane + harness.

This PR's own CI run **self-validates the new e2e lane** on GitHub Actions. Foundation for #196 — all later items add committed e2e flows gated by this lane.

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean; `ci.yml` valid YAML
- [x] `tests/e2e/` — smoke full-loop **passes locally (~4s)** against real uvicorn
- [x] `tests/unit/test_e2e_lane.py` (2) + contract + openapi (8) green
- [ ] CI: `ci` lane green **and** new `e2e` lane green (self-validating)

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)