### PR TITLE
Overnight B1 — volunteer self-serve open shifts

### DIFF
--- a/tests/e2e/test_open_shifts.py
+++ b/tests/e2e/test_open_shifts.py
@@ -1,0 +1,54 @@
+"""Overnight B1 e2e — volunteer self-claims an open shift end-to-end."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+
+pytestmark = pytest.mark.e2e
+
+
+def test_volunteer_claims_open_shift(live_server, new_context, page, db_path):
+    base = live_server
+    vol_email = f"vol+{rid()}@hope.e2e"
+
+    signup_admin(page, base)
+
+    # Invite + accept a volunteer (isolated context).
+    page.goto(f"{base}/a/people")
+    page.click("button:has-text('Invite person')")
+    page.fill("#inv_name", "Sam Lee")
+    page.fill("#inv_email", vol_email)
+    page.select_option("#inv_role", "volunteer")
+    page.click("button:has-text('Send invite')")
+    page.wait_for_selector("#invite-result:has-text('Invitation sent')")
+    tok = invite_token(db_path, vol_email)
+    assert tok
+    vol_page = accept_invitation(new_context(), base, tok)
+
+    # Admin creates an event with one open 'volunteer' role.
+    page.goto(f"{base}/a/events")
+    page.click("button:has-text('New event')")
+    page.wait_for_selector("#ev_type", state="visible")
+    page.fill("#ev_type", "Sunday 10am Service")
+    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_start", "10:00")
+    page.fill("#ev_end", "11:30")
+    page.fill("input[name=role_name]", "volunteer")
+    page.fill("input[name=role_count]", "1")
+    page.click("button:has-text('Create event')")
+    page.wait_for_selector("#events-list:has-text('Sunday 10am Service')")
+
+    # Volunteer sees it on /v/open and claims it.
+    vol_page.goto(f"{base}/v/open")
+    vol_page.wait_for_selector("#open-list:has-text('Sunday 10am Service')")
+    assert "1 of 1 open" in vol_page.content()
+    vol_page.click("button:has-text('Claim')")
+    vol_page.wait_for_selector("#open-list:has-text('No open shifts')")
+
+    # It now appears on their schedule.
+    vol_page.goto(f"{base}/v/schedule")
+    vol_page.wait_for_selector("text=Sunday 10am Service")
+
+    no_js_errors(vol_page)

--- a/tests/web/test_open_shifts.py
+++ b/tests/web/test_open_shifts.py
@@ -1,0 +1,106 @@
+"""Overnight B1 — volunteer self-serve open shifts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from api.models import Assignment, Event
+from tests.web.conftest import seed_person
+from web.deps import SESSION_COOKIE
+
+
+def _vol(client, db, *, org, email, pid):
+    seed_person(db, person_id=pid, org_id=org, email=email, roles=["volunteer"])
+    r = client.post("/auth/login", data={"email": email, "password": "WebPass123!"})
+    return r.cookies[SESSION_COOKIE]
+
+
+def _event(db, org, eid, *, role_counts, days=14):
+    start = datetime.utcnow() + timedelta(days=days)
+    db.add(
+        Event(
+            id=eid,
+            org_id=org,
+            type="Sunday Service",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+            extra_data={"role_counts": role_counts},
+        )
+    )
+    db.commit()
+
+
+def test_open_requires_auth(client):
+    assert client.get("/v/open").status_code == 303
+
+
+def test_lists_and_claims_open_role(client, db):
+    tok = _vol(client, db, org="os_o1", email="v1@os.test", pid="os_v1")
+    _event(db, "os_o1", "os_ev", role_counts={"volunteer": 2})
+
+    page = client.get("/v/open", cookies={SESSION_COOKIE: tok})
+    assert page.status_code == 200
+    assert "Sunday Service" in page.text
+    assert "2 of 2 open" in page.text
+
+    r = client.post(
+        "/v/open/os_ev/claim",
+        data={"role": "volunteer"},
+        cookies={SESSION_COOKIE: tok},
+    )
+    assert r.status_code == 200
+    a = (
+        db.query(Assignment)
+        .filter(Assignment.event_id == "os_ev", Assignment.person_id == "os_v1")
+        .first()
+    )
+    assert a is not None and a.role == "volunteer" and a.status == "confirmed"
+    # Already on the event → no longer offered.
+    assert "Sunday Service" not in r.text
+
+
+def test_capacity_and_double_claim_blocked(client, db):
+    tok = _vol(client, db, org="os_o2", email="v2@os.test", pid="os_v2")
+    seed_person(db, person_id="os_other", org_id="os_o2", email="o@os.test", roles=["volunteer"])
+    _event(db, "os_o2", "os_ev2", role_counts={"usher": 1})
+    # Fill the only slot with someone else.
+    db.add(Assignment(event_id="os_ev2", person_id="os_other", role="usher", status="confirmed"))
+    db.commit()
+
+    r = client.post("/v/open/os_ev2/claim", data={"role": "usher"}, cookies={SESSION_COOKIE: tok})
+    assert r.status_code == 400
+    assert "filled up" in r.text.lower()
+    assert (
+        db.query(Assignment)
+        .filter(Assignment.event_id == "os_ev2", Assignment.person_id == "os_v2")
+        .first()
+        is None
+    )
+
+
+def test_past_event_not_open(client, db):
+    tok = _vol(client, db, org="os_o3", email="v3@os.test", pid="os_v3")
+    start = datetime.utcnow() - timedelta(days=2)
+    db.add(
+        Event(
+            id="os_past",
+            org_id="os_o3",
+            type="Old",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+            extra_data={"role_counts": {"volunteer": 1}},
+        )
+    )
+    db.commit()
+    page = client.get("/v/open", cookies={SESSION_COOKIE: tok})
+    assert "Old" not in page.text
+    blocked = client.post(
+        "/v/open/os_past/claim", data={"role": "volunteer"}, cookies={SESSION_COOKIE: tok}
+    )
+    assert blocked.status_code == 400
+
+
+def test_schedule_links_to_open(client, db):
+    tok = _vol(client, db, org="os_o4", email="v4@os.test", pid="os_v4")
+    sched = client.get("/v/schedule", cookies={SESSION_COOKIE: tok})
+    assert 'href="/v/open"' in sched.text

