### PR TITLE
fix(e2e): sweep stale 2026-06-07 dates + hardcoded solver windows

### DIFF
--- a/tests/e2e/_helpers.py
+++ b/tests/e2e/_helpers.py
@@ -30,6 +30,23 @@ def next_sunday_iso() -> str:
     return (today + timedelta(days=days_until_sunday)).isoformat()
 
 
+def solver_window_around(seed_iso: str) -> tuple[str, str]:
+    """Return (from_date, to_date) ISO strings that safely bracket a seed
+    event date for `/a/solver`.
+
+    Flows that seed an event with `next_sunday_iso()` then run the solver
+    over a window must pick from/to dates that comfortably contain the
+    seed. Fixed literal windows (e.g. from=2026-05-19, to=2026-06-30)
+    rot as time passes and drop the seed event outside the window. This
+    helper returns a 3-week-before / 3-week-after bracket around the
+    seed, mirroring the pattern the sweep replaces.
+    """
+    seed = date.fromisoformat(seed_iso)
+    from_date = (seed - timedelta(days=21)).isoformat()
+    to_date = (seed + timedelta(days=21)).isoformat()
+    return from_date, to_date
+
+
 def signup_admin(
     page, base_url, *, org="Hope Chapel", name="Admin Dana", email=None, password="HopePass123!"
 ):

--- a/tests/e2e/test_analytics_recurring_swapreview.py
+++ b/tests/e2e/test_analytics_recurring_swapreview.py
@@ -7,9 +7,20 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
+
+EV_DATE = next_sunday_iso()
+FROM_DATE, TO_DATE = solver_window_around(EV_DATE)
 
 
 def _new_event(page, base, etype):
