### PR TITLE
fix(e2e): bump stale 2026-06-07 seed dates so /v/open tests stop timing out

### DIFF
--- a/tests/e2e/_helpers.py
+++ b/tests/e2e/_helpers.py
@@ -6,10 +6,28 @@ from __future__ import annotations
 
 import sqlite3
 import uuid
+from datetime import date, timedelta
 
 
 def rid() -> str:
     return uuid.uuid4().hex[:8]
+
+
+def next_sunday_iso() -> str:
+    """Return the ISO date of a Sunday at least 7 days from today.
+
+    The open-shift, swap, and decline-reopen flows seed a "Sunday 10am
+    Service" event and expect it to appear on `/v/open` (which filters
+    out past events). Hard-coded dates rot the suite as time passes —
+    this keeps the seed event safely in the future on every run.
+    """
+    today = date.today()
+    # weekday(): Monday=0 ... Sunday=6. Days until next Sunday after at
+    # least a 7-day cushion.
+    days_until_sunday = (6 - today.weekday()) % 7
+    if days_until_sunday < 7:
+        days_until_sunday += 7
+    return (today + timedelta(days=days_until_sunday)).isoformat()
 
 
 def signup_admin(

--- a/tests/e2e/test_decline_reopen.py
+++ b/tests/e2e/test_decline_reopen.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -39,7 +46,7 @@ def test_decline_reopens_slot(live_server, new_context, page, db_path):
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", next_sunday_iso())
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")

--- a/tests/e2e/test_event_roster_fill.py
+++ b/tests/e2e/test_event_roster_fill.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -28,7 +35,7 @@ def test_admin_fills_roster_gap(live_server, new_context, page, db_path):
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", next_sunday_iso())
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "usher")

--- a/tests/e2e/test_open_shifts.py
+++ b/tests/e2e/test_open_shifts.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -32,7 +39,7 @@ def test_volunteer_claims_open_shift(live_server, new_context, page, db_path):
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", next_sunday_iso())
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")

--- a/tests/e2e/test_swap_marketplace.py
+++ b/tests/e2e/test_swap_marketplace.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -36,7 +43,7 @@ def test_cover_a_swap_end_to_end(live_server, new_context, page, db_path):
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", next_sunday_iso())
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")


### PR DESCRIPTION
## Why

Four e2e tests (`test_decline_reopen`, `test_event_roster_fill`, `test_open_shifts`, `test_swap_marketplace`) seed a "Sunday 10am Service" event with hard-coded date `2026-06-07` and then wait for it on `/v/open` (or the swap-open list). Those volunteer-facing views filter out past events, so as soon as today's date rolled past 2026-06-07 the selector `#open-list:has-text('Sunday 10am Service')` started timing out on every PR — blocking the E2E lane for **all** new work, not just the PR that happens to be open.

PR #226 (calendar/export auth) is currently red on this exact pattern. Landing this first unblocks both #226 and the in-flight `sprint-4-pr-4-5c-calendar-org-export-auth` work.

## What changed

- `tests/e2e/_helpers.py` — new `next_sunday_iso()` helper returning a Sunday at least 7 days from `date.today()`. Keeps the seed event reliably in the future regardless of when the suite runs.
- `tests/e2e/test_decline_reopen.py`, `test_event_roster_fill.py`, `test_open_shifts.py`, `test_swap_marketplace.py` — replace the literal `"2026-06-07"` with `next_sunday_iso()`.

## Scope

Narrow on purpose. Seven other e2e files still pass `"2026-06-07"`, but they exercise admin views that do not filter on date, and some pair the date with a hard-coded solver window (e.g. `_solve_and_publish` uses `from=2026-05-19, to=2026-06-30`). Bumping their date without also bumping the window would break previously-green tests. Left as a follow-up.

## Validation

- `poetry run black tests/e2e/` clean
- `poetry run ruff check tests/e2e/` clean
- `poetry run pytest --co tests/` collects 361 tests (imports OK)
- E2E suite could not run locally — the pre-installed Playwright Chromium is v1194 while the CI install pulls v1223, so the launch fails. CI is the source of truth for this lane.

## Follow-ups

- Sweep the remaining 7 e2e files that still use `2026-06-07`. Bump the dates **and** the matching solver windows in the same PR.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuRZNryfqzWoAJ46vqArxU)_