### PR TITLE
Sprint 4 PR 4.9 — make the Makefile reset the DB the tests actually use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@ TEST_SERVER_PORT ?= 8000
 TEST_APP_URL ?= http://localhost:$(TEST_SERVER_PORT)
 TEST_API_BASE ?= $(TEST_APP_URL)/api
 
-TEST_DB_PATH := $(abspath test_roster.db)
+# tests/conftest.py sets TESTING_FORCE_MEMORY=true, which makes
+# api/database.py bind to /tmp/signupflow_test.db no matter what
+# DATABASE_URL says. Point the Makefile at that same file so `rm` and
+# `setup_test_data` actually reset the database the suite reads. Using
+# ./test_roster.db here meant every reset was a no-op and the real DB
+# accumulated rows across runs until fixed-ID tests collided with 409.
+TEST_DB_PATH := /tmp/signupflow_test.db
 TEST_DB_PATH_STRIPPED := $(patsubst /%,%,$(TEST_DB_PATH))
 TEST_DB_URL := sqlite:////$(TEST_DB_PATH_STRIPPED)
 export DATABASE_URL ?= $(TEST_DB_URL)
@@ -186,7 +192,7 @@ test-integration: check-poetry
 
 test-all: ensure-test-env
 	@echo "🚀 Running complete test suite..."
-	@rm -f test_roster.db test_roster.db-shm test_roster.db-wal
+	@rm -f $(TEST_DB_PATH) $(TEST_DB_PATH)-shm $(TEST_DB_PATH)-wal
 	@echo "🔄 Rebuilding fresh SQLite test database..."
 	@poetry run python -m tests.setup_test_data >/dev/null
 	@echo ""
@@ -231,7 +237,7 @@ clean:
 	@rm -rf coverage
 	@rm -rf htmlcov
 	@rm -rf .pytest_cache
-	@rm -rf test_roster.db
+	@rm -f $(TEST_DB_PATH) $(TEST_DB_PATH)-shm $(TEST_DB_PATH)-wal
 	@rm -rf __pycache__
 	@find . -type d -name "__pycache__" ! -path "*/.venv/*" -exec rm -rf {} + 2>/dev/null || true
 	@find . -type f -name "*.pyc" ! -path "*/.venv/*" -delete 2>/dev/null || true