--- a/web/routers/pages.py
+++ b/web/routers/pages.py
@@ -129,6 +129,69 @@ def root(request: Request):
     return RedirectResponse(url=landing, status_code=303)
 
 
+def _open_shifts(db: Session, person: Person) -> list[dict]:
+    """Future events in the volunteer's org with unfilled role capacity
+    (extra_data.role_counts vs assignments), excluding events they're
+    already on. Org-scoped via the Event join."""
+    from datetime import datetime
+
+    now = datetime.utcnow()
+    events = (
+        db.query(Event)
+        .filter(Event.org_id == person.org_id, Event.start_time >= now)
+        .order_by(Event.start_time.asc())
+        .all()
+    )
+    out = []
+    for e in events:
+        rc = (e.extra_data or {}).get("role_counts") or {}
+        if not rc:
+            continue
+        rows = (
+            db.query(Assignment)
+            .join(Event, Assignment.event_id == Event.id)
+            .filter(Event.org_id == person.org_id, Assignment.event_id == e.id)
+            .all()
+        )
+        if any(a.person_id == person.id for a in rows):
+            continue  # already on this event — don't offer it
+        filled: dict[str, int] = {}
+        for a in rows:
+            filled[a.role or ""] = filled.get(a.role or "", 0) + 1
+        roles = [
+            {"role": r, "needed": n, "remaining": n - filled.get(r, 0)}
+            for r, n in rc.items()
+            if n - filled.get(r, 0) > 0
+        ]
+        if roles:
+            out.append(
+                {
+                    "event_id": e.id,
+                    "event_type": e.type,
+                    "when": e.start_time.strftime("%a %d %b %Y · %H:%M")
+                    if e.start_time
+                    else "",
+                    "roles": roles,
+                }
+            )
+    return out
+
+
+@router.get("/v/open", response_class=HTMLResponse)
+def volunteer_open_shifts(
+    request: Request,
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "volunteer/open.html",
+        {"person": person, "active_tab": "schedule", "open": _open_shifts(db, person)},
+    )
+
+
 @router.get("/v/schedule", response_class=HTMLResponse)
 def volunteer_schedule(
     request: Request,

--- a/web/routers/partials.py
+++ b/web/routers/partials.py
@@ -87,6 +87,7 @@ from web.routers.pages import (
     _my_exceptions,
     _my_rrule,
     _my_timeoff,
+    _open_shifts,
     _recurring,
     _solution_owned,
     _solution_review,
@@ -181,6 +182,67 @@ def swap(
     except HTTPException:
         return _gone()
     return _card(request, person, db, assignment_id)
+
+
+# ── Volunteer: self-serve open shifts ────────────────────────────────
+
+
+def _open_list(request: Request, person: Person, db: Session, *, error=None):
+    from web.app import templates
+
+    return templates.TemplateResponse(
+        request,
+        "partials/open_list.html",
+        {"open": _open_shifts(db, person), "error": error},
+        status_code=400 if error else 200,
+    )
+
+
+@router.post("/v/open/{event_id}/claim", response_class=HTMLResponse)
+def open_claim(
+    request: Request,
+    event_id: str,
+    role: str = Form(...),
+    person: Person = Depends(get_session_user),
+    db: Session = Depends(get_db),
+):
+    """Volunteer self-claims an open role. Re-validated server-side
+    (org, future, role exists, capacity, no double-claim) so it's
+    race-safe; org-scoped direct write (no admin API reuse)."""
+    from datetime import datetime
+
+    ev = (
+        db.query(Event)
+        .filter(Event.org_id == person.org_id, Event.id == event_id)
+        .first()
+    )
+    if ev is None or (ev.start_time and ev.start_time < datetime.utcnow()):
+        return _open_list(request, person, db, error="That event is no longer open.")
+    rc = (ev.extra_data or {}).get("role_counts") or {}
+    if role not in rc:
+        return _open_list(request, person, db, error="That role isn't open.")
+    rows = (
+        db.query(Assignment)
+        .join(Event, Assignment.event_id == Event.id)
+        .filter(Event.org_id == person.org_id, Assignment.event_id == event_id)
+        .all()
+    )
+    if any(a.person_id == person.id for a in rows):
+        return _open_list(request, person, db, error="You're already on this event.")
+    if sum(1 for a in rows if (a.role or "") == role) >= rc[role]:
+        return _open_list(request, person, db, error="That role just filled up.")
+
+    db.add(
+        Assignment(
+            event_id=event_id,
+            person_id=person.id,
+            role=role,
+            solution_id=None,
+            status="confirmed",
+        )
+    )
+    db.commit()
+    return _open_list(request, person, db)
 
 
 # ── Availability: time-off ───────────────────────────────────────────

--- a/web/templates/partials/open_list.html
+++ b/web/templates/partials/open_list.html
@@ -1,0 +1,35 @@
+{# Open (unfilled) shifts the volunteer can self-claim. #open-list. #}
+<div id="open-list">
+  {% if error %}
+  <div class="form-error" role="alert">{{ error }}</div>
+  <div class="spacer-12"></div>
+  {% endif %}
+
+  {% if not open %}
+  <div class="empty">No open shifts right now. 🎉</div>
+  {% else %}
+  {% for ev in open %}
+  <div class="card" style="margin-bottom:12px">
+    <div class="row-title">{{ ev.event_type }}</div>
+    <div class="row-sub">{{ ev.when }}</div>
+    <div class="spacer-12"></div>
+    {% for r in ev.roles %}
+    <div class="row">
+      <div class="row-main">
+        <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+          <span class="role-chip">{{ r.role }}</span>
+          <span class="row-sub">{{ r.remaining }} of {{ r.needed }} open</span>
+        </div>
+      </div>
+      <form hx-post="/v/open/{{ ev.event_id }}/claim"
+            hx-target="#open-list" hx-swap="outerHTML" style="margin:0">
+        <input type="hidden" name="role" value="{{ r.role }}">
+        <button class="btn btn-go" style="width:auto;padding:6px 14px"
+                type="submit">Claim</button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  {% endif %}
+</div>

--- a/web/templates/volunteer/open.html
+++ b/web/templates/volunteer/open.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Open shifts · SignUpFlow{% endblock %}
+{% block body %}
+<div class="nav">
+  <a class="nav-back" href="/v/schedule">‹ Schedule</a>
+  <form method="post" action="/auth/logout" style="margin:0">
+    <button class="nav-action" type="submit">Sign out</button>
+  </form>
+</div>
+<div class="page-title">Open shifts</div>
+<div class="scroll">
+  {% include "partials/open_list.html" %}
+</div>
+{% set tabs = [
+  ('/v/schedule', '▦', 'Schedule', 'schedule'),
+  ('/v/availability', '◷', 'Availability', 'availability'),
+  ('/v/profile', '◍', 'Profile', 'profile'),
+] %}
+{% include "_nav.html" %}
+{% endblock %}

--- a/web/templates/volunteer/schedule.html
+++ b/web/templates/volunteer/schedule.html
@@ -2,7 +2,7 @@
 {% block title %}Schedule · SignUpFlow{% endblock %}
 {% block body %}
 <div class="nav">
-  <span class="nav-back"></span>
+  <a class="nav-back" href="/v/open">Open shifts</a>
   <a class="nav-action" href="/v/inbox">Inbox{% if unread %} ({{ unread }}){% endif %}</a>
 </div>
 <div class="page-title">Schedule</div>


### PR DESCRIPTION
## Summary

New volunteer workflow: **`/v/open`** lists future events in the volunteer's org with **unfilled role capacity** (`extra_data.role_counts` vs assignments), excluding events they're already on. **`POST /v/open/{event}/claim`** self-assigns a slot, **re-validated server-side** (org-scoped, future-only, role exists, capacity remaining, no double-claim) so it's race-safe — an org-scoped direct write (the admin `manage_assignment` API is RBAC-gated and deliberately not reused). Linked from the volunteer schedule header.

Part of #196 (Phase B). First workflow feature with a committed e2e flow under the new blocking lane.

## Test plan

- [x] `black --check api tests` / `ruff check api tests` clean
- [x] `tests/web/test_open_shifts.py` (5) — auth gate, list+claim, capacity/double-claim blocked, past-event excluded, schedule link
- [x] `pytest tests/web tests/contract tests/unit/test_openapi_schema.py` — 201 passed
- [x] `tests/e2e/test_open_shifts.py` — admin creates event w/ role → volunteer claims on /v/open → shows on schedule; full suite (smoke + B1) green locally
- [ ] CI: `ci` + blocking `e2e` lanes green

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)