@@ -17,7 +28,7 @@ def _new_event(page, base, etype):
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", etype)
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", EV_DATE)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -28,8 +39,8 @@ def _new_event(page, base, etype):
 
 def _solve_and_publish(page, base):
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", FROM_DATE)
+    page.fill("#to_date", TO_DATE)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/e2e/test_availability_solver.py
+++ b/tests/e2e/test_availability_solver.py
@@ -10,7 +10,15 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -31,10 +39,12 @@ def test_timeoff_blocks_solver_assignment(live_server, new_context, page, db_pat
     vol_page = accept_invitation(new_context(), base, invite_token(db_path, vol_email))
 
     # Volunteer books time-off covering the event date.
+    ev_date = next_sunday_iso()
+    from_date, to_date = solver_window_around(ev_date)
     vol_page.goto(f"{base}/v/availability")
     vol_page.wait_for_selector("#start_date")
-    vol_page.fill("#start_date", "2026-06-07")
-    vol_page.fill("#end_date", "2026-06-07")
+    vol_page.fill("#start_date", ev_date)
+    vol_page.fill("#end_date", ev_date)
     vol_page.fill("#reason", "Vacation")
     vol_page.click("button:has-text('Add time-off')")
     vol_page.wait_for_selector("#timeoff-list:has-text('Vacation')")
@@ -44,7 +54,7 @@ def test_timeoff_blocks_solver_assignment(live_server, new_context, page, db_pat
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", ev_date)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -54,8 +64,8 @@ def test_timeoff_blocks_solver_assignment(live_server, new_context, page, db_pat
 
     # Solve, then publish.
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", from_date)
+    page.fill("#to_date", to_date)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/e2e/test_bulk_notify.py
+++ b/tests/e2e/test_bulk_notify.py
@@ -8,7 +8,15 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -28,11 +36,13 @@ def test_notify_published_schedule_reaches_inbox(live_server, new_context, page,
     page.wait_for_selector("#invite-result:has-text('Invitation sent')")
     vol_page = accept_invitation(new_context(), base, invite_token(db_path, vol_email))
 
+    ev_date = next_sunday_iso()
+    from_date, to_date = solver_window_around(ev_date)
     page.goto(f"{base}/a/events")
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", ev_date)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -41,8 +51,8 @@ def test_notify_published_schedule_reaches_inbox(live_server, new_context, page,
     page.wait_for_selector("#events-list:has-text('Sunday 10am Service')")
 
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", from_date)
+    page.fill("#to_date", to_date)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/e2e/test_calendar_subscription.py
+++ b/tests/e2e/test_calendar_subscription.py
@@ -10,7 +10,15 @@ import re
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -38,11 +46,13 @@ def test_subscription_gates_on_publish(live_server, new_context, page, db_path):
     page.wait_for_selector("#invite-result:has-text('Invitation sent')")
     vol_page = accept_invitation(new_context(), base, invite_token(db_path, vol_email))
 
+    ev_date = next_sunday_iso()
+    from_date, to_date = solver_window_around(ev_date)
     page.goto(f"{base}/a/events")
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", ev_date)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -52,8 +62,8 @@ def test_subscription_gates_on_publish(live_server, new_context, page, db_path):
 
     # Solve — produces a DRAFT (unpublished) solution + assignment.
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", from_date)
+    page.fill("#to_date", to_date)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
 

--- a/tests/e2e/test_notif_assign_unpublish.py
+++ b/tests/e2e/test_notif_assign_unpublish.py
@@ -9,9 +9,20 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
+
+EV_DATE = next_sunday_iso()
+FROM_DATE, TO_DATE = solver_window_around(EV_DATE)
 
 
 def _new_event(page, base, etype="Sunday 10am Service", role="volunteer", count="1"):
@@ -19,7 +30,7 @@ def _new_event(page, base, etype="Sunday 10am Service", role="volunteer", count=
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", etype)
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", EV_DATE)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", role)
@@ -30,8 +41,8 @@ def _new_event(page, base, etype="Sunday 10am Service", role="volunteer", count=
 
 def _solve_and_publish(page, base):
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", FROM_DATE)
+    page.fill("#to_date", TO_DATE)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/e2e/test_onboarding_wizard.py
+++ b/tests/e2e/test_onboarding_wizard.py
@@ -9,7 +9,15 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -40,11 +48,13 @@ def test_fresh_admin_completes_wizard(live_server, new_context, page, db_path):
     _progress(page, base, "1 of 4 done")
 
     # 2) Create an event.
+    ev_date = next_sunday_iso()
+    from_date, to_date = solver_window_around(ev_date)
     page.goto(f"{base}/a/events")
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", ev_date)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -57,8 +67,8 @@ def test_fresh_admin_completes_wizard(live_server, new_context, page, db_path):
     # sequence (the solver page only holds the result until you navigate
     # away, so the review link must be clicked without leaving).
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", from_date)
+    page.fill("#to_date", to_date)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/e2e/test_smoke_full_loop.py
+++ b/tests/e2e/test_smoke_full_loop.py
@@ -9,7 +9,15 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e._helpers import accept_invitation, invite_token, no_js_errors, rid, signup_admin
+from tests.e2e._helpers import (
+    accept_invitation,
+    invite_token,
+    next_sunday_iso,
+    no_js_errors,
+    rid,
+    signup_admin,
+    solver_window_around,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -37,11 +45,13 @@ def test_full_loop(live_server, new_context, page, db_path):
     vol_page = accept_invitation(new_context(), base, tok)
 
     # Admin creates an event with a role the solver can fill.
+    ev_date = next_sunday_iso()
+    from_date, to_date = solver_window_around(ev_date)
     page.goto(f"{base}/a/events")
     page.click("button:has-text('New event')")
     page.wait_for_selector("#ev_type", state="visible")
     page.fill("#ev_type", "Sunday 10am Service")
-    page.fill("#ev_date", "2026-06-07")
+    page.fill("#ev_date", ev_date)
     page.fill("#ev_start", "10:00")
     page.fill("#ev_end", "11:30")
     page.fill("input[name=role_name]", "volunteer")
@@ -51,8 +61,8 @@ def test_full_loop(live_server, new_context, page, db_path):
 
     # Solve.
     page.goto(f"{base}/a/solver")
-    page.fill("#from_date", "2026-05-19")
-    page.fill("#to_date", "2026-06-30")
+    page.fill("#from_date", from_date)
+    page.fill("#to_date", to_date)
     page.click("button:has-text('Run solver')")
     page.wait_for_selector("#solver-result:has-text('Review solution')")
     page.click("a:has-text('Review solution')")

--- a/tests/unit/test_e2e_helpers.py
+++ b/tests/unit/test_e2e_helpers.py
@@ -1,0 +1,38 @@
+"""Invariants for `tests/e2e/_helpers` date utilities.
+
+These lock in the properties the e2e-lane relies on:
+- `next_sunday_iso()` returns a Sunday at least 7 days in the future.
+- `solver_window_around(seed)` returns (from, to) that comfortably
+  brackets `seed` so the seed always falls inside the solver window.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from tests.e2e._helpers import next_sunday_iso, solver_window_around
+
+
+def test_next_sunday_iso_is_a_future_sunday():
+    seed = date.fromisoformat(next_sunday_iso())
+    assert seed.weekday() == 6, "helper must return a Sunday"
+    assert (seed - date.today()).days >= 7, "helper must return a date at least 7 days from today"
+
+
+def test_solver_window_brackets_seed():
+    seed_iso = next_sunday_iso()
+    seed = date.fromisoformat(seed_iso)
+    from_iso, to_iso = solver_window_around(seed_iso)
+    from_d = date.fromisoformat(from_iso)
+    to_d = date.fromisoformat(to_iso)
+    assert from_d < seed < to_d, "seed must fall strictly inside (from, to)"
+    assert (seed - from_d).days >= 7, "from_date must be well before seed"
+    assert (to_d - seed).days >= 7, "to_date must be well after seed"
+
+
+def test_solver_window_deterministic_from_seed():
+    from_a, to_a = solver_window_around("2026-08-02")
+    from_b, to_b = solver_window_around("2026-08-02")
+    assert (from_a, to_a) == (from_b, to_b)
+    assert from_a == "2026-07-12"
+    assert to_a == "2026-08-23"


### PR DESCRIPTION
## Why

Follow-up from #227. That PR bumped `2026-06-07` in the four e2e files that watch `/v/open` (which filters out past events), but explicitly deferred the remaining seven because their tests also seed a hardcoded solver window (`from=2026-05-19, to=2026-06-30`) that has to move in lockstep with the seed event date — bumping just one would push the seed outside the window and drop the assignment.

Today (2026-07-13) is already **~5 weeks past** `2026-06-07`. The seven files continue to compile and run, but any downstream assertion that depends on a solve-and-publish producing a real assignment (`/v/schedule` seeing "Sunday 10am Service", `/v/inbox` seeing the auto notification, the ICS feed containing the shift, the onboarding wizard hitting `2 of 4 done`) is at real risk of quietly going empty as the seed date recedes and the fixed window falls out of relevance.

This PR closes the sweep in one commit.

## What changed

- **`tests/e2e/_helpers.py`** — new `solver_window_around(seed_iso)` helper that returns a `(from_date, to_date)` pair three weeks either side of the seed. Same rot-prevention pattern as the existing `next_sunday_iso()`.
- **Inlined seed + window in single-test files** (each was already calling `page.fill("#ev_date", ...)` and `page.fill("#from_date"|"#to_date", ...)` inside a single test function):
  - `test_smoke_full_loop.py`
  - `test_availability_solver.py` — same seed date used for `/v/availability` time-off entries as well
  - `test_bulk_notify.py`
  - `test_calendar_subscription.py`
  - `test_onboarding_wizard.py`
- **Module-level constants** for two files whose seed + window are shared across multiple test functions via helpers (`_new_event`, `_solve_and_publish`):
  - `test_notif_assign_unpublish.py`
  - `test_analytics_recurring_swapreview.py`
  - Chose `EV_DATE` / `FROM_DATE` / `TO_DATE` at import time so the helpers stay parameterless. `next_sunday_iso()` is pure w.r.t. `date.today()`, so a single test run sees one consistent triple.
- **`tests/unit/test_e2e_helpers.py`** — new: 3 invariants for the two helpers (Sunday-in-future, seed strictly inside window, deterministic given the same seed).

## Validation

- `poetry run pytest tests/unit/test_e2e_helpers.py tests/unit/test_e2e_lane.py` → 5 passed
- `make test-unit-fast` → 341 passed, 21 skipped
- `poetry run pytest tests/api tests/contract tests/web` → 550 passed
- `poetry run black --check api tests` → clean
- `poetry run ruff check api tests` → clean

E2E lane could not be exercised locally (Playwright browser channel mismatch, same limitation noted in #227); CI is the source of truth for the e2e job. Contract snapshot untouched — no endpoints changed.

## Follow-ups

- `2026-07-05` in `test_analytics_recurring_swapreview.py` (`#rs_sd`, a recurring-series start date on a different code path) is not on any solve-and-publish flow and is still ~2 weeks in the future. Left alone to keep this sweep narrow; worth bumping alongside the next rot fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jrhveSKJ47AZujrZjXbpS)_