--- a/tests/unit/test_make_test_db_path.py
+++ b/tests/unit/test_make_test_db_path.py
@@ -1,0 +1,75 @@
+"""Guard: the Makefile must reset the database the tests actually use.
+
+`tests/conftest.py` forces `TESTING_FORCE_MEMORY=true`, which makes
+`api/database.py` bind to `/tmp/signupflow_test.db` regardless of
+`DATABASE_URL`. The Makefile used to define its test DB as
+`./test_roster.db` and `rm` that file between runs — a file the suite
+never reads.
+
+Combined with the Makefile's `SKIP_TEST_DB_FIXTURES=true` (which skips the
+per-test truncation fixture), nothing ever reset the real database, so
+`/tmp/signupflow_test.db` accumulated rows across every run and
+fixed-ID create-tests eventually collided with 409 CONFLICT. `make
+test-all` was red on any machine that had run the suite before, while CI
+— which runs bare `pytest` on a fresh runner — stayed green.
+
+These tests pin the two halves of that contract so the paths cannot drift
+apart again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+CONFTEST = REPO_ROOT / "tests" / "conftest.py"
+
+# The path api/database.py binds to when TESTING_FORCE_MEMORY is set.
+FORCED_TEST_DB = "/tmp/signupflow_test.db"
+
+
+def _makefile_var(name: str) -> str:
+    """Return the literal right-hand side of a `NAME := value` assignment."""
+    match = re.search(rf"^{re.escape(name)}\s*:?=\s*(.+)$", MAKEFILE.read_text(), re.MULTILINE)
+    assert match is not None, f"{name} not found in Makefile"
+    return match.group(1).strip()
+
+
+def test_database_module_forces_the_tmp_path_under_testing() -> None:
+    """`api/database.py` redirects to the /tmp DB when TESTING_FORCE_MEMORY is set."""
+    source = (REPO_ROOT / "api" / "database.py").read_text()
+
+    assert 'os.getenv("TESTING_FORCE_MEMORY") == "true"' in source
+    assert FORCED_TEST_DB in source
+
+
+def test_conftest_sets_testing_force_memory() -> None:
+    """conftest turns that redirect on for every test run."""
+    source = CONFTEST.read_text()
+
+    assert 'os.environ["TESTING_FORCE_MEMORY"] = "true"' in source
+
+
+def test_makefile_test_db_path_matches_the_db_tests_use() -> None:
+    """The Makefile's TEST_DB_PATH must be the DB the suite actually binds to."""
+    assert _makefile_var("TEST_DB_PATH") == FORCED_TEST_DB
+
+
+def test_makefile_never_targets_the_unused_roster_db() -> None:
+    """No Makefile recipe should still be resetting the stale test_roster.db."""
+    offenders = [
+        line.strip()
+        for line in MAKEFILE.read_text().splitlines()
+        if "test_roster.db" in line and not line.lstrip().startswith("#")
+    ]
+
+    assert offenders == [], (
+        "Makefile still references test_roster.db, which the test suite never "
+        f"reads (it binds to {FORCED_TEST_DB}):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary

`make test-all` — the gate `CLAUDE.md` tells contributors to run before pushing a PR — has been **red on `main`** on any machine that had run the suite before. Measured at `a09e422`: **9 failed / 333 passed**.

The cause is a path mismatch, not a flaky test.

### The two halves that disagreed

- `tests/conftest.py:15` sets `TESTING_FORCE_MEMORY=true` unconditionally, which makes `api/database.py:18-19` bind to `/tmp/signupflow_test.db` **regardless of `DATABASE_URL`**.
- The Makefile defined `TEST_DB_PATH := $(abspath test_roster.db)` and `rm`'d *that* file between runs — a file the suite never reads. `setup_test_data` seeded it too, via the Makefile's exported `DATABASE_URL`.

So `@echo "🔄 Rebuilding fresh SQLite test database..."` was a no-op. Every run.

### Why that turned into failures

The Makefile also exports `SKIP_TEST_DB_FIXTURES=true`, which makes `conftest` skip the per-test truncation fixture. With truncation skipped *and* the reset hitting the wrong file, nothing ever cleaned `/tmp/signupflow_test.db`. It accumulated across every run the repo had ever done — **518 organizations and 794 people** by the time I diagnosed it. Tests that create fixed IDs (`person_001`, `avail_test_org1`, …) eventually hit rows left by earlier runs and got `409 CONFLICT`. Failures grew run over run: a partially-dirty DB gave 2 failures, a dirtier one gave 9.

CI never noticed because it runs bare `pytest` on a fresh runner and never invokes `make`.

## Fix

Point `TEST_DB_PATH` at `/tmp/signupflow_test.db` so both the reset and the seed target the DB the suite actually binds to, and derive every `rm` from that variable rather than hardcoding the stale filename.

```diff
-TEST_DB_PATH := $(abspath test_roster.db)
+TEST_DB_PATH := /tmp/signupflow_test.db
```

```diff
-	@rm -f test_roster.db test_roster.db-shm test_roster.db-wal
+	@rm -f $(TEST_DB_PATH) $(TEST_DB_PATH)-shm $(TEST_DB_PATH)-wal
```

## Tests

New `tests/unit/test_make_test_db_path.py` (4 tests) pins both halves of the contract so they cannot drift apart again:

1. `api/database.py` still redirects to the `/tmp` path under `TESTING_FORCE_MEMORY`
2. `conftest` still sets that variable
3. the Makefile's `TEST_DB_PATH` equals that path
4. no Makefile recipe still references `test_roster.db`

## Validation

| Check | Result |
| --- | --- |
| `make test-all` (from a dirty DB) | unit **350**, api **332**, cli **16**, integration **324** — zero failures (was 9 failed / 333 passed) |
| `make test-all` run twice back to back | byte-identical counts — the target is now idempotent |
| `pytest tests/unit tests/api tests/cli tests/contract tests/web` | **916 passed, 21 skipped** |
| `black` / `ruff` | clean |
| `mypy api/utils api/core api/schemas` | clean, 61 files |

The two-consecutive-runs check is the one that matters: before this change the second run was strictly worse than the first, which is the signature of the accumulation.

## Follow-ups

- The create-tests still use fixed IDs and are only safe because the DB is now reset between runs. Giving them unique per-test IDs would make them robust regardless of DB state — worth doing, but it's a broader change across several files and doesn't belong in this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013v7qGC4EZftRXXxdFcasAN)_