### PR TITLE
C5 — e2e backfill: CSV import, settings, billing, pricing, dark mode

### DIFF
--- a/tests/e2e/test_settings_billing_pricing.py
+++ b/tests/e2e/test_settings_billing_pricing.py
@@ -1,0 +1,77 @@
+"""Overnight C5 — e2e backfill: CSV import, settings, billing, pricing, dark mode.
+
+Regression guards for existing settings/admin/public surfaces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e._helpers import no_js_errors, rid, signup_admin
+
+pytestmark = pytest.mark.e2e
+
+
+def test_csv_import(live_server, page):
+    base = live_server
+    signup_admin(page, base)
+    page.goto(f"{base}/a/people")
+    page.click("button:text-is('Import CSV')")
+    page.fill("#csv_text", f"Casey Imp,casey+{rid()}@hope.e2e,volunteer")
+    page.click("button:text-is('Import')")
+    page.wait_for_selector("#import-result:has-text('Imported 1')")
+    no_js_errors(page)
+
+
+def test_org_settings_save(live_server, page):
+    base = live_server
+    signup_admin(page, base)
+    page.goto(f"{base}/a/settings")
+    page.wait_for_selector(".page-title:has-text('Settings')")
+    page.fill("#org_name", "Hope Chapel Renamed")
+    page.click("#settings-form button:has-text('Save settings')")
+    page.wait_for_selector("#settings-form:has-text('Settings saved.')")
+    no_js_errors(page)
+
+
+def test_password_change(live_server, page):
+    base = live_server
+    signup_admin(page, base)
+    page.goto(f"{base}/a/settings")
+    page.wait_for_selector("#password-form")
+    page.fill("#pw_current", "HopePass123!")
+    page.fill("#pw_new", "NewHopePass456!")
+    page.fill("#pw_confirm", "NewHopePass456!")
+    page.click("#password-form button:has-text('Change password')")
+    page.wait_for_selector("#password-form .form-notice[role='status']")
+    no_js_errors(page)
+
+
+def test_billing_and_public_pricing(live_server, page):
+    base = live_server
+    signup_admin(page, base)
+    page.goto(f"{base}/a/billing")
+    page.wait_for_selector(".page-title:has-text('Billing')")
+
+    page.goto(f"{base}/pricing")
+    page.wait_for_selector("text=Pricing")
+    page.wait_for_selector("text=pro")
+    page.wait_for_selector("text=enterprise")
+    no_js_errors(page)
+
+
+def test_dark_mode_toggle_persists(live_server, page):
+    base = live_server
+    signup_admin(page, base)
+    page.goto(f"{base}/v/profile")
+    page.wait_for_selector("text=Appearance")
+
+    page.click("button:has-text('Dark')")
+    assert page.evaluate("document.documentElement.getAttribute('data-theme')") == "dark"
+
+    page.reload()  # persisted via localStorage → no-flash script re-applies
+    assert page.evaluate("document.documentElement.getAttribute('data-theme')") == "dark"
+
+    page.click("button:has-text('Light')")
+    assert page.evaluate("document.documentElement.getAttribute('data-theme')") == "light"
+    no_js_errors(page)


### PR DESCRIPTION
## Summary
Final Phase C cluster — regression e2e (no production change): CSV bulk import, org-settings save, self password change, billing + public pricing pages, and dark-mode toggle persisting via localStorage.

## Test plan
- [x] `tests/e2e/test_settings_billing_pricing.py` — 5 tests, green locally
- [x] `black` + `ruff` clean
- [ ] CI: lint/type/test + blocking e2e lane green

Closes #224 · part of #196 (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)