### PR TITLE
Sprint 4 PR 4.8 — mypy strict for api/core and api/schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,12 @@ jobs:
       - name: Ruff (lint)
         run: poetry run ruff check api tests
 
-      - name: mypy strict (api/utils)
-        # PR 4.7 made api/utils strict. Failures here block merges.
-        # When you add a new file to api/utils it must satisfy strict mypy.
-        run: poetry run mypy api/utils
+      - name: mypy strict (api/utils, api/core, api/schemas)
+        # PR 4.7 made api/utils strict; PR 4.8 added api/core (solver domain)
+        # and api/schemas (Pydantic contract layer). Failures here block
+        # merges. When you add a new file to any of these packages it must
+        # satisfy strict mypy.
+        run: poetry run mypy api/utils api/core api/schemas
 
       - name: mypy (type check, advisory)
         # mypy is advisory for the rest of api/ while we work down the legacy

--- a/api/core/constraints/dsl.py
+++ b/api/core/constraints/dsl.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
-from datetime import date
 from typing import Any
 
 from api.core.models import Event, Person, Team
@@ -16,11 +16,14 @@ class EvalContext:
     event: Event | None = None
     person: Person | None = None
     team: Team | None = None
-    date: date | None = None
+    # NOTE: the field name `date` shadows the `date` symbol inside this class
+    # body, so both annotations below must qualify as `datetime.date`.
+    # Previously `holidays` resolved to the *field*, not the type.
+    date: datetime.date | None = None
     all_events: list[Event] | None = None
     all_people: list[Person] | None = None
     all_teams: list[Team] | None = None
-    holidays: dict[date, bool] | None = None
+    holidays: dict[datetime.date, bool] | None = None
     params: dict[str, Any] | None = None
     assignments: dict[str, list[str]] | None = None  # event_id -> person_ids
     person_assignments: dict[str, list[Event]] | None = None  # person_id -> events

--- a/api/core/loader.py
+++ b/api/core/loader.py
@@ -29,7 +29,8 @@ def load_yaml(path: Path) -> dict[str, Any]:
 def load_json(path: Path) -> dict[str, Any]:
     """Load JSON file to dict."""
     with open(path, encoding="utf-8") as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
 def save_json(path: Path, data: dict[str, Any]) -> None:

--- a/api/core/solver/heuristics.py
+++ b/api/core/solver/heuristics.py
@@ -160,7 +160,7 @@ class GreedyHeuristicSolver(SolverAdapter):
             # No specific requirements, assign from team or skip
             if event.team_ids and self.context.teams:
                 team_map = {t.id: t for t in self.context.teams}
-                assignees = []
+                assignees: list[str] = []
                 for team_id in event.team_ids:
                     if team_id in team_map:
                         assignees.extend(team_map[team_id].members[:2])  # Take first 2
@@ -172,8 +172,9 @@ class GreedyHeuristicSolver(SolverAdapter):
                 )
             return Assignment(event_id=event.id, assignees=[], resource_id=event.resource_id)
 
-        # Assign people to roles
-        assignees: list[str] = []
+        # Assign people to roles. Re-binds the name declared above; the
+        # no-required-roles branch always returns before reaching here.
+        assignees = []
         people_map = {p.id: p for p in self.context.people}
 
         for req_role in required_roles:

--- a/api/core/timeutils.py
+++ b/api/core/timeutils.py
@@ -6,10 +6,15 @@ from datetime import date, datetime, timedelta
 from dateutil import rrule
 
 
-def parse_rrule(rrule_str: str, dtstart: datetime, until: datetime) -> Iterator[datetime]:
-    """Parse RRULE string and generate occurrences."""
+def parse_rrule(rrule_str: str, dtstart: datetime, until: datetime) -> list[datetime]:
+    """Parse RRULE string and return occurrences in [dtstart, until] inclusive.
+
+    `rrule.between()` materialises a list, so callers may safely re-iterate
+    the result.
+    """
     rule = rrule.rrulestr(rrule_str, dtstart=dtstart)
-    return rule.between(dtstart, until, inc=True)
+    occurrences: list[datetime] = list(rule.between(dtstart, until, inc=True))
+    return occurrences
 
 
 def date_range(start: date, end: date) -> Iterator[date]:

--- a/tests/unit/test_core_typing_strict.py
+++ b/tests/unit/test_core_typing_strict.py
@@ -1,0 +1,75 @@
+"""Strict-typing gate for `api/core` and `api/schemas` (Sprint 4 PR 4.8).
+
+PR 4.7 made `api/utils` a blocking strict-mypy step in CI. This module
+extends the same treatment to the solver domain (`api/core`) and the
+Pydantic contract layer (`api/schemas`), and pins the behaviour of the
+two latent bugs the strict pass surfaced:
+
+- `EvalContext.date` shadowed the imported `datetime.date` type, so
+  `holidays: dict[date, bool]` silently resolved to the *field*, not the
+  type.
+- `GreedyHeuristicSolver._assign_event` bound `assignees` twice, the
+  second time with a conflicting annotation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date, datetime
+
+import pytest
+
+from api.core.constraints.dsl import EvalContext
+from api.core.timeutils import parse_rrule
+
+pytestmark = pytest.mark.unit
+
+
+STRICT_PACKAGES = ["api/core", "api/schemas"]
+
+
+def test_mypy_strict_clean_for_core_and_schemas() -> None:
+    """`mypy api/core api/schemas` must be clean — this gate blocks merges."""
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", *STRICT_PACKAGES],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "strict mypy regressed for "
+        f"{' '.join(STRICT_PACKAGES)}:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_eval_context_date_field_accepts_a_real_date() -> None:
+    """The `date` field holds a `datetime.date`, not the shadowed type alias."""
+    ctx = EvalContext(date=date(2026, 8, 4))
+
+    assert ctx.date == date(2026, 8, 4)
+    assert isinstance(ctx.date, date)
+
+
+def test_eval_context_holidays_is_keyed_by_date() -> None:
+    """`holidays` maps `datetime.date` -> bool despite the field name clash."""
+    holiday = date(2026, 12, 25)
+    ctx = EvalContext(date=holiday, holidays={holiday: True})
+
+    assert ctx.holidays is not None
+    assert ctx.holidays[holiday] is True
+    assert all(isinstance(key, date) for key in ctx.holidays)
+
+
+def test_parse_rrule_returns_a_concrete_sequence() -> None:
+    """`parse_rrule` returns a list — `between()` never yields an iterator."""
+    start = datetime(2026, 8, 3)
+    until = datetime(2026, 8, 31)
+
+    occurrences = parse_rrule("FREQ=WEEKLY;BYDAY=MO", start, until)
+
+    assert isinstance(occurrences, list)
+    assert all(isinstance(occ, datetime) for occ in occurrences)
+    # Mondays in the window: Aug 3, 10, 17, 24, 31.
+    assert len(occurrences) == 5
+    # Re-iterating a list is safe; an exhausted iterator would be empty.
+    assert list(occurrences) == list(occurrences)


### PR DESCRIPTION
## Summary

Extends the PR 4.7 blocking strict-mypy CI step from `api/utils` to the solver domain (`api/core`) and the Pydantic contract layer (`api/schemas`).

`api/schemas` was already strict-clean (18 files). `api/core` had 4 errors, **two of which were genuine latent type bugs**:

### `api/core/constraints/dsl.py` — field shadowed the type
```python
date: date | None = None                 # field named `date` shadows the import
holidays: dict[date, bool] | None = None # ...so this resolved to the *field*, not the type
```
Switched to `import datetime` and qualified both annotations as `datetime.date`. Runtime behaviour is unchanged (the module uses `from __future__ import annotations`, so dataclass annotations are never evaluated), but the declared contract is now correct — previously `holidays` had a meaningless key type.

### `api/core/solver/heuristics.py` — double binding
`assignees` was bound at line 163 and again at 176 with a conflicting annotation. The no-required-roles branch always returns before reaching the second binding, so this was type-level only; moved the annotation to the first binding.

### `api/core/timeutils.py` — wrong return type
`parse_rrule` declared `Iterator[datetime]` but `rrule.between()` returns a list. Corrected to `list[datetime]` so callers may safely re-iterate.

### `api/core/loader.py`
Bound `json.load()` to a typed local to silence `no-any-return`.

## Changed files

| File | Change |
| --- | --- |
| `api/core/constraints/dsl.py` | qualify `datetime.date` in `EvalContext` |
| `api/core/solver/heuristics.py` | annotate first `assignees` binding |
| `api/core/timeutils.py` | `parse_rrule -> list[datetime]` |
| `api/core/loader.py` | typed local for `json.load()` |
| `.github/workflows/ci.yml` | strict step covers all three packages |
| `tests/unit/test_core_typing_strict.py` | **new** — 4 tests |

The new test file includes a gate that shells out to `mypy api/core api/schemas` and asserts it exits clean, so a typing regression fails the unit tier locally rather than only in CI. The other three tests pin the behaviour of the two latent bugs (`EvalContext.date` holds a real `datetime.date`, `holidays` is keyed by date, `parse_rrule` returns a re-iterable sequence).

## Validation

- `poetry run mypy api/utils api/core api/schemas` → clean, 61 source files
- `poetry run black --check api tests` → clean
- `poetry run ruff check api tests` → clean
- `pytest tests/unit tests/api tests/cli tests/contract` → **695 passed, 21 skipped**
- `pytest tests/web tests/integration` → **541 passed**

No endpoints or response shapes changed, so no OpenAPI snapshot refresh is required.

## Follow-ups

- **`make test-all` is red on `main`, pre-existing.** Verified at `a09e422` *before* this branch: 9 failed / 333 passed. The Makefile exports `SKIP_TEST_DB_FIXTURES=true`, which disables per-test DB isolation, so create-tests collide with `tests.setup_test_data` seed rows and return 409. CI runs bare `pytest` and is unaffected, which is why it went unnoticed. This branch shows the same 9 failures plus its 4 new passing tests — no regression. Worth its own PR.
- Remaining advisory mypy backlog is concentrated in `api/routers` (508 errors) and `api/services` (180).

---
_Generated by [Claude Code](https://claude.ai/code/session_013v7qGC4EZftRXXxdFcasAN